### PR TITLE
feat: support UnixFS 1.5 file mode and modification times

### DIFF
--- a/files/file.go
+++ b/files/file.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"time"
 )
 
 var (
@@ -16,6 +17,13 @@ var (
 // Node is a common interface for files, directories and other special files
 type Node interface {
 	io.Closer
+
+	// Mode returns the file's mode
+	Mode() os.FileMode
+
+	// ModTime returns the files last modification time.
+	// If the last modification time is unknown/unspecified `mtime` is zero.
+	ModTime() (mtime time.Time)
 
 	// Size returns size of this file (if this file is a directory, total size of
 	// all files stored in the tree should be returned). Some implementations may

--- a/files/file_test.go
+++ b/files/file_test.go
@@ -70,7 +70,7 @@ func TestMultipartFiles(t *testing.T) {
 	data := `
 --Boundary!
 Content-Type: text/plain
-Content-Disposition: form-data; name="file-0?mode=0754&mtime=1604320500&mtime-nsecs=55555"; filename="file1"
+Content-Disposition: form-data; name="file-0?mode=0754&mtime=1604320500&mtime-nsecs=55555"; filename="%C2%A3%E1%BA%9E%C7%91%C7%93%C3%86+%C3%A6+%E2%99%AB%E2%99%AC"
 Some-Header: beep
 
 beep
@@ -122,7 +122,7 @@ implicit file2
 	CheckDir(t, dir, []Event{
 		{
 			kind:  TFile,
-			name:  "file1",
+			name:  "£ẞǑǓÆ æ ♫♬",
 			value: "beep",
 			mode:  0754,
 			mtime: time.Unix(1604320500, 55555),

--- a/files/filter_test.go
+++ b/files/filter_test.go
@@ -4,15 +4,31 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 type mockFileInfo struct {
 	os.FileInfo
-	name string
+	name  string
+	mode  os.FileMode
+	mtime time.Time
+	size  int64
 }
 
 func (m *mockFileInfo) Name() string {
 	return m.name
+}
+
+func (m *mockFileInfo) Mode() os.FileMode {
+	return m.mode
+}
+
+func (m *mockFileInfo) ModTime() time.Time {
+	return m.mtime
+}
+
+func (m *mockFileInfo) Size() int64 {
+	return m.size
 }
 
 func (m *mockFileInfo) Sys() interface{} {

--- a/files/helpers_test.go
+++ b/files/helpers_test.go
@@ -2,7 +2,9 @@ package files
 
 import (
 	"io"
+	"os"
 	"testing"
+	"time"
 )
 
 type Kind int
@@ -18,6 +20,8 @@ type Event struct {
 	kind  Kind
 	name  string
 	value string
+	mode  os.FileMode
+	mtime time.Time
 }
 
 func CheckDir(t *testing.T, dir Directory, expected []Event) {
@@ -48,6 +52,14 @@ func CheckDir(t *testing.T, dir Directory, expected []Event) {
 
 			if it.Name() != next.name {
 				t.Fatalf("[%d] expected filename to be %q", i, next.name)
+			}
+
+			if it.Node().Mode()&os.ModePerm != next.mode {
+				t.Fatalf("[%d] expected mode for '%s' to be %O, got %O", i, it.Name(), next.mode, it.Node().Mode())
+			}
+
+			if !next.mtime.IsZero() && !it.Node().ModTime().Equal(next.mtime) {
+				t.Fatalf("[%d] expected modification time for '%s' to be %q", i, it.Name(), next.mtime)
 			}
 
 			switch next.kind {

--- a/files/linkfile.go
+++ b/files/linkfile.go
@@ -3,19 +3,35 @@ package files
 import (
 	"os"
 	"strings"
+	"time"
 )
 
 type Symlink struct {
 	Target string
-
-	stat   os.FileInfo
+	mtime  time.Time
 	reader strings.Reader
 }
 
 func NewLinkFile(target string, stat os.FileInfo) File {
-	lf := &Symlink{Target: target, stat: stat}
+	mtime := time.Time{}
+	if stat != nil {
+		mtime = stat.ModTime()
+	}
+	return NewSymlinkFile(target, mtime)
+}
+
+func NewSymlinkFile(target string, mtime time.Time) File {
+	lf := &Symlink{Target: target, mtime: mtime}
 	lf.reader.Reset(lf.Target)
 	return lf
+}
+
+func (lf *Symlink) Mode() os.FileMode {
+	return os.ModeSymlink | os.ModePerm
+}
+
+func (lf *Symlink) ModTime() time.Time {
+	return lf.mtime
 }
 
 func (lf *Symlink) Close() error {

--- a/files/multifilereader.go
+++ b/files/multifilereader.go
@@ -89,7 +89,7 @@ func (mfr *MultiFileReader) Read(buf []byte) (written int, err error) {
 
 			// write the boundary and headers
 			header := make(textproto.MIMEHeader)
-			filename := url.QueryEscape(path.Join(path.Join(mfr.path...), entry.Name()))
+			filename := path.Join(path.Join(mfr.path...), entry.Name())
 			mfr.addContentDisposition(header, filename)
 
 			var contentType string
@@ -168,7 +168,7 @@ func (mfr *MultiFileReader) addContentDisposition(header textproto.MIMEHeader, f
 		sb.WriteString("attachment")
 	}
 
-	fmt.Fprintf(sb, "; filename=\"%s\"", filename)
+	fmt.Fprintf(sb, "; filename=\"%s\"", url.QueryEscape(filename))
 
 	header.Set(contentDispositionHeader, sb.String())
 }

--- a/files/multifilereader_test.go
+++ b/files/multifilereader_test.go
@@ -3,19 +3,29 @@ package files
 import (
 	"io"
 	"mime/multipart"
+	"strings"
 	"testing"
+	"time"
 )
 
 var text = "Some text! :)"
 
 func getTestMultiFileReader(t *testing.T) *MultiFileReader {
 	sf := NewMapDirectory(map[string]Node{
-		"file.txt": NewBytesFile([]byte(text)),
+		"file.txt": NewReaderStatFile(
+			strings.NewReader(text),
+			&mockFileInfo{name: "file.txt", mode: 0, mtime: time.Time{}}),
 		"boop": NewMapDirectory(map[string]Node{
-			"a.txt": NewBytesFile([]byte("bleep")),
-			"b.txt": NewBytesFile([]byte("bloop")),
+			"a.txt": NewReaderStatFile(
+				strings.NewReader("bleep"),
+				&mockFileInfo{name: "a.txt", mode: 0744, mtime: time.Time{}}),
+			"b.txt": NewReaderStatFile(
+				strings.NewReader("bloop"),
+				&mockFileInfo{name: "b.txt", mode: 0666, mtime: time.Unix(1604320500, 0)}),
 		}),
-		"beep.txt": NewBytesFile([]byte("beep")),
+		"beep.txt": NewReaderStatFile(
+			strings.NewReader("beep"),
+			&mockFileInfo{name: "beep.txt", mode: 0754, mtime: time.Unix(1604320500, 55555)}),
 	})
 
 	// testing output by reading it with the go stdlib "mime/multipart" Reader
@@ -34,6 +44,14 @@ func TestMultiFileReaderToMultiFile(t *testing.T) {
 
 	if !it.Next() || it.Name() != "beep.txt" {
 		t.Fatal("iterator didn't work as expected")
+	}
+
+	n := it.Node()
+	if n.Mode() != 0754 {
+		t.Fatal("unexpected file mode")
+	}
+	if n.ModTime() != time.Unix(1604320500, 55555) {
+		t.Fatal("unexpected last modification time")
 	}
 
 	if !it.Next() || it.Name() != "boop" || DirFromEntry(it) == nil {

--- a/files/multifilereader_test.go
+++ b/files/multifilereader_test.go
@@ -233,6 +233,6 @@ func testContentDispositionEncoding(t *testing.T, form bool, filename string, ex
 	mfr.addContentDisposition(header, filename)
 	v := header.Get(contentDispositionHeader)
 	if v != expected {
-		t.Fatalf("expected content-disposition to be: %s", v)
+		t.Fatalf("content-disposition did not match:\nExpected: %s\nActual  : %s", expected, v)
 	}
 }

--- a/files/multipartfile.go
+++ b/files/multipartfile.go
@@ -5,8 +5,12 @@ import (
 	"mime"
 	"mime/multipart"
 	"net/url"
+	"os"
 	"path"
+	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
 )
 
 const (
@@ -17,15 +21,46 @@ const (
 	applicationSymlink   = "application/symlink"
 	applicationFile      = "application/octet-stream"
 
-	contentTypeHeader = "Content-Type"
+	contentTypeHeader        = "Content-Type"
+	contentDispositionHeader = "Content-Disposition"
 )
+
+// multiPartFileInfo implements the `fs.FileInfo` interface for a file or
+// directory received in a `multipart.part`.
+type multiPartFileInfo struct {
+	name  string
+	mode  os.FileMode
+	mtime time.Time
+}
+
+func (fi *multiPartFileInfo) Name() string       { return fi.name }
+func (fi *multiPartFileInfo) Mode() os.FileMode  { return fi.mode }
+func (fi *multiPartFileInfo) ModTime() time.Time { return fi.mtime }
+func (fi *multiPartFileInfo) IsDir() bool        { return fi.mode.IsDir() }
+func (fi *multiPartFileInfo) Sys() interface{}   { return nil }
+func (fi *multiPartFileInfo) Size() int64        { panic("size for multipart file info is not supported") }
 
 type multipartDirectory struct {
 	path   string
 	walker *multipartWalker
+	stat   os.FileInfo
 
 	// part is the part describing the directory. It's nil when implicit.
 	part *multipart.Part
+}
+
+func (f *multipartDirectory) Mode() os.FileMode {
+	if f.stat != nil {
+		return f.stat.Mode()
+	}
+	return 0
+}
+
+func (f *multipartDirectory) ModTime() time.Time {
+	if f.stat != nil {
+		return f.stat.ModTime()
+	}
+	return time.Time{}
 }
 
 type multipartWalker struct {
@@ -85,12 +120,15 @@ func (w *multipartWalker) nextFile() (Node, error) {
 		}
 	}
 
+	name := fileName(part)
+
 	switch contentType {
 	case multipartFormdataType, applicationDirectory:
 		return &multipartDirectory{
 			part:   part,
-			path:   fileName(part),
+			path:   name,
 			walker: w,
+			stat:   fileInfo(name, part),
 		}, nil
 	case applicationSymlink:
 		out, err := io.ReadAll(part)
@@ -98,11 +136,12 @@ func (w *multipartWalker) nextFile() (Node, error) {
 			return nil, err
 		}
 
-		return NewLinkFile(string(out), nil), nil
+		return NewLinkFile(string(out), fileInfo(name, part)), nil
 	default:
 		return &ReaderFile{
 			reader:  part,
 			abspath: part.Header.Get("abspath"),
+			stat:    fileInfo(name, part),
 		}, nil
 	}
 }
@@ -159,6 +198,44 @@ func (it *multipartIterator) Node() Node {
 	return it.curFile
 }
 
+// fileInfo constructs an `os.FileInfo` from a `multipart.part` serving
+// a file or directory.
+func fileInfo(name string, part *multipart.Part) os.FileInfo {
+	fi := multiPartFileInfo{name: filepath.Base(name)}
+	formName := part.FormName()
+
+	i := strings.IndexByte(formName, '?')
+	if i == -1 {
+		return &fi
+	}
+
+	params, err := url.ParseQuery(formName[i+1:])
+	if err != nil {
+		return nil
+	}
+
+	if v := params["mode"]; v != nil {
+		mode, err := strconv.ParseUint(v[0], 8, 32)
+		if err == nil {
+			fi.mode = os.FileMode(mode)
+		}
+	}
+
+	var secs, nsecs int64
+	if v := params["mtime"]; v != nil {
+		secs, err = strconv.ParseInt(v[0], 10, 64)
+		if err != nil {
+			return &fi
+		}
+	}
+	if v := params["mtime-nsecs"]; v != nil {
+		nsecs, _ = strconv.ParseInt(v[0], 10, 64)
+	}
+	fi.mtime = time.Unix(secs, nsecs)
+
+	return &fi
+}
+
 func (it *multipartIterator) Next() bool {
 	if it.f.walker.reader == nil || it.err != nil {
 		return false
@@ -196,9 +273,9 @@ func (it *multipartIterator) Next() bool {
 			}
 			return true
 		}
-		it.curName = name
 
 		// Finally, advance to the next file.
+		it.curName = name
 		it.curFile, it.err = it.f.walker.nextFile()
 
 		return it.err == nil

--- a/files/readerfile.go
+++ b/files/readerfile.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 // ReaderFile is a implementation of File created from an `io.Reader`.
@@ -13,12 +14,29 @@ type ReaderFile struct {
 	abspath string
 	reader  io.ReadCloser
 	stat    os.FileInfo
+	fsize   int64
+}
 
-	fsize int64
+func (f *ReaderFile) Mode() os.FileMode {
+	if f.stat == nil {
+		return 0
+	}
+	return f.stat.Mode()
+}
+
+func (f *ReaderFile) ModTime() time.Time {
+	if f.stat == nil {
+		return time.Time{}
+	}
+	return f.stat.ModTime()
 }
 
 func NewBytesFile(b []byte) File {
 	return &ReaderFile{"", NewReaderFile(bytes.NewReader(b)), nil, int64(len(b))}
+}
+
+func NewBytesStatFile(b []byte, stat os.FileInfo) File {
+	return NewReaderStatFile(bytes.NewReader(b), stat)
 }
 
 func NewReaderFile(reader io.Reader) File {

--- a/files/serialfile.go
+++ b/files/serialfile.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 // serialFile implements Node, and reads from a path on the OS filesystem.
@@ -162,6 +163,14 @@ func (f *serialFile) Size() (int64, error) {
 	})
 
 	return du, err
+}
+
+func (f *serialFile) Mode() os.FileMode {
+	return f.stat.Mode()
+}
+
+func (f *serialFile) ModTime() time.Time {
+	return f.stat.ModTime()
 }
 
 var _ Directory = &serialFile{}

--- a/files/tarwriter.go
+++ b/files/tarwriter.go
@@ -18,23 +18,25 @@ type TarWriter struct {
 	TarW       *tar.Writer
 	baseDirSet bool
 	baseDir    string
+	format     tar.Format
 }
 
 // NewTarWriter wraps given io.Writer into a new tar writer
 func NewTarWriter(w io.Writer) (*TarWriter, error) {
 	return &TarWriter{
-		TarW: tar.NewWriter(w),
+		TarW:   tar.NewWriter(w),
+		format: tar.FormatUnknown,
 	}, nil
 }
 
 func (w *TarWriter) writeDir(f Directory, fpath string) error {
-	if err := writeDirHeader(w.TarW, fpath); err != nil {
+	if err := w.writeHeader(f, fpath, 0); err != nil {
 		return err
 	}
 
 	it := f.Entries()
 	for it.Next() {
-		if err := w.WriteFile(it.Node(), path.Join(fpath, it.Name())); err != nil {
+		if err := w.WriteNode(it.Node(), path.Join(fpath, it.Name())); err != nil {
 			return err
 		}
 	}
@@ -47,7 +49,7 @@ func (w *TarWriter) writeFile(f File, fpath string) error {
 		return err
 	}
 
-	if err := writeFileHeader(w.TarW, fpath, uint64(size)); err != nil {
+	if err = w.writeHeader(f, fpath, size); err != nil {
 		return err
 	}
 
@@ -79,7 +81,7 @@ func validateTarFilePath(baseDir, fpath string) bool {
 }
 
 // WriteNode adds a node to the archive.
-func (w *TarWriter) WriteFile(nd Node, fpath string) error {
+func (w *TarWriter) WriteNode(nd Node, fpath string) error {
 	if !w.baseDirSet {
 		w.baseDirSet = true // Use a variable for this as baseDir may be an empty string.
 		w.baseDir = fpath
@@ -91,7 +93,7 @@ func (w *TarWriter) WriteFile(nd Node, fpath string) error {
 
 	switch nd := nd.(type) {
 	case *Symlink:
-		return writeSymlinkHeader(w.TarW, nd.Target, fpath)
+		return w.writeHeader(nd, fpath, 0)
 	case File:
 		return w.writeFile(nd, fpath)
 	case Directory:
@@ -106,32 +108,33 @@ func (w *TarWriter) Close() error {
 	return w.TarW.Close()
 }
 
-func writeDirHeader(w *tar.Writer, fpath string) error {
-	return w.WriteHeader(&tar.Header{
-		Name:     fpath,
-		Typeflag: tar.TypeDir,
-		Mode:     0777,
-		ModTime:  time.Now().Truncate(time.Second),
-		// TODO: set mode, dates, etc. when added to unixFS
-	})
+func (w *TarWriter) writeHeader(n Node, fpath string, size int64) error {
+	hdr := &tar.Header{
+		Format: w.format,
+		Name:   fpath,
+		Size:   size,
+		Mode:   int64(UnixPermsOrDefault(n)),
+	}
+
+	switch nd := n.(type) {
+	case *Symlink:
+		hdr.Typeflag = tar.TypeSymlink
+		hdr.Linkname = nd.Target
+	case Directory:
+		hdr.Typeflag = tar.TypeDir
+	default:
+		hdr.Typeflag = tar.TypeReg
+	}
+
+	if m := n.ModTime(); m.IsZero() {
+		hdr.ModTime = time.Now()
+	} else {
+		hdr.ModTime = m
+	}
+
+	return w.TarW.WriteHeader(hdr)
 }
 
-func writeFileHeader(w *tar.Writer, fpath string, size uint64) error {
-	return w.WriteHeader(&tar.Header{
-		Name:     fpath,
-		Size:     int64(size),
-		Typeflag: tar.TypeReg,
-		Mode:     0644,
-		ModTime:  time.Now().Truncate(time.Second),
-		// TODO: set mode, dates, etc. when added to unixFS
-	})
-}
-
-func writeSymlinkHeader(w *tar.Writer, target, fpath string) error {
-	return w.WriteHeader(&tar.Header{
-		Name:     fpath,
-		Linkname: target,
-		Mode:     0777,
-		Typeflag: tar.TypeSymlink,
-	})
+func (w *TarWriter) SetFormat(format tar.Format) {
+	w.format = format
 }

--- a/files/tarwriter_test.go
+++ b/files/tarwriter_test.go
@@ -11,11 +11,13 @@ import (
 func TestTarWriter(t *testing.T) {
 	tf := NewMapDirectory(map[string]Node{
 		"file.txt": NewBytesFile([]byte(text)),
-		"boop": NewMapDirectory(map[string]Node{
+		"boop": NewMapStatDirectory(map[string]Node{
 			"a.txt": NewBytesFile([]byte("bleep")),
 			"b.txt": NewBytesFile([]byte("bloop")),
-		}),
-		"beep.txt": NewBytesFile([]byte("beep")),
+		}, &mockFileInfo{name: "", mode: 0750, mtime: time.Unix(6600000000, 0)}),
+		"beep.txt": NewBytesStatFile([]byte("beep"),
+			&mockFileInfo{name: "beep.txt", size: 4, mode: 0766, mtime: time.Unix(1604320500, 54321)}),
+		"boop-sl": NewSymlinkFile("boop", time.Unix(6600050000, 0)),
 	})
 
 	pr, pw := io.Pipe()
@@ -23,18 +25,20 @@ func TestTarWriter(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	tw.SetFormat(tar.FormatPAX)
 	tr := tar.NewReader(pr)
 
 	go func() {
 		defer tw.Close()
-		if err := tw.WriteFile(tf, ""); err != nil {
+		if err := tw.WriteNode(tf, ""); err != nil {
 			t.Error(err)
 		}
 	}()
 
 	var cur *tar.Header
+	delta := 4 * time.Second
 
-	checkHeader := func(name string, typ byte, size int64) {
+	checkHeader := func(name string, typ byte, size int64, mode int64, mtime time.Time) {
 		if cur.Name != name {
 			t.Errorf("got wrong name: %s != %s", cur.Name, name)
 		}
@@ -44,41 +48,53 @@ func TestTarWriter(t *testing.T) {
 		if cur.Size != size {
 			t.Errorf("got wrong size: %d != %d", cur.Size, size)
 		}
-		now := time.Now()
-		if cur.ModTime.After(now) {
-			t.Errorf("wrote timestamp in the future: %s (now) < %s", now, cur.ModTime)
+		if cur.Mode != mode {
+			t.Errorf("got wrong mode: %d != %d", cur.Mode, mode)
+		}
+		if mtime.IsZero() {
+			interval := time.Since(cur.ModTime)
+			if interval < -delta || interval > delta {
+				t.Errorf("expected timestamp to be current: %s", cur.ModTime)
+			}
+		} else if cur.ModTime.UnixNano() != mtime.UnixNano() {
+			t.Errorf("got wrong timestamp: %s != %s", cur.ModTime, mtime)
+
 		}
 	}
 
 	if cur, err = tr.Next(); err != nil {
 		t.Fatal(err)
 	}
-	checkHeader("", tar.TypeDir, 0)
+	checkHeader("", tar.TypeDir, 0, 0755, time.Time{})
 
 	if cur, err = tr.Next(); err != nil {
 		t.Fatal(err)
 	}
-	checkHeader("beep.txt", tar.TypeReg, 4)
+	checkHeader("beep.txt", tar.TypeReg, 4, 0766, time.Unix(1604320500, 54321))
 
 	if cur, err = tr.Next(); err != nil {
 		t.Fatal(err)
 	}
-	checkHeader("boop", tar.TypeDir, 0)
+	checkHeader("boop", tar.TypeDir, 0, 0750, time.Unix(6600000000, 0))
 
 	if cur, err = tr.Next(); err != nil {
 		t.Fatal(err)
 	}
-	checkHeader("boop/a.txt", tar.TypeReg, 5)
+	checkHeader("boop/a.txt", tar.TypeReg, 5, 0644, time.Time{})
 
 	if cur, err = tr.Next(); err != nil {
 		t.Fatal(err)
 	}
-	checkHeader("boop/b.txt", tar.TypeReg, 5)
+	checkHeader("boop/b.txt", tar.TypeReg, 5, 0644, time.Time{})
 
 	if cur, err = tr.Next(); err != nil {
 		t.Fatal(err)
 	}
-	checkHeader("file.txt", tar.TypeReg, 13)
+	checkHeader("boop-sl", tar.TypeSymlink, 0, 0777, time.Unix(6600050000, 0))
+	if cur, err = tr.Next(); err != nil {
+		t.Fatal(err)
+	}
+	checkHeader("file.txt", tar.TypeReg, 13, 0644, time.Time{})
 
 	if cur, err = tr.Next(); err != io.EOF {
 		t.Fatal(err)
@@ -101,7 +117,7 @@ func TestTarWriterRelativePathInsideRoot(t *testing.T) {
 	}
 
 	defer tw.Close()
-	if err := tw.WriteFile(tf, ""); err != nil {
+	if err := tw.WriteNode(tf, ""); err != nil {
 		t.Error(err)
 	}
 }
@@ -122,7 +138,7 @@ func TestTarWriterFailsFileOutsideRoot(t *testing.T) {
 	}
 
 	defer tw.Close()
-	if err := tw.WriteFile(tf, ""); !errors.Is(err, ErrUnixFSPathOutsideRoot) {
+	if err := tw.WriteNode(tf, ""); !errors.Is(err, ErrUnixFSPathOutsideRoot) {
 		t.Errorf("unexpected error, wanted: %v; got: %v", ErrUnixFSPathOutsideRoot, err)
 	}
 }
@@ -143,7 +159,7 @@ func TestTarWriterFailsFileOutsideRootWithBaseDir(t *testing.T) {
 	}
 
 	defer tw.Close()
-	if err := tw.WriteFile(tf, "test.tar"); !errors.Is(err, ErrUnixFSPathOutsideRoot) {
+	if err := tw.WriteNode(tf, "test.tar"); !errors.Is(err, ErrUnixFSPathOutsideRoot) {
 		t.Errorf("unexpected error, wanted: %v; got: %v", ErrUnixFSPathOutsideRoot, err)
 	}
 }

--- a/files/util.go
+++ b/files/util.go
@@ -1,5 +1,7 @@
 package files
 
+import "os"
+
 // ToFile is an alias for n.(File). If the file isn't a regular file, nil value
 // will be returned
 func ToFile(n Node) File {
@@ -22,4 +24,37 @@ func FileFromEntry(e DirEntry) File {
 // DirFromEntry calls ToDir on Node in the given entry
 func DirFromEntry(e DirEntry) Directory {
 	return ToDir(e.Node())
+}
+
+// UnixPermsOrDefault returns the unix style permissions stored for the given Node,
+// or default unix permissions for the Node type.
+func UnixPermsOrDefault(n Node) uint32 {
+	perms := ModePermsToUnixPerms(n.Mode())
+	if perms != 0 {
+		return perms
+	}
+
+	switch n.(type) {
+	case *Symlink:
+		return 0777
+	case Directory:
+		return 0755
+	default:
+		return 0644
+	}
+}
+
+// ModePermsToUnixPerms converts the permission bits of an os.FileMode to unix style mode permissions.
+func ModePermsToUnixPerms(fileMode os.FileMode) uint32 {
+	return uint32((fileMode & 0xC00000 >> 12) | (fileMode & os.ModeSticky >> 11) | (fileMode & 0x1FF))
+}
+
+// UnixPermsToModePerms converts unix style mode permissions to os.FileMode permissions, as it only
+// operates on permission bits it does not set the underlying type (fs.ModeDir, fs.ModeSymlink, etc.)
+// in the returned os.FileMode.
+func UnixPermsToModePerms(unixPerms uint32) (m os.FileMode) {
+	if unixPerms != 0 {
+		m = os.FileMode((unixPerms & 0x1FF) | (unixPerms & 0xC00 << 12) | (unixPerms & 0x200 << 11))
+	}
+	return m
 }

--- a/files/util_test.go
+++ b/files/util_test.go
@@ -1,0 +1,23 @@
+package files
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestModePermsToUnixPerms(t *testing.T) {
+	assert.Equal(t, uint32(0777), ModePermsToUnixPerms(os.FileMode(0777)))
+	assert.Equal(t, uint32(04755), ModePermsToUnixPerms(0755|os.ModeSetuid))
+	assert.Equal(t, uint32(02777), ModePermsToUnixPerms(0777|os.ModeSetgid))
+	assert.Equal(t, uint32(01377), ModePermsToUnixPerms(0377|os.ModeSticky))
+	assert.Equal(t, uint32(05300), ModePermsToUnixPerms(0300|os.ModeSetuid|os.ModeSticky))
+}
+
+func TestUnixPermsToModePerms(t *testing.T) {
+	assert.Equal(t, os.FileMode(0777), UnixPermsToModePerms(0777))
+	assert.Equal(t, 0755|os.ModeSetuid, UnixPermsToModePerms(04755))
+	assert.Equal(t, 0777|os.ModeSetgid, UnixPermsToModePerms(02777))
+	assert.Equal(t, 0377|os.ModeSticky, UnixPermsToModePerms(01377))
+	assert.Equal(t, 0300|os.ModeSetuid|os.ModeSticky, UnixPermsToModePerms(05300))
+}

--- a/files/webfile.go
+++ b/files/webfile.go
@@ -7,7 +7,15 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
+	"time"
 )
+
+// the HTTP Response header that provides the last modified timestamp
+const LastModifiedHeaderName = "Last-Modified"
+
+// the HTTP Response header that provides the unix file mode
+const FileModeHeaderName = "File-Mode"
 
 // WebFile is an implementation of File which reads it
 // from a Web URL (http). A GET request will be performed
@@ -16,6 +24,16 @@ type WebFile struct {
 	body          io.ReadCloser
 	url           *url.URL
 	contentLength int64
+	mode          os.FileMode
+	mtime         time.Time
+}
+
+func (wf *WebFile) Mode() os.FileMode {
+	return wf.mode
+}
+
+func (wf *WebFile) ModTime() time.Time {
+	return wf.mtime
 }
 
 // NewWebFile creates a WebFile with the given URL, which
@@ -38,8 +56,24 @@ func (wf *WebFile) start() error {
 		}
 		wf.body = resp.Body
 		wf.contentLength = resp.ContentLength
+		wf.getResponseMetaData(resp)
 	}
 	return nil
+}
+
+func (wf *WebFile) getResponseMetaData(resp *http.Response) {
+	ts := resp.Header.Get(LastModifiedHeaderName)
+	if ts != "" {
+		if mtime, err := time.Parse(time.RFC1123, ts); err == nil {
+			wf.mtime = mtime
+		}
+	}
+	md := resp.Header.Get(FileModeHeaderName)
+	if md != "" {
+		if mode, err := strconv.ParseInt(md, 8, 32); err == nil {
+			wf.mode = os.FileMode(mode)
+		}
+	}
 }
 
 // Read reads the File from it's web location. On the first

--- a/tar/extractor.go
+++ b/tar/extractor.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"errors"
 	"fmt"
-	"github.com/ipfs/go-libipfs/files"
 	"io"
 	"os"
 	fp "path/filepath"
@@ -415,10 +414,13 @@ func updateMeta(path string, mode int64, mtime time.Time) error {
 	if err := updateModTime(path, mtime); err != nil {
 		return err
 	}
-	if mode != 0 {
-		if err := os.Chmod(path, files.UnixPermsToModePerms(uint32(mode))); err != nil {
-			return fmt.Errorf("failed to update file mode on '%s'", path)
-		}
+	return updateFileMode(path, mode)
+}
+
+// updateFileMode sets the unix mode of the filesystem object referenced by path
+func updateFileMode(path string, mode int64) error {
+	if err := updateMode(path, mode); err != nil {
+		return fmt.Errorf("[%v] failed to update file mode on '%s'", err, path)
 	}
 	return nil
 }
@@ -428,7 +430,7 @@ func updateMeta(path string, mode int64, mtime time.Time) error {
 // When the given path references a symlink, if supported the symlink is updated.
 func updateModTime(path string, mtime time.Time) error {
 	if err := updateMtime(path, mtime); err != nil {
-		return fmt.Errorf("[%v] failed to update last modification time on '%s'", path, err)
+		return fmt.Errorf("[%v] failed to update last modification time on '%s'", err, path)
 	}
 	return nil
 }

--- a/tar/extractor_test.go
+++ b/tar/extractor_test.go
@@ -365,6 +365,9 @@ func TestSymlinkWithModTime(t *testing.T) {
 	if !symlinksEnabled {
 		t.Skip("symlinks disabled on this platform", symlinksEnabledErr)
 	}
+	if runtime.GOOS == "darwin" {
+		t.Skip("changing symlink modification time is not currently supported on darwin")
+	}
 	tm := time.Unix(660000000, 0)
 	add5 := func() time.Time {
 		tm = tm.Add(5 * time.Second)

--- a/tar/extractor_test.go
+++ b/tar/extractor_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"github.com/ipfs/go-libipfs/files"
 	"io"
-	"io/ioutil"
 	"os"
 	fp "path/filepath"
 	"runtime"
@@ -78,7 +77,7 @@ func TestSingleFileWithMeta(t *testing.T) {
 			testMeta(t, path, mode, mtime)
 			f, err := os.Open(path)
 			assert.NoError(t, err)
-			data, err := ioutil.ReadAll(f)
+			data, err := io.ReadAll(f)
 			assert.NoError(t, err)
 			assert.Equal(t, fileData, string(data))
 			assert.NoError(t, f.Close())

--- a/tar/util_other.go
+++ b/tar/util_other.go
@@ -1,0 +1,13 @@
+//go:build !linux && !freebsd && !netbsd && !openbsd && !dragonfly
+// +build !linux,!freebsd,!netbsd,!openbsd,!dragonfly
+
+package tar
+
+import (
+	"os"
+	"time"
+)
+
+func updateMtime(path string, mtime time.Time) error {
+	return os.Chtimes(path, mtime, mtime)
+}

--- a/tar/util_other.go
+++ b/tar/util_other.go
@@ -1,5 +1,5 @@
-//go:build !linux && !freebsd && !netbsd && !openbsd && !dragonfly
-// +build !linux,!freebsd,!netbsd,!openbsd,!dragonfly
+//go:build !linux && !freebsd && !netbsd && !openbsd && !dragonfly && !windows
+// +build !linux,!freebsd,!netbsd,!openbsd,!dragonfly,!windows
 
 package tar
 
@@ -8,6 +8,16 @@ import (
 	"time"
 )
 
+func updateMode(path string, mode int64) error {
+	if mode != 0 {
+		return os.Chmod(path, files.UnixPermsToModePerms(uint32(mode)))
+	}
+	return nil
+}
+
 func updateMtime(path string, mtime time.Time) error {
-	return os.Chtimes(path, mtime, mtime)
+	if !mtime.IsZero() {
+		return os.Chtimes(path, mtime, mtime)
+	}
+	return nil
 }

--- a/tar/util_posix.go
+++ b/tar/util_posix.go
@@ -4,27 +4,37 @@
 package tar
 
 import (
+	"github.com/ipfs/go-libipfs/files"
 	"golang.org/x/sys/unix"
+	"os"
 	"syscall"
 	"time"
 	"unsafe"
 )
 
+func updateMode(path string, mode int64) error {
+	if mode != 0 {
+		return os.Chmod(path, files.UnixPermsToModePerms(uint32(mode)))
+	}
+	return nil
+}
+
 func updateMtime(path string, mtime time.Time) error {
-	var AtFdCwd = -100
-	pathname, err := syscall.BytePtrFromString(path)
-	if err != nil {
-		return err
-	}
+	if !mtime.IsZero() {
+		var AtFdCwd = -100
+		pathname, err := syscall.BytePtrFromString(path)
+		if err != nil {
+			return err
+		}
 
-	tm := syscall.NsecToTimespec(mtime.UnixNano())
-	ts := [2]syscall.Timespec{tm, tm}
-	_, _, e := syscall.Syscall6(syscall.SYS_UTIMENSAT, uintptr(AtFdCwd),
-		uintptr(unsafe.Pointer(pathname)), uintptr(unsafe.Pointer(&ts)),
-		uintptr(unix.AT_SYMLINK_NOFOLLOW), 0, 0)
-	if e != 0 {
-		return error(e)
+		tm := syscall.NsecToTimespec(mtime.UnixNano())
+		ts := [2]syscall.Timespec{tm, tm}
+		_, _, e := syscall.Syscall6(syscall.SYS_UTIMENSAT, uintptr(AtFdCwd),
+			uintptr(unsafe.Pointer(pathname)), uintptr(unsafe.Pointer(&ts)),
+			uintptr(unix.AT_SYMLINK_NOFOLLOW), 0, 0)
+		if e != 0 {
+			return error(e)
+		}
 	}
-
 	return nil
 }

--- a/tar/util_posix.go
+++ b/tar/util_posix.go
@@ -1,0 +1,30 @@
+//go:build linux || freebsd || netbsd || openbsd || dragonfly
+// +build linux freebsd netbsd openbsd dragonfly
+
+package tar
+
+import (
+	"golang.org/x/sys/unix"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+func updateMtime(path string, mtime time.Time) error {
+	var AtFdCwd = -100
+	pathname, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return err
+	}
+
+	tm := syscall.NsecToTimespec(mtime.UnixNano())
+	ts := [2]syscall.Timespec{tm, tm}
+	_, _, e := syscall.Syscall6(syscall.SYS_UTIMENSAT, uintptr(AtFdCwd),
+		uintptr(unsafe.Pointer(pathname)), uintptr(unsafe.Pointer(&ts)),
+		uintptr(unix.AT_SYMLINK_NOFOLLOW), 0, 0)
+	if e != 0 {
+		return error(e)
+	}
+
+	return nil
+}

--- a/tar/util_windows.go
+++ b/tar/util_windows.go
@@ -1,0 +1,31 @@
+package tar
+
+import (
+	"os"
+	"time"
+)
+
+/*
+os.Chmod - On Windows, only the 0200 bit (owner writable) of mode is used; It
+controls whether the file's read-only attribute is set or cleared. The other
+bits are currently unused.
+
+Use mode 0400 for a read-only file and 0600 for a readable+writable file.
+*/
+func updateMode(path string, mode int64) error {
+	if mode != 0 {
+		/* read+write if owner, group or world writeable */
+		if mode&0222 != 0 {
+			return os.Chmod(path, 0600)
+		} /* otherwise read-only */
+		return os.Chmod(path, 0400)
+	}
+
+	return nil
+}
+
+func updateMtime(path string, mtime time.Time) error {
+	if !mtime.IsZero() {
+		return os.Chtimes(path, mtime, mtime)
+	}
+}

--- a/tar/util_windows.go
+++ b/tar/util_windows.go
@@ -28,4 +28,5 @@ func updateMtime(path string, mtime time.Time) error {
 	if !mtime.IsZero() {
 		return os.Chtimes(path, mtime, mtime)
 	}
+	return nil
 }


### PR DESCRIPTION
Adds support for storing and retrieving file mode and last modification time.

Support added to:
- [X] Files
- [X] LinkFiles
- [X] Webfiles
- [X] Directories
- [X] Tar Archives

When the TAR archive (headers) include a file mode or modification time, the extractor will restore that metadata when supported for the underlying filesystem.

The Golang runtime currently does not support changing the times on a symlink, for Linux and some BSDs a custom solution has been implemented, for Darwin this is not the case so when copying a symlink to the filesystem the last modification time is not updated. Since for concrete files and directories stored modes and modification times are faithfully restored to the filesystem this should not be a breaking issue, a similar solution to that implemented for Linux/BSDs is likely implementable by a developer with access to a Darwin platform.

Replaces PRs:
- https://github.com/ipfs/go-ipfs-files/pull/31
- https://github.com/ipfs/tar-utils/pull/11

Relates to https://github.com/ipfs/kubo/issues/6920