### PR TITLE
chore: release 0.6.1

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.6.0"
+  "version": "v0.6.1"
 }


### PR DESCRIPTION
Kubo uses an untagged PR joined commit right now (it has been merged, but with rebase), this unblock fixing this in Kubo.