### PR TITLE
examples: add routing for car example

### DIFF
--- a/examples/gateway/car/main.go
+++ b/examples/gateway/car/main.go
@@ -29,7 +29,9 @@ func main() {
 	}
 	defer f.Close()
 
-	gwAPI, err := common.NewBlocksGateway(blockService, nil)
+	routing := newStaticRouting()
+
+	gwAPI, err := common.NewBlocksGateway(blockService, routing)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/gateway/car/routing.go
+++ b/examples/gateway/car/routing.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"context"
+
+	"github.com/libp2p/go-libp2p/core/routing"
+)
+
+type staticRouting struct {
+}
+
+func newStaticRouting() routing.ValueStore {
+	return &staticRouting{}
+}
+
+func (s *staticRouting) PutValue(context.Context, string, []byte, ...routing.Option) error {
+	return routing.ErrNotSupported
+}
+
+func (s *staticRouting) GetValue(ctx context.Context, k string, opts ...routing.Option) ([]byte, error) {
+	return nil, routing.ErrNotSupported
+}
+
+func (s *staticRouting) SearchValue(ctx context.Context, k string, opts ...routing.Option) (<-chan []byte, error) {
+	return nil, routing.ErrNotSupported
+}


### PR DESCRIPTION
(experiment to setup a gateway)

Adding a "no-op" routing means I can setup some dnslink names for testing:
https://github.com/ipfs/go-namesys/blob/9f5f653207b1e2ba05f5fdbb1d1deb6e0a7a3f67/namesys.go#L94-L97