### PR TITLE
fix: ensure (dag)-cbor/json codecs are registered

### DIFF
--- a/gateway/handler_codec.go
+++ b/gateway/handler_codec.go
@@ -16,6 +16,12 @@ import (
 	mc "github.com/multiformats/go-multicodec"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+
+	// Ensure basic codecs are registered.
+	_ "github.com/ipld/go-ipld-prime/codec/cbor"
+	_ "github.com/ipld/go-ipld-prime/codec/dagcbor"
+	_ "github.com/ipld/go-ipld-prime/codec/dagjson"
+	_ "github.com/ipld/go-ipld-prime/codec/json"
 )
 
 // codecToContentType maps the supported IPLD codecs to the HTTP Content


### PR DESCRIPTION
Moving https://github.com/ipfs/bifrost-gateway/pull/64 here, since that's where we convert stuff between codecs.