### PR TITLE
bitswap/client: add option to disable duplicated block stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The following emojis are used to highlight certain changes:
 
 * `boxo/gateway`:
   * A new `WithResolver(...)` option can be used with `NewBlocksBackend(...)` allowing the user to pass their custom `Resolver` implementation.
+* `boxo/bitswap/client`:
+  * A new `WithoutDuplicatedBlockStats()` option can be used with `bitswap.New` and `bsclient.New`. This disable accounting for duplicated blocks, which requires a `blockstore.Has()` lookup for every received block and thus, can impact performance.
 
 ### Changed
 

--- a/bitswap/client/client.go
+++ b/bitswap/client/client.go
@@ -392,8 +392,6 @@ func (bs *Client) updateReceiveCounters(blocks []blocks.Block) {
 	var blocksHas []bool
 	if !bs.skipDuplicatedBlocksStats {
 		blocksHas = bs.blockstoreHas(blocks)
-	} else {
-		blocksHas = make([]bool, len(blocks))
 	}
 
 	bs.counterLk.Lock()
@@ -401,7 +399,7 @@ func (bs *Client) updateReceiveCounters(blocks []blocks.Block) {
 
 	// Do some accounting for each block
 	for i, b := range blocks {
-		has := blocksHas[i]
+		has := (blocksHas != nil) && blocksHas[i]
 
 		blkLen := len(b.RawData())
 		bs.allMetric.Observe(float64(blkLen))


### PR DESCRIPTION
Keeping a counter should not require query-ing the blockstore repeteadly for every single block received, so I have added an option to disable it.

Currently there is the assumption that doing Has() calls is cheap. That can be correct for most cases but also badly incorrect for others.