### PR TITLE
fix(gateway): ensure ipfs_http_gw_get_duration_seconds gets updated

### DIFF
--- a/gateway/handler_unixfs.go
+++ b/gateway/handler_unixfs.go
@@ -29,8 +29,7 @@ func (i *handler) serveUnixFS(ctx context.Context, w http.ResponseWriter, r *htt
 	// Handling Unixfs file
 	if f, ok := dr.(files.File); ok {
 		logger.Debugw("serving unixfs file", "path", contentPath)
-		i.serveFile(ctx, w, r, resolvedPath, contentPath, f, begin)
-		return false
+		return i.serveFile(ctx, w, r, resolvedPath, contentPath, f, begin)
 	}
 
 	// Handling Unixfs directory
@@ -41,6 +40,5 @@ func (i *handler) serveUnixFS(ctx context.Context, w http.ResponseWriter, r *htt
 	}
 
 	logger.Debugw("serving unixfs directory", "path", contentPath)
-	i.serveDirectory(ctx, w, r, resolvedPath, contentPath, dir, begin, logger)
-	return true
+	return i.serveDirectory(ctx, w, r, resolvedPath, contentPath, dir, begin, logger)
 }


### PR DESCRIPTION
In #155 I overlooked where I was returning the success status and ended up returning `false` for all UnixFS files. I added more nested success status returning so the metric is more accurate now. Closes #162.