### PR TITLE
refactor: use assert in remaining gateway tests

### DIFF
--- a/gateway/handler_test.go
+++ b/gateway/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+
 	"testing"
 	"time"
 
@@ -36,9 +37,7 @@ func TestEtagMatch(t *testing.T) {
 		{`*`, `"etag"`, "", true},                        // wildcard etag match
 	} {
 		result := etagMatch(test.header, test.cidEtag, test.dirEtag)
-		if result != test.expected {
-			t.Fatalf("unexpected result of etagMatch(%q, %q, %q), got %t, expected %t", test.header, test.cidEtag, test.dirEtag, result, test.expected)
-		}
+		assert.Equalf(t, test.expected, result, "etagMatch(%q, %q, %q)", test.header, test.cidEtag, test.dirEtag)
 	}
 }
 


### PR DESCRIPTION
Just use the `assert` library more thoroughly.