### PR TITLE
chore: run kubo cli gateway tests

### DIFF
--- a/.github/workflows/gateway-sharness.yml
+++ b/.github/workflows/gateway-sharness.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Install sharness dependencies
         run: make test_sharness_deps
         working-directory: kubo
-      - name: Run Sharness Tests
+      - name: Run Kubo Sharness Tests
         run: find . -maxdepth 1 -name "*gateway*.sh" -print0 | xargs -0 -I {} bash -c "echo {}; {}"
         working-directory: kubo/test/sharness
+      - name: Run Kubo CLI Tests
+        run: go test -v *gateway*.go
+        working-directory: kubo/test/cli

--- a/.github/workflows/gateway-sharness.yml
+++ b/.github/workflows/gateway-sharness.yml
@@ -47,5 +47,5 @@ jobs:
         run: find . -maxdepth 1 -name "*gateway*.sh" -print0 | xargs -0 -I {} bash -c "echo {}; {}"
         working-directory: kubo/test/sharness
       - name: Run Kubo CLI Tests
-        run: go test -v *gateway*.go
+        run: go test -v -run=Gateway .
         working-directory: kubo/test/cli


### PR DESCRIPTION
Closes #140 by adding the Kubo CLI Gateway related tests. The tests do not run on this PR automatically because we didn't change gateway code. However, I started up a manual one: https://github.com/ipfs/go-libipfs/actions/runs/4052983024 (it is ✅).