### PR TITLE
feat(routing/http/client): allow custom User-Agent

### DIFF
--- a/routing/http/client/transport.go
+++ b/routing/http/client/transport.go
@@ -4,14 +4,19 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"runtime/debug"
 )
 
 type ResponseBodyLimitedTransport struct {
 	http.RoundTripper
 	LimitBytes int64
+	UserAgent  string
 }
 
 func (r *ResponseBodyLimitedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if r.UserAgent != "" {
+		req.Header.Set("User-Agent", r.UserAgent)
+	}
 	resp, err := r.RoundTripper.RoundTrip(req)
 	if resp != nil && resp.Body != nil {
 		resp.Body = &limitReadCloser{
@@ -35,4 +40,36 @@ func (l *limitReadCloser) Read(p []byte) (int, error) {
 		return 0, fmt.Errorf("reached read limit of %d bytes after reading %d bytes", l.limit, l.bytesRead)
 	}
 	return n, err
+}
+
+// ImportPath is the canonical import path that allows us to identify
+// official client builds vs modified forks, and use that info in User-Agent header.
+const ImportPath = "github.com/ipfs/go-libipfs/routing/http/client"
+
+// moduleVersion returns a useful user agent version string allowing us to
+// identify requests coming from officialxl releases of this module.
+func moduleVersion() string {
+	var module *debug.Module
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+
+	// find this client in the dependency list
+	// of the app that has it in go.mod
+	for _, dep := range bi.Deps {
+		if dep.Path == ImportPath {
+			module = dep
+			break
+		}
+	}
+
+	if module == nil {
+		return ""
+	}
+	ua := ImportPath + "/" + module.Version
+	if module.Sum != "" {
+		ua += "/" + module.Sum
+	}
+	return ua
 }

--- a/routing/http/client/transport_test.go
+++ b/routing/http/client/transport_test.go
@@ -75,3 +75,10 @@ func TestResponseBodyLimitedTransport(t *testing.T) {
 		})
 	}
 }
+
+func TestUserAgentVersionString(t *testing.T) {
+	// forks will have to update below lines to pass test
+	assert.Equal(t, importPath(), "github.com/ipfs/go-libipfs")
+	// @unknown because we run in tests
+	assert.Equal(t, moduleVersion(), "github.com/ipfs/go-libipfs@unknown")
+}


### PR DESCRIPTION
This PR Closes #17 

- Adds `WithUserAgent` which allows Kubo (or any other user of `routing/http/client`) to set own version
  - Kubo PR:  https://github.com/ipfs/kubo/pull/9550
- Uses module version if reported via `ReadBuildInfo()`  when no override is present and module is imported from `github.com/ipfs/go-libipfs/routing/http/client` – allows us to quickly tell if a request was made by stable official release or some hacky fork. 
- Does nothing  otherwise. This sends `User-Agent: Go-http-client/1.1` (current state)