### PR TITLE
feat(gateway): improve GO API interface, remove Writable API

### DIFF
--- a/gateway/README.md
+++ b/gateway/README.md
@@ -15,18 +15,16 @@ headers := map[string][]string{}
 gateway.AddAccessControlHeaders(headers)
 
 conf := gateway.Config{
-  Writable: false,
   Headers:  headers,
 }
 
 // Initialize a NodeAPI interface for both an online and offline versions.
 // The offline version should not make any network request for missing content.
 ipfs := ...
-offlineIPFS := ...
 
 // Create http mux and setup path gateway handler.
 mux := http.NewServeMux()
-gwHandler := gateway.NewHandler(conf, ipfs, offlineIPFS)
+gwHandler := gateway.NewHandler(conf, ipfs)
 mux.Handle("/ipfs/", gwHandler)
 mux.Handle("/ipns/", gwHandler)
 

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -5,33 +5,38 @@ import (
 	"net/http"
 	"sort"
 
-	coreiface "github.com/ipfs/interface-go-ipfs-core"
-	path "github.com/ipfs/interface-go-ipfs-core/path"
+	cid "github.com/ipfs/go-cid"
+	"github.com/ipfs/go-libipfs/blocks"
+	"github.com/ipfs/go-libipfs/files"
+	iface "github.com/ipfs/interface-go-ipfs-core"
+	options "github.com/ipfs/interface-go-ipfs-core/options"
+	"github.com/ipfs/interface-go-ipfs-core/path"
 )
 
-// Config is the configuration that will be applied when creating a new gateway
-// handler.
+// Config is the configuration used when creating a new gateway handler.
 type Config struct {
-	Headers  map[string][]string
-	Writable bool
+	Headers map[string][]string
 }
 
-// NodeAPI defines the minimal set of API services required by a gateway handler
-type NodeAPI interface {
-	// Unixfs returns an implementation of Unixfs API
-	Unixfs() coreiface.UnixfsAPI
+// API defines the minimal set of API services required for a gateway handler.
+type API interface {
+	// GetUnixFsNode returns a read-only handle to a file tree referenced by a path.
+	GetUnixFsNode(context.Context, path.Path) (files.Node, error)
 
-	// Block returns an implementation of Block API
-	Block() coreiface.BlockAPI
+	// LsUnixFsDir returns the list of links in a directory.
+	LsUnixFsDir(context.Context, path.Path, ...options.UnixfsLsOption) (<-chan iface.DirEntry, error)
 
-	// Dag returns an implementation of Dag API
-	Dag() coreiface.APIDagService
+	// GetBlock return a block from a certain CID.
+	GetBlock(context.Context, cid.Cid) (blocks.Block, error)
 
-	// Routing returns an implementation of Routing API.
-	// Used for returning signed IPNS records, see IPIP-0328
-	Routing() coreiface.RoutingAPI
+	// GetIPNSRecord retrieves the best IPNS record for a given CID (libp2p-key)
+	// from the routing system.
+	GetIPNSRecord(context.Context, cid.Cid) ([]byte, error)
 
-	// ResolvePath resolves the path using Unixfs resolver
+	// IsCached returns whether or not the path exists locally.
+	IsCached(context.Context, path.Path) bool
+
+	// ResolvePath resolves the path using UnixFS resolver
 	ResolvePath(context.Context, path.Path) (path.Resolved, error)
 }
 

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ipfs/go-libipfs/blocks"
 	"github.com/ipfs/go-libipfs/files"
 	iface "github.com/ipfs/interface-go-ipfs-core"
-	options "github.com/ipfs/interface-go-ipfs-core/options"
 	"github.com/ipfs/interface-go-ipfs-core/path"
 )
 
@@ -21,10 +20,10 @@ type Config struct {
 // API defines the minimal set of API services required for a gateway handler.
 type API interface {
 	// GetUnixFsNode returns a read-only handle to a file tree referenced by a path.
-	GetUnixFsNode(context.Context, path.Path) (files.Node, error)
+	GetUnixFsNode(context.Context, path.Resolved) (files.Node, error)
 
 	// LsUnixFsDir returns the list of links in a directory.
-	LsUnixFsDir(context.Context, path.Path, ...options.UnixfsLsOption) (<-chan iface.DirEntry, error)
+	LsUnixFsDir(context.Context, path.Resolved) (<-chan iface.DirEntry, error)
 
 	// GetBlock return a block from a certain CID.
 	GetBlock(context.Context, cid.Cid) (blocks.Block, error)
@@ -36,7 +35,9 @@ type API interface {
 	// IsCached returns whether or not the path exists locally.
 	IsCached(context.Context, path.Path) bool
 
-	// ResolvePath resolves the path using UnixFS resolver
+	// ResolvePath resolves the path using UnixFS resolver. If the path does not
+	// exist due to a missing link, it should return an error of type:
+	// https://pkg.go.dev/github.com/ipfs/go-path@v0.3.0/resolver#ErrNoLink
 	ResolvePath(context.Context, path.Path) (path.Resolved, error)
 }
 

--- a/gateway/handler_car.go
+++ b/gateway/handler_car.go
@@ -8,7 +8,6 @@ import (
 
 	cid "github.com/ipfs/go-cid"
 	blocks "github.com/ipfs/go-libipfs/blocks"
-	coreiface "github.com/ipfs/interface-go-ipfs-core"
 	ipath "github.com/ipfs/interface-go-ipfs-core/path"
 	gocar "github.com/ipld/go-car"
 	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
@@ -68,7 +67,7 @@ func (i *handler) serveCAR(ctx context.Context, w http.ResponseWriter, r *http.R
 	w.Header().Set("X-Content-Type-Options", "nosniff") // no funny business in the browsers :^)
 
 	// Same go-car settings as dag.export command
-	store := dagStore{dag: i.api.Dag(), ctx: ctx}
+	store := dagStore{api: i.api, ctx: ctx}
 
 	// TODO: support selectors passed as request param: https://github.com/ipfs/kubo/issues/8769
 	dag := gocar.Dag{Root: rootCid, Selector: selectorparse.CommonSelector_ExploreAllRecursively}
@@ -89,10 +88,10 @@ func (i *handler) serveCAR(ctx context.Context, w http.ResponseWriter, r *http.R
 
 // FIXME(@Jorropo): https://github.com/ipld/go-car/issues/315
 type dagStore struct {
-	dag coreiface.APIDagService
+	api API
 	ctx context.Context
 }
 
 func (ds dagStore) Get(_ context.Context, c cid.Cid) (blocks.Block, error) {
-	return ds.dag.Get(ds.ctx, c)
+	return ds.api.GetBlock(ds.ctx, c)
 }

--- a/gateway/handler_tar.go
+++ b/gateway/handler_tar.go
@@ -23,7 +23,7 @@ func (i *handler) serveTAR(ctx context.Context, w http.ResponseWriter, r *http.R
 	defer cancel()
 
 	// Get Unixfs file
-	file, err := i.api.Unixfs().Get(ctx, resolvedPath)
+	file, err := i.api.GetUnixFsNode(ctx, resolvedPath)
 	if err != nil {
 		webError(w, "ipfs cat "+html.EscapeString(contentPath.String()), err, http.StatusBadRequest)
 		return

--- a/gateway/handler_unixfs.go
+++ b/gateway/handler_unixfs.go
@@ -19,7 +19,7 @@ func (i *handler) serveUnixFS(ctx context.Context, w http.ResponseWriter, r *htt
 	defer span.End()
 
 	// Handling UnixFS
-	dr, err := i.api.Unixfs().Get(ctx, resolvedPath)
+	dr, err := i.api.GetUnixFsNode(ctx, resolvedPath)
 	if err != nil {
 		webError(w, "ipfs cat "+html.EscapeString(contentPath.String()), err, http.StatusBadRequest)
 		return

--- a/gateway/handler_unixfs__redirects.go
+++ b/gateway/handler_unixfs__redirects.go
@@ -120,7 +120,7 @@ func (i *handler) handleRedirectsFileRules(w http.ResponseWriter, r *http.Reques
 
 func (i *handler) getRedirectRules(r *http.Request, redirectsFilePath ipath.Resolved) ([]redirects.Rule, error) {
 	// Convert the path into a file node
-	node, err := i.api.Unixfs().Get(r.Context(), redirectsFilePath)
+	node, err := i.api.GetUnixFsNode(r.Context(), redirectsFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("could not get _redirects: %w", err)
 	}
@@ -170,7 +170,7 @@ func (i *handler) serve4xx(w http.ResponseWriter, r *http.Request, content4xxPat
 		return err
 	}
 
-	node, err := i.api.Unixfs().Get(r.Context(), resolved4xxPath)
+	node, err := i.api.GetUnixFsNode(r.Context(), resolved4xxPath)
 	if err != nil {
 		return err
 	}
@@ -220,7 +220,7 @@ func (i *handler) serveLegacy404IfPresent(w http.ResponseWriter, r *http.Request
 		return false
 	}
 
-	dr, err := i.api.Unixfs().Get(r.Context(), resolved404Path)
+	dr, err := i.api.GetUnixFsNode(r.Context(), resolved404Path)
 	if err != nil {
 		return false
 	}

--- a/gateway/handler_unixfs_dir.go
+++ b/gateway/handler_unixfs_dir.go
@@ -61,7 +61,7 @@ func (i *handler) serveDirectory(ctx context.Context, w http.ResponseWriter, r *
 
 	// Check if directory has index.html, if so, serveFile
 	idxPath := ipath.Join(contentPath, "index.html")
-	idx, err := i.api.Unixfs().Get(ctx, idxPath)
+	idx, err := i.api.GetUnixFsNode(ctx, idxPath)
 	switch err.(type) {
 	case nil:
 		f, ok := idx.(files.File)
@@ -107,7 +107,7 @@ func (i *handler) serveDirectory(ctx context.Context, w http.ResponseWriter, r *
 	// Optimization: use Unixfs.Ls without resolving children, but using the
 	// cumulative DAG size as the file size. This allows for a fast listing
 	// while keeping a good enough Size field.
-	results, err := i.api.Unixfs().Ls(ctx,
+	results, err := i.api.LsUnixFsDir(ctx,
 		resolvedPath,
 		options.Unixfs.ResolveChildren(false),
 		options.Unixfs.UseCumulativeSize(true),

--- a/gateway/handler_unixfs_dir.go
+++ b/gateway/handler_unixfs_dir.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ipfs/go-libipfs/gateway/assets"
 	path "github.com/ipfs/go-path"
 	"github.com/ipfs/go-path/resolver"
-	options "github.com/ipfs/interface-go-ipfs-core/options"
 	ipath "github.com/ipfs/interface-go-ipfs-core/path"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -61,9 +60,15 @@ func (i *handler) serveDirectory(ctx context.Context, w http.ResponseWriter, r *
 
 	// Check if directory has index.html, if so, serveFile
 	idxPath := ipath.Join(contentPath, "index.html")
-	idx, err := i.api.GetUnixFsNode(ctx, idxPath)
+	idxResolvedPath, err := i.api.ResolvePath(ctx, idxPath)
 	switch err.(type) {
 	case nil:
+		idx, err := i.api.GetUnixFsNode(ctx, idxResolvedPath)
+		if err != nil {
+			internalWebError(w, err)
+			return
+		}
+
 		f, ok := idx.(files.File)
 		if !ok {
 			internalWebError(w, files.ErrNotReader)
@@ -104,14 +109,7 @@ func (i *handler) serveDirectory(ctx context.Context, w http.ResponseWriter, r *
 		return
 	}
 
-	// Optimization: use Unixfs.Ls without resolving children, but using the
-	// cumulative DAG size as the file size. This allows for a fast listing
-	// while keeping a good enough Size field.
-	results, err := i.api.LsUnixFsDir(ctx,
-		resolvedPath,
-		options.Unixfs.ResolveChildren(false),
-		options.Unixfs.UseCumulativeSize(true),
-	)
+	results, err := i.api.LsUnixFsDir(ctx, resolvedPath)
 	if err != nil {
 		internalWebError(w, err)
 		return

--- a/go.mod
+++ b/go.mod
@@ -23,13 +23,10 @@ require (
 	github.com/ipfs/go-ipfs-routing v0.3.0
 	github.com/ipfs/go-ipfs-util v0.0.2
 	github.com/ipfs/go-ipld-format v0.4.0
-	github.com/ipfs/go-ipld-legacy v0.1.1
 	github.com/ipfs/go-ipns v0.3.0
 	github.com/ipfs/go-log v1.0.5
 	github.com/ipfs/go-log/v2 v2.5.1
-	github.com/ipfs/go-merkledag v0.9.0
 	github.com/ipfs/go-metrics-interface v0.0.1
-	github.com/ipfs/go-mfs v0.2.1
 	github.com/ipfs/go-path v0.3.0
 	github.com/ipfs/go-peertaskqueue v0.8.0
 	github.com/ipfs/interface-go-ipfs-core v0.10.0
@@ -58,7 +55,6 @@ require (
 )
 
 require (
-	github.com/alecthomas/units v0.0.0-20210927113745-59d0afb8317a // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -70,17 +66,14 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/huin/goupnp v1.0.3 // indirect
 	github.com/ipfs/bbloom v0.0.4 // indirect
-	github.com/ipfs/go-bitfield v1.0.0 // indirect
 	github.com/ipfs/go-block-format v0.1.1 // indirect
 	github.com/ipfs/go-blockservice v0.5.0 // indirect
 	github.com/ipfs/go-fetcher v1.6.1 // indirect
-	github.com/ipfs/go-ipfs-chunker v0.0.1 // indirect
 	github.com/ipfs/go-ipfs-ds-help v1.1.0 // indirect
-	github.com/ipfs/go-ipfs-files v0.0.8 // indirect
-	github.com/ipfs/go-ipfs-posinfo v0.0.1 // indirect
 	github.com/ipfs/go-ipfs-pq v0.0.2 // indirect
 	github.com/ipfs/go-ipld-cbor v0.0.6 // indirect
-	github.com/ipfs/go-unixfs v0.3.1 // indirect
+	github.com/ipfs/go-ipld-legacy v0.1.1 // indirect
+	github.com/ipfs/go-merkledag v0.9.0 // indirect
 	github.com/ipfs/go-verifcid v0.0.2 // indirect
 	github.com/ipld/go-codec-dagpb v1.5.0 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
@@ -114,7 +107,6 @@ require (
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/ucarion/urlpath v0.0.0-20200424170820-7ccc79b76bbb // indirect
 	github.com/whyrusleeping/cbor-gen v0.0.0-20221220214510-0333c149dec0 // indirect
-	github.com/whyrusleeping/chunker v0.0.0-20181014151217-fe64bd25879f // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect
 	golang.org/x/exp v0.0.0-20220916125017-b168a2c6b86b // indirect

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,6 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/alecthomas/units v0.0.0-20210927113745-59d0afb8317a h1:E/8AP5dFtMhl5KPJz66Kt9G0n+7Sn41Fy1wv9/jHOrc=
-github.com/alecthomas/units v0.0.0-20210927113745-59d0afb8317a/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
@@ -343,8 +341,6 @@ github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod
 github.com/ipfs/bbloom v0.0.1/go.mod h1:oqo8CVWsJFMOZqTglBG4wydCE4IQA/G2/SEofB0rjUI=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/go-bitfield v1.0.0 h1:y/XHm2GEmD9wKngheWNNCNL0pzrWXZwCdQGv1ikXknQ=
-github.com/ipfs/go-bitfield v1.0.0/go.mod h1:N/UiujQy+K+ceU1EF5EkVd1TNqevLrCQMIcAEPrdtus=
 github.com/ipfs/go-bitswap v0.1.0/go.mod h1:FFJEf18E9izuCqUtHxbWEvq+reg7o4CW5wSAE1wsxj0=
 github.com/ipfs/go-bitswap v0.1.2/go.mod h1:qxSWS4NXGs7jQ6zQvoPY3+NmOfHHG47mhkiLzBpJQIs=
 github.com/ipfs/go-bitswap v0.5.1/go.mod h1:P+ckC87ri1xFLvk74NlXdP0Kj9RmWAh4+H78sC6Qopo=
@@ -398,7 +394,6 @@ github.com/ipfs/go-ipfs-blockstore v1.2.0 h1:n3WTeJ4LdICWs/0VSfjHrlqpPpl6MZ+ySd3
 github.com/ipfs/go-ipfs-blockstore v1.2.0/go.mod h1:eh8eTFLiINYNSNawfZOC7HOxNTxpB1PFuA5E1m/7exE=
 github.com/ipfs/go-ipfs-blocksutil v0.0.1 h1:Eh/H4pc1hsvhzsQoMEP3Bke/aW5P5rVM1IWFJMcGIPQ=
 github.com/ipfs/go-ipfs-blocksutil v0.0.1/go.mod h1:Yq4M86uIOmxmGPUHv/uI7uKqZNtLb449gwKqXjIsnRk=
-github.com/ipfs/go-ipfs-chunker v0.0.1 h1:cHUUxKFQ99pozdahi+uSC/3Y6HeRpi9oTeUHbE27SEw=
 github.com/ipfs/go-ipfs-chunker v0.0.1/go.mod h1:tWewYK0we3+rMbOh7pPFGDyypCtvGcBFymgY4rSDLAw=
 github.com/ipfs/go-ipfs-delay v0.0.0-20181109222059-70721b86a9a8/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=
 github.com/ipfs/go-ipfs-delay v0.0.1 h1:r/UXYyRcddO6thwOnhiznIAiSvxMECGgtv35Xs1IeRQ=
@@ -415,9 +410,6 @@ github.com/ipfs/go-ipfs-exchange-offline v0.0.1/go.mod h1:WhHSFCVYX36H/anEKQboAz
 github.com/ipfs/go-ipfs-exchange-offline v0.1.1/go.mod h1:vTiBRIbzSwDD0OWm+i3xeT0mO7jG2cbJYatp3HPk5XY=
 github.com/ipfs/go-ipfs-exchange-offline v0.3.0 h1:c/Dg8GDPzixGd0MC8Jh6mjOwU57uYokgWRFidfvEkuA=
 github.com/ipfs/go-ipfs-files v0.0.3/go.mod h1:INEFm0LL2LWXBhNJ2PMIIb2w45hpXgPjNoE7yA8Y1d4=
-github.com/ipfs/go-ipfs-files v0.0.8 h1:8o0oFJkJ8UkO/ABl8T6ac6tKF3+NIpj67aAB6ZpusRg=
-github.com/ipfs/go-ipfs-files v0.0.8/go.mod h1:wiN/jSG8FKyk7N0WyctKSvq3ljIa2NNTiZB55kpTdOs=
-github.com/ipfs/go-ipfs-posinfo v0.0.1 h1:Esoxj+1JgSjX0+ylc0hUmJCOv6V2vFoZiETLR6OtpRs=
 github.com/ipfs/go-ipfs-posinfo v0.0.1/go.mod h1:SwyeVP+jCwiDu0C313l/8jg6ZxM0qqtlt2a0vILTc1A=
 github.com/ipfs/go-ipfs-pq v0.0.1/go.mod h1:LWIqQpqfRG3fNc5XsnIhz/wQ2XXGyugQwls7BgUmUfY=
 github.com/ipfs/go-ipfs-pq v0.0.2 h1:e1vOOW6MuOwG2lqxcLA+wEn93i/9laCY8sXAw76jFOY=
@@ -468,9 +460,6 @@ github.com/ipfs/go-merkledag v0.9.0 h1:DFC8qZ96Dz1hMT7dtIpcY524eFFDiEWAF8hNJHWW2
 github.com/ipfs/go-merkledag v0.9.0/go.mod h1:bPHqkHt5OZ0p1n3iqPeDiw2jIBkjAytRjS3WSBwjq90=
 github.com/ipfs/go-metrics-interface v0.0.1 h1:j+cpbjYvu4R8zbleSs36gvB7jR+wsL2fGD6n0jO4kdg=
 github.com/ipfs/go-metrics-interface v0.0.1/go.mod h1:6s6euYU4zowdslK0GKHmqaIZ3j/b/tL7HTWtJ4VPgWY=
-github.com/ipfs/go-mfs v0.2.1 h1:5jz8+ukAg/z6jTkollzxGzhkl3yxm022Za9f2nL5ab8=
-github.com/ipfs/go-mfs v0.2.1/go.mod h1:Woj80iuw4ajDnIP6+seRaoHpPsc9hmL0pk/nDNDWP88=
-github.com/ipfs/go-path v0.2.1/go.mod h1:NOScsVgxfC/eIw4nz6OiGwK42PjaSJ4Y/ZFPn1Xe07I=
 github.com/ipfs/go-path v0.3.0 h1:tkjga3MtpXyM5v+3EbRvOHEoo+frwi4oumw5K+KYWyA=
 github.com/ipfs/go-path v0.3.0/go.mod h1:NOScsVgxfC/eIw4nz6OiGwK42PjaSJ4Y/ZFPn1Xe07I=
 github.com/ipfs/go-peertaskqueue v0.1.0/go.mod h1:Jmk3IyCcfl1W3jTW3YpghSwSEC6IJ3Vzz/jUmWw8Z0U=
@@ -478,8 +467,6 @@ github.com/ipfs/go-peertaskqueue v0.7.0/go.mod h1:M/akTIE/z1jGNXMU7kFB4TeSEFvj68
 github.com/ipfs/go-peertaskqueue v0.8.0 h1:JyNO144tfu9bx6Hpo119zvbEL9iQ760FHOiJYsUjqaU=
 github.com/ipfs/go-peertaskqueue v0.8.0/go.mod h1:cz8hEnnARq4Du5TGqiWKgMr/BOSQ5XOgMOh1K5YYKKM=
 github.com/ipfs/go-unixfs v0.2.4/go.mod h1:SUdisfUjNoSDzzhGVxvCL9QO/nKdwXdr+gbMUdqcbYw=
-github.com/ipfs/go-unixfs v0.3.1 h1:LrfED0OGfG98ZEegO4/xiprx2O+yS+krCMQSp7zLVv8=
-github.com/ipfs/go-unixfs v0.3.1/go.mod h1:h4qfQYzghiIc8ZNFKiLMFWOTzrWIAtzYQ59W/pCFf1o=
 github.com/ipfs/go-unixfsnode v1.1.2 h1:aTsCdhwU0F4dMShMwYGroAj4v4EzSONLdoENebvTRb0=
 github.com/ipfs/go-unixfsnode v1.1.2/go.mod h1:5dcE2x03pyjHk4JjamXmunTMzz+VUtqvPwZjIEkfV6s=
 github.com/ipfs/go-verifcid v0.0.1/go.mod h1:5Hrva5KBeIog4A+UpqlaIU+DEstipcJYQQZc0g37pY0=
@@ -1084,7 +1071,6 @@ github.com/warpfork/go-wish v0.0.0-20200122115046-b9ea61034e4a/go.mod h1:x6AKhvS
 github.com/whyrusleeping/cbor-gen v0.0.0-20200123233031-1cdf64d27158/go.mod h1:Xj/M2wWU+QdTdRbu/L/1dIZY8/Wb2K9pAhtroQuxJJI=
 github.com/whyrusleeping/cbor-gen v0.0.0-20221220214510-0333c149dec0 h1:obKzQ1ey5AJg5NKjgtTo/CKwLImVP4ETLRcsmzFJ4Qw=
 github.com/whyrusleeping/cbor-gen v0.0.0-20221220214510-0333c149dec0/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
-github.com/whyrusleeping/chunker v0.0.0-20181014151217-fe64bd25879f h1:jQa4QT2UP9WYv2nzyawpKMOCl+Z/jW7djv2/J50lj9E=
 github.com/whyrusleeping/chunker v0.0.0-20181014151217-fe64bd25879f/go.mod h1:p9UJB6dDgdPgMJZs7UjUOdulKyRr9fqkS+6JKAInPy8=
 github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1/go.mod h1:8UvriyWtv5Q5EOgjHaSseUEdkQfvwFv1I/In/O2M9gc=
 github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc/go.mod h1:bopw91TMyo8J3tvftk8xmU2kPmlrt4nScJQZU2hE5EM=


### PR DESCRIPTION
Closes #61

This PR does the following:

1. Simplifies `NodeAPI` (renamed `API`), such that we only require the bare minimum functions we need on the gateway. These have each the minimum required amount of functions required. This will allow other developers to use our gateway code much more easily.
2. Consolidates the `offlineAPI` as a single function on `API` (`IsCached`).
3. Removes the Writable Gateway. The code for the Writable Gateway is moved to Kubo codebase and deprecated https://github.com/ipfs/kubo/issues/9622. See https://github.com/ipfs/kubo/pull/9616.

Please **note**: gateway sharness tests are expected to fail since they are run against Kubo's `master` version. The PR in Kubo with this changes can be viewed at: https://github.com/ipfs/kubo/pull/9616
