### PR TITLE
feat: support HTTP 429 with Retry-After

### DIFF
--- a/gateway/errors.go
+++ b/gateway/errors.go
@@ -99,8 +99,7 @@ func webError(w http.ResponseWriter, err error, defaultCode int) {
 	switch {
 	case isErrNotFound(err):
 		code = http.StatusNotFound
-	case errors.Is(err, ErrGatewayTimeout),
-		errors.Is(err, context.DeadlineExceeded):
+	case errors.Is(err, context.DeadlineExceeded):
 		code = http.StatusGatewayTimeout
 	}
 

--- a/gateway/errors.go
+++ b/gateway/errors.go
@@ -1,0 +1,98 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+
+	ipld "github.com/ipfs/go-ipld-format"
+	"github.com/ipfs/go-path/resolver"
+)
+
+var (
+	ErrGatewayTimeout = errors.New(http.StatusText(http.StatusGatewayTimeout))
+	ErrBadGateway     = errors.New(http.StatusText(http.StatusBadGateway))
+)
+
+type ErrTooManyRequests struct {
+	RetryAfter uint64
+}
+
+func (e *ErrTooManyRequests) Error() string {
+	return http.StatusText(http.StatusTooManyRequests)
+}
+
+func (e *ErrTooManyRequests) Is(err error) bool {
+	switch err.(type) {
+	case *ErrTooManyRequests:
+		return true
+	default:
+		return false
+	}
+}
+
+func webError(w http.ResponseWriter, err error, defaultCode int) {
+	code := defaultCode
+
+	switch {
+	case isErrNotFound(err):
+		code = http.StatusNotFound
+	case errors.Is(err, ErrGatewayTimeout),
+		errors.Is(err, context.DeadlineExceeded):
+		code = http.StatusGatewayTimeout
+	case errors.Is(err, ErrBadGateway):
+		code = http.StatusBadGateway
+	case errors.Is(err, &ErrTooManyRequests{}):
+		var tooManyRequests *ErrTooManyRequests
+		_ = errors.As(err, &tooManyRequests)
+		if tooManyRequests.RetryAfter > 0 {
+			w.Header().Set("Retry-After", strconv.FormatUint(tooManyRequests.RetryAfter, 10))
+		}
+
+		code = http.StatusTooManyRequests
+	}
+
+	http.Error(w, err.Error(), code)
+	if code >= 500 {
+		log.Warnf("server error: %s", err)
+	}
+}
+
+func isErrNotFound(err error) bool {
+	if ipld.IsNotFound(err) {
+		return true
+	}
+
+	// Checks if err is a resolver.ErrNoLink. resolver.ErrNoLink does not implement
+	// the .Is interface and cannot be directly compared to. Therefore, errors.Is
+	// always returns false with it.
+	for {
+		_, ok := err.(resolver.ErrNoLink)
+		if ok {
+			return true
+		}
+
+		err = errors.Unwrap(err)
+		if err == nil {
+			return false
+		}
+	}
+}
+
+func webRequestError(w http.ResponseWriter, err *requestError) {
+	webError(w, err.Err, err.StatusCode)
+}
+
+// Custom type for collecting error details to be handled by `webRequestError`
+type requestError struct {
+	StatusCode int
+	Err        error
+}
+
+func newRequestError(err error, statusCode int) *requestError {
+	return &requestError{
+		Err:        err,
+		StatusCode: statusCode,
+	}
+}

--- a/gateway/errors_test.go
+++ b/gateway/errors_test.go
@@ -14,20 +14,20 @@ import (
 func TestErrRetryAfterIs(t *testing.T) {
 	var err error
 
-	err = NewErrorWithRetryAfter(errors.New("test"), 10*time.Second)
-	assert.True(t, errors.Is(err, &errRetryAfter{}), "pointer to error must be error")
+	err = NewErrorRetryAfter(errors.New("test"), 10*time.Second)
+	assert.True(t, errors.Is(err, &ErrorRetryAfter{}), "pointer to error must be error")
 
 	err = fmt.Errorf("wrapped: %w", err)
-	assert.True(t, errors.Is(err, &errRetryAfter{}), "wrapped pointer to error must be error")
+	assert.True(t, errors.Is(err, &ErrorRetryAfter{}), "wrapped pointer to error must be error")
 }
 
 func TestErrRetryAfterAs(t *testing.T) {
 	var (
 		err   error
-		errRA *errRetryAfter
+		errRA *ErrorRetryAfter
 	)
 
-	err = NewErrorWithRetryAfter(errors.New("test"), 25*time.Second)
+	err = NewErrorRetryAfter(errors.New("test"), 25*time.Second)
 	assert.True(t, errors.As(err, &errRA), "pointer to error must be error")
 	assert.EqualValues(t, errRA.RetryAfter, 25*time.Second)
 
@@ -40,7 +40,7 @@ func TestWebError(t *testing.T) {
 	t.Parallel()
 
 	t.Run("429 Too Many Requests", func(t *testing.T) {
-		err := fmt.Errorf("wrapped for testing: %w", NewErrorWithRetryAfter(ErrTooManyRequests, 0))
+		err := fmt.Errorf("wrapped for testing: %w", NewErrorRetryAfter(ErrTooManyRequests, 0))
 		w := httptest.NewRecorder()
 		webError(w, err, http.StatusInternalServerError)
 		assert.Equal(t, http.StatusTooManyRequests, w.Result().StatusCode)
@@ -48,7 +48,7 @@ func TestWebError(t *testing.T) {
 	})
 
 	t.Run("429 Too Many Requests with Retry-After header", func(t *testing.T) {
-		err := NewErrorWithRetryAfter(ErrTooManyRequests, 25*time.Second)
+		err := NewErrorRetryAfter(ErrTooManyRequests, 25*time.Second)
 		w := httptest.NewRecorder()
 		webError(w, err, http.StatusInternalServerError)
 		assert.Equal(t, http.StatusTooManyRequests, w.Result().StatusCode)

--- a/gateway/errors_test.go
+++ b/gateway/errors_test.go
@@ -1,0 +1,56 @@
+package gateway
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrTooManyRequestsIs(t *testing.T) {
+	var err error
+
+	err = &ErrTooManyRequests{RetryAfter: 10}
+	assert.True(t, errors.Is(err, &ErrTooManyRequests{}), "pointer to error must be error")
+
+	err = fmt.Errorf("wrapped: %w", err)
+	assert.True(t, errors.Is(err, &ErrTooManyRequests{}), "wrapped pointer to error must be error")
+}
+
+func TestErrTooManyRequestsAs(t *testing.T) {
+	var (
+		err    error
+		errTMR *ErrTooManyRequests
+	)
+
+	err = &ErrTooManyRequests{RetryAfter: 25}
+	assert.True(t, errors.As(err, &errTMR), "pointer to error must be error")
+	assert.EqualValues(t, errTMR.RetryAfter, 25)
+
+	err = fmt.Errorf("wrapped: %w", err)
+	assert.True(t, errors.As(err, &errTMR), "wrapped pointer to error must be error")
+	assert.EqualValues(t, errTMR.RetryAfter, 25)
+}
+
+func TestWebError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("429 Too Many Requests", func(t *testing.T) {
+		err := fmt.Errorf("wrapped for testing: %w", &ErrTooManyRequests{})
+		w := httptest.NewRecorder()
+		webError(w, err, http.StatusInternalServerError)
+		assert.Equal(t, http.StatusTooManyRequests, w.Result().StatusCode)
+		assert.Zero(t, len(w.Result().Header.Values("Retry-After")))
+	})
+
+	t.Run("429 Too Many Requests with Retry-After header", func(t *testing.T) {
+		err := &ErrTooManyRequests{RetryAfter: 25}
+		w := httptest.NewRecorder()
+		webError(w, err, http.StatusInternalServerError)
+		assert.Equal(t, http.StatusTooManyRequests, w.Result().StatusCode)
+		assert.Equal(t, "25", w.Result().Header.Get("Retry-After"))
+	})
+}

--- a/gateway/errors_test.go
+++ b/gateway/errors_test.go
@@ -54,4 +54,12 @@ func TestWebError(t *testing.T) {
 		assert.Equal(t, http.StatusTooManyRequests, w.Result().StatusCode)
 		assert.Equal(t, "25", w.Result().Header.Get("Retry-After"))
 	})
+
+	t.Run("503 Service Unavailable with Retry-After header", func(t *testing.T) {
+		err := NewErrorRetryAfter(ErrServiceUnavailable, 50*time.Second)
+		w := httptest.NewRecorder()
+		webError(w, err, http.StatusInternalServerError)
+		assert.Equal(t, http.StatusServiceUnavailable, w.Result().StatusCode)
+		assert.Equal(t, "50", w.Result().Header.Get("Retry-After"))
+	})
 }

--- a/gateway/errors_test.go
+++ b/gateway/errors_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -13,7 +14,7 @@ import (
 func TestErrTooManyRequestsIs(t *testing.T) {
 	var err error
 
-	err = &ErrTooManyRequests{RetryAfter: 10}
+	err = &ErrTooManyRequests{RetryAfter: 10 * time.Second}
 	assert.True(t, errors.Is(err, &ErrTooManyRequests{}), "pointer to error must be error")
 
 	err = fmt.Errorf("wrapped: %w", err)
@@ -26,13 +27,13 @@ func TestErrTooManyRequestsAs(t *testing.T) {
 		errTMR *ErrTooManyRequests
 	)
 
-	err = &ErrTooManyRequests{RetryAfter: 25}
+	err = &ErrTooManyRequests{RetryAfter: 25 * time.Second}
 	assert.True(t, errors.As(err, &errTMR), "pointer to error must be error")
-	assert.EqualValues(t, errTMR.RetryAfter, 25)
+	assert.EqualValues(t, errTMR.RetryAfter, 25*time.Second)
 
 	err = fmt.Errorf("wrapped: %w", err)
 	assert.True(t, errors.As(err, &errTMR), "wrapped pointer to error must be error")
-	assert.EqualValues(t, errTMR.RetryAfter, 25)
+	assert.EqualValues(t, errTMR.RetryAfter, 25*time.Second)
 }
 
 func TestWebError(t *testing.T) {
@@ -47,7 +48,7 @@ func TestWebError(t *testing.T) {
 	})
 
 	t.Run("429 Too Many Requests with Retry-After header", func(t *testing.T) {
-		err := &ErrTooManyRequests{RetryAfter: 25}
+		err := &ErrTooManyRequests{RetryAfter: 25 * time.Second}
 		w := httptest.NewRecorder()
 		webError(w, err, http.StatusInternalServerError)
 		assert.Equal(t, http.StatusTooManyRequests, w.Result().StatusCode)

--- a/gateway/handler_test.go
+++ b/gateway/handler_test.go
@@ -123,8 +123,9 @@ func TestErrorBubblingFromAPI(t *testing.T) {
 		headerValue  string
 		headerLength int // how many times was headerName set
 	}{
-		{"429 Too Many Requests without Retry-After header", &ErrTooManyRequests{}, http.StatusTooManyRequests, "Retry-After", "", 0},
-		{"429 Too Many Requests with Retry-After header", &ErrTooManyRequests{RetryAfter: 3600 * time.Second}, http.StatusTooManyRequests, "Retry-After", "3600", 1},
+		{"429 Too Many Requests without Retry-After header", ErrTooManyRequests, http.StatusTooManyRequests, "Retry-After", "", 0},
+		{"429 Too Many Requests without Retry-After header", NewErrorWithRetryAfter(ErrTooManyRequests, 0*time.Second), http.StatusTooManyRequests, "Retry-After", "", 0},
+		{"429 Too Many Requests with Retry-After header", NewErrorWithRetryAfter(ErrTooManyRequests, 3600*time.Second), http.StatusTooManyRequests, "Retry-After", "3600", 1},
 	} {
 		api := &errorMockAPI{err: fmt.Errorf("wrapped for testing purposes: %w", test.err)}
 		ts := newTestServer(t, api)

--- a/gateway/handler_test.go
+++ b/gateway/handler_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ipfs/go-path/resolver"
 	iface "github.com/ipfs/interface-go-ipfs-core"
 	ipath "github.com/ipfs/interface-go-ipfs-core/path"
-	"github.com/tj/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestEtagMatch(t *testing.T) {

--- a/gateway/handler_test.go
+++ b/gateway/handler_test.go
@@ -124,8 +124,8 @@ func TestErrorBubblingFromAPI(t *testing.T) {
 		headerLength int // how many times was headerName set
 	}{
 		{"429 Too Many Requests without Retry-After header", ErrTooManyRequests, http.StatusTooManyRequests, "Retry-After", "", 0},
-		{"429 Too Many Requests without Retry-After header", NewErrorWithRetryAfter(ErrTooManyRequests, 0*time.Second), http.StatusTooManyRequests, "Retry-After", "", 0},
-		{"429 Too Many Requests with Retry-After header", NewErrorWithRetryAfter(ErrTooManyRequests, 3600*time.Second), http.StatusTooManyRequests, "Retry-After", "3600", 1},
+		{"429 Too Many Requests without Retry-After header", NewErrorRetryAfter(ErrTooManyRequests, 0*time.Second), http.StatusTooManyRequests, "Retry-After", "", 0},
+		{"429 Too Many Requests with Retry-After header", NewErrorRetryAfter(ErrTooManyRequests, 3600*time.Second), http.StatusTooManyRequests, "Retry-After", "3600", 1},
 	} {
 		api := &errorMockAPI{err: fmt.Errorf("wrapped for testing purposes: %w", test.err)}
 		ts := newTestServer(t, api)

--- a/gateway/handler_test.go
+++ b/gateway/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	cid "github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
@@ -123,7 +124,7 @@ func TestErrorBubblingFromAPI(t *testing.T) {
 		headerLength int // how many times was headerName set
 	}{
 		{"429 Too Many Requests without Retry-After header", &ErrTooManyRequests{}, http.StatusTooManyRequests, "Retry-After", "", 0},
-		{"429 Too Many Requests with Retry-After header", &ErrTooManyRequests{RetryAfter: 3600}, http.StatusTooManyRequests, "Retry-After", "3600", 1},
+		{"429 Too Many Requests with Retry-After header", &ErrTooManyRequests{RetryAfter: 3600 * time.Second}, http.StatusTooManyRequests, "Retry-After", "3600", 1},
 	} {
 		api := &errorMockAPI{err: fmt.Errorf("wrapped for testing purposes: %w", test.err)}
 		ts := newTestServer(t, api)

--- a/gateway/handler_test.go
+++ b/gateway/handler_test.go
@@ -7,8 +7,10 @@ import (
 	"testing"
 
 	cid "github.com/ipfs/go-cid"
+	ipld "github.com/ipfs/go-ipld-format"
 	"github.com/ipfs/go-libipfs/blocks"
 	"github.com/ipfs/go-libipfs/files"
+	"github.com/ipfs/go-path/resolver"
 	iface "github.com/ipfs/interface-go-ipfs-core"
 	ipath "github.com/ipfs/interface-go-ipfs-core/path"
 	"github.com/tj/assert"
@@ -85,28 +87,55 @@ func TestGatewayInternalServerErrorInvalidPath(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, res.StatusCode)
 }
 
-func TestGatewayTimeoutBubblingFromAPI(t *testing.T) {
-	api := &errorMockAPI{err: fmt.Errorf("the mock api has timed out: %w", ErrGatewayTimeout)}
-	ts := newTestServer(t, api)
-	t.Logf("test server url: %s", ts.URL)
+func TestErrorBubblingFromAPI(t *testing.T) {
+	t.Parallel()
 
-	req, err := http.NewRequest(http.MethodGet, ts.URL+"/ipns/en.wikipedia-on-ipfs.org", nil)
-	assert.Nil(t, err)
+	for _, test := range []struct {
+		name   string
+		err    error
+		status int
+	}{
+		{"404 Not Found from IPLD", &ipld.ErrNotFound{}, http.StatusNotFound},
+		{"404 Not Found from path resolver", resolver.ErrNoLink{}, http.StatusNotFound},
+		{"502 Bad Gateway", ErrBadGateway, http.StatusBadGateway},
+		{"504 Gateway Timeout", ErrGatewayTimeout, http.StatusGatewayTimeout},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			api := &errorMockAPI{err: fmt.Errorf("wrapped for testing purposes: %w", test.err)}
+			ts := newTestServer(t, api)
+			t.Logf("test server url: %s", ts.URL)
 
-	res, err := ts.Client().Do(req)
-	assert.Nil(t, err)
-	assert.Equal(t, http.StatusGatewayTimeout, res.StatusCode)
-}
+			req, err := http.NewRequest(http.MethodGet, ts.URL+"/ipns/en.wikipedia-on-ipfs.org", nil)
+			assert.Nil(t, err)
 
-func TestBadGatewayBubblingFromAPI(t *testing.T) {
-	api := &errorMockAPI{err: fmt.Errorf("the mock api has a bad gateway: %w", ErrBadGateway)}
-	ts := newTestServer(t, api)
-	t.Logf("test server url: %s", ts.URL)
+			res, err := ts.Client().Do(req)
+			assert.Nil(t, err)
+			assert.Equal(t, test.status, res.StatusCode)
+		})
+	}
 
-	req, err := http.NewRequest(http.MethodGet, ts.URL+"/ipns/en.wikipedia-on-ipfs.org", nil)
-	assert.Nil(t, err)
+	for _, test := range []struct {
+		name         string
+		err          error
+		status       int
+		headerName   string
+		headerValue  string
+		headerLength int // how many times was headerName set
+	}{
+		{"429 Too Many Requests without Retry-After header", &ErrTooManyRequests{}, http.StatusTooManyRequests, "Retry-After", "", 0},
+		{"429 Too Many Requests with Retry-After header", &ErrTooManyRequests{RetryAfter: 3600}, http.StatusTooManyRequests, "Retry-After", "3600", 1},
+	} {
+		api := &errorMockAPI{err: fmt.Errorf("wrapped for testing purposes: %w", test.err)}
+		ts := newTestServer(t, api)
+		t.Logf("test server url: %s", ts.URL)
 
-	res, err := ts.Client().Do(req)
-	assert.Nil(t, err)
-	assert.Equal(t, http.StatusBadGateway, res.StatusCode)
+		req, err := http.NewRequest(http.MethodGet, ts.URL+"/ipns/en.wikipedia-on-ipfs.org", nil)
+		assert.Nil(t, err)
+
+		res, err := ts.Client().Do(req)
+		assert.Nil(t, err)
+		assert.Equal(t, test.status, res.StatusCode)
+		assert.Equal(t, test.headerValue, res.Header.Get(test.headerName))
+		assert.Equal(t, test.headerLength, len(res.Header.Values(test.headerName)))
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,6 @@ require (
 	github.com/prometheus/client_golang v1.14.0
 	github.com/samber/lo v1.36.0
 	github.com/stretchr/testify v1.8.1
-	github.com/tj/assert v0.0.3
 	go.opencensus.io v0.24.0
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/trace v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1040,7 +1040,6 @@ github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpP
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/thoas/go-funk v0.9.1 h1:O549iLZqPpTUQ10ykd26sZhzD+rmR5pWhuElrhbC20M=
 github.com/tj/assert v0.0.3 h1:Df/BlaZ20mq6kuai7f5z2TvPFiwC3xaWJSDQNiIS3Rk=
-github.com/tj/assert v0.0.3/go.mod h1:Ne6X72Q+TB1AteidzQncjw9PabbMp4PBMZ1k+vd1Pvk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ucarion/urlpath v0.0.0-20200424170820-7ccc79b76bbb h1:Ywfo8sUltxogBpFuMOFRrrSifO788kAFxmvVw31PtQQ=
 github.com/ucarion/urlpath v0.0.0-20200424170820-7ccc79b76bbb/go.mod h1:ikPs9bRWicNw3S7XpJ8sK/smGwU9WcSVU3dy9qahYBM=
@@ -1548,7 +1547,6 @@ gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This closes #188.

- Moved all - I think - logic related to errors to `errors.go`. I also added some simply sanity tests for this new error as it is its own custom type to support the `RetryAfter` field.
- Added `gateway.ErrTooManyRequests`. Returning an error of this type will make the gateway return 429. If the field `RetryAfter` above 0, it will set the `Retry-After` header. Also added a more "e2e" test for this, albeit arguable unnecessary since I added tests for `webError`.