### PR TITLE
Use find providers async context

### DIFF
--- a/bitswap/client/internal/providerquerymanager/providerquerymanager.go
+++ b/bitswap/client/internal/providerquerymanager/providerquerymanager.go
@@ -378,8 +378,8 @@ func (npqm *newProvideQueryMessage) debugMessage() string {
 func (npqm *newProvideQueryMessage) handle(pqm *ProviderQueryManager) {
 	requestStatus, ok := pqm.inProgressRequestStatuses[npqm.k]
 	if !ok {
-
-		ctx, cancelFn := context.WithCancel(pqm.ctx)
+		// used the passed in context to FindProvidersAsync for this call
+		ctx, cancelFn := context.WithCancel(npqm.ctx)
 		requestStatus = &inProgressRequestStatus{
 			listeners: make(map[chan peer.ID]struct{}),
 			ctx:       ctx,


### PR DESCRIPTION
# Goals

In Bitswap, when I call FindProvidersAsync on a call to the ProviderQueryManager, the ultimate call to DHT should retain the context I used with the ProviderQueryManager.

# Background

Since I imagine the review here may or may not have ever even worked with the ProviderQueryManager in Bitswap, here's some background on it.

Essentially I wrote this piece of code almost three years ago, which has two purposes:
- Limit the number of concurrent DHT queries running at the same time
- Reuse queries for the same CID across sessions (and or the global context if for some reason you're not using sessions)

It is a lot of code to manage all that, and looking at it now, I'm like, "wow new Go programmer me you were really go-routine happy back then". It all works (cause you know, this runs in every bitswap) but could be simplified a lot.

But, today is not that day. 


# Implementation

I was suprised to find the context I passed to initialize a bitswap session in Lassie was not being retained here. Instead, I was getting global context. Digging into this, I found what I can only assume is a bug in the code I wrote. While the session context is passed across the go-routine barrier, it isn't even used. Instead the global context is. Perhaps because of the wonderfully similar named variables `npqm` and `pqm` to represent the structs that have the local and global context respectively.

I am pretty sure this is a bug, cause otherwise why pass the session context over the go-routine variable? So I corrected it.

# For Discussion

Looking at my code... well I'm not actually sure of intent here. There are implications to using the session context -- if two queries are called for the same CID in two different sessions, the first sessions context is used, so if that session gets cancelled, then the others query is also cancelled. Maybe that's why I used the global context? But then why pass the context across the go-routine at all (alternate solution: don't do so for clarity).

The use case we're dealing with is trying to extract value's from the context. Maybe that's too much of an edge case to optimize for.

But this PR is aimed to identify the bug (there's a context passed over a go routine but not used) and let you all decide the right outcome.