### PR TITLE
Use `PUT` as method to insert provider records

### DIFF
--- a/routing/http/client/client.go
+++ b/routing/http/client/client.go
@@ -211,7 +211,7 @@ func (c *client) provideSignedBitswapRecord(ctx context.Context, bswp *types.Wri
 		return 0, err
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(b))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewBuffer(b))
 	if err != nil {
 		return 0, err
 	}

--- a/routing/http/server/server.go
+++ b/routing/http/server/server.go
@@ -57,8 +57,8 @@ func Handler(svc ContentRouter, opts ...serverOption) http.Handler {
 	}
 
 	r := mux.NewRouter()
-	r.HandleFunc(ProvidePath, server.provide).Methods("POST")
-	r.HandleFunc(FindProvidersPath, server.findProviders).Methods("GET")
+	r.HandleFunc(ProvidePath, server.provide).Methods(http.MethodPut)
+	r.HandleFunc(FindProvidersPath, server.findProviders).Methods(http.MethodGet)
 
 	return r
 }
@@ -70,6 +70,7 @@ type server struct {
 func (s *server) provide(w http.ResponseWriter, httpReq *http.Request) {
 	req := types.WriteProvidersRequest{}
 	err := json.NewDecoder(httpReq.Body).Decode(&req)
+	_ = httpReq.Body.Close()
 	if err != nil {
 		writeErr(w, "Provide", http.StatusBadRequest, fmt.Errorf("invalid request: %w", err))
 		return


### PR DESCRIPTION
Change the implementation of HTTP delegated routing provider records to match the IPIP-337 specification. The specification was changed to use `PUT`.

Close request body after decoding when handling provide.