### PR TITLE
fix(gateway): display correct error with 500

### DIFF
--- a/gateway/handler_unixfs_dir.go
+++ b/gateway/handler_unixfs_dir.go
@@ -118,7 +118,7 @@ func (i *handler) serveDirectory(ctx context.Context, w http.ResponseWriter, r *
 	dirListing := make([]assets.DirectoryItem, 0, len(results))
 	for link := range results {
 		if link.Err != nil {
-			internalWebError(w, err)
+			internalWebError(w, link.Err)
 			return
 		}
 


### PR DESCRIPTION
Returns the correct error. Should give insight with https://github.com/ipfs/bifrost-gateway/issues/23.