### PR TITLE
refactor(examples): proxy gateway to use exchange

### DIFF
--- a/examples/gateway/proxy/blockstore.go
+++ b/examples/gateway/proxy/blockstore.go
@@ -2,47 +2,38 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 
-	blockstore "github.com/ipfs/boxo/blockstore"
-	"github.com/ipfs/go-block-format"
+	"github.com/ipfs/boxo/exchange"
+	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 )
 
-var (
-	errNotImplemented = errors.New("not implemented")
-)
-
-type proxyStore struct {
+type proxyExchange struct {
 	httpClient *http.Client
 	gatewayURL string
-	validate   bool
 }
 
-func newProxyStore(gatewayURL string, client *http.Client) blockstore.Blockstore {
+func newProxyExchange(gatewayURL string, client *http.Client) exchange.Interface {
 	if client == nil {
 		client = http.DefaultClient
 	}
 
-	return &proxyStore{
+	return &proxyExchange{
 		gatewayURL: gatewayURL,
 		httpClient: client,
-		// Enables block validation by default. Important since we are
-		// proxying block requests to an untrusted gateway.
-		validate: true,
 	}
 }
 
-func (ps *proxyStore) fetch(ctx context.Context, c cid.Cid) (blocks.Block, error) {
-	u, err := url.Parse(fmt.Sprintf("%s/ipfs/%s?format=raw", ps.gatewayURL, c))
+func (e *proxyExchange) fetch(ctx context.Context, c cid.Cid) (blocks.Block, error) {
+	u, err := url.Parse(fmt.Sprintf("%s/ipfs/%s?format=raw", e.gatewayURL, c))
 	if err != nil {
 		return nil, err
 	}
-	resp, err := ps.httpClient.Do(&http.Request{
+	resp, err := e.httpClient.Do(&http.Request{
 		Method: http.MethodGet,
 		URL:    u,
 		Header: http.Header{
@@ -63,57 +54,60 @@ func (ps *proxyStore) fetch(ctx context.Context, c cid.Cid) (blocks.Block, error
 		return nil, err
 	}
 
-	if ps.validate {
-		nc, err := c.Prefix().Sum(rb)
-		if err != nil {
-			return nil, blocks.ErrWrongHash
-		}
-		if !nc.Equals(c) {
-			fmt.Printf("got %s vs %s\n", nc, c)
-			return nil, blocks.ErrWrongHash
-		}
+	// Validate incoming blocks
+	// This is important since we are proxying block requests to an untrusted gateway.
+	nc, err := c.Prefix().Sum(rb)
+	if err != nil {
+		return nil, blocks.ErrWrongHash
 	}
+	if !nc.Equals(c) {
+		fmt.Printf("got %s vs %s\n", nc, c)
+		return nil, blocks.ErrWrongHash
+	}
+
 	return blocks.NewBlockWithCid(rb, c)
 }
 
-func (ps *proxyStore) Has(ctx context.Context, c cid.Cid) (bool, error) {
-	blk, err := ps.fetch(ctx, c)
-	if err != nil {
-		return false, err
-	}
-	return blk != nil, nil
-}
-
-func (ps *proxyStore) Get(ctx context.Context, c cid.Cid) (blocks.Block, error) {
-	blk, err := ps.fetch(ctx, c)
+func (e *proxyExchange) GetBlock(ctx context.Context, c cid.Cid) (blocks.Block, error) {
+	blk, err := e.fetch(ctx, c)
 	if err != nil {
 		return nil, err
 	}
 	return blk, nil
 }
 
-func (ps *proxyStore) GetSize(ctx context.Context, c cid.Cid) (int, error) {
-	blk, err := ps.fetch(ctx, c)
-	if err != nil {
-		return 0, err
-	}
-	return len(blk.RawData()), nil
+func (e *proxyExchange) GetBlocks(ctx context.Context, cids []cid.Cid) (<-chan blocks.Block, error) {
+	ch := make(chan blocks.Block)
+
+	// Note: this implementation of GetBlocks does not make use of worker pools or parallelism
+	// However, production implementations generally will, and an advanced
+	// version of this can be found in https://github.com/ipfs/bifrost-gateway/
+	go func() {
+		defer close(ch)
+		for _, c := range cids {
+			blk, err := e.fetch(ctx, c)
+			if err != nil {
+				return
+			}
+			select {
+			case ch <- blk:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return ch, nil
 }
 
-func (ps *proxyStore) HashOnRead(enabled bool) {
-	ps.validate = enabled
+func (e *proxyExchange) NotifyNewBlocks(ctx context.Context, blocks ...blocks.Block) error {
+	// Note: while not required this function could be used optimistically to prevent fetching
+	// of data that the client has retrieved already even though a Get call is in progress.
+	return nil
 }
 
-func (c *proxyStore) Put(context.Context, blocks.Block) error {
-	return errNotImplemented
-}
-
-func (c *proxyStore) PutMany(context.Context, []blocks.Block) error {
-	return errNotImplemented
-}
-func (c *proxyStore) AllKeysChan(ctx context.Context) (<-chan cid.Cid, error) {
-	return nil, errNotImplemented
-}
-func (c *proxyStore) DeleteBlock(context.Context, cid.Cid) error {
-	return errNotImplemented
+func (e *proxyExchange) Close() error {
+	// Note: while nothing is strictly required to happen here it would be reasonable to close
+	// existing connections and prevent new operations from starting.
+	return nil
 }

--- a/examples/gateway/proxy/main_test.go
+++ b/examples/gateway/proxy/main_test.go
@@ -7,10 +7,12 @@ import (
 	"testing"
 
 	"github.com/ipfs/boxo/blockservice"
+	"github.com/ipfs/boxo/blockstore"
 	"github.com/ipfs/boxo/examples/gateway/common"
-	offline "github.com/ipfs/boxo/exchange/offline"
 	"github.com/ipfs/boxo/gateway"
 	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-datastore"
+	dssync "github.com/ipfs/go-datastore/sync"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,8 +21,9 @@ const (
 )
 
 func newProxyGateway(t *testing.T, rs *httptest.Server) *httptest.Server {
-	blockStore := newProxyStore(rs.URL, nil)
-	blockService := blockservice.New(blockStore, offline.Exchange(blockStore))
+	blockStore := blockstore.NewBlockstore(dssync.MutexWrap(datastore.NewMapDatastore()))
+	exch := newProxyExchange(rs.URL, nil)
+	blockService := blockservice.New(blockStore, exch)
 	routing := newProxyRouting(rs.URL, nil)
 
 	gw, err := gateway.NewBlocksGateway(blockService, gateway.WithValueStore(routing))


### PR DESCRIPTION
Using a blockstore isn't really the right interface here (e.g. `Has` doesn't really make any sense). The `exchange.Interface` or better the `exchange.Fetcher` interfaces are more appropriate and less confusing.

This also removes all the `notImplemented` errors. The functions not implemented are essentially optional, so descriptions as to what they are for have been left there but they otherwise should not cause issues.

Note: there seems to be some good cause here to simplify the examples (and make them more production-like) by adding:
- An implementation of the exchange interface that takes an `exchange.Fetcher`.
- An implementation of an LRU blockstore

Both of these are effectively implemented in bifrost-gateway (https://github.com/ipfs/bifrost-gateway/pull/61). So once we're happy with how things pan out there we should consider porting implementations back to boxo.

Explicitly looking for feedback such as:
- Things to fix
- Comments to add/remove
- If we should hold off on merging this until some of the bifrost-gateway pieces have moved back here so the example is more production-like

Other feedback welcome too 😄
