### PR TITLE
feat(libp2p): add defaults for libp2p host construction

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -85,6 +85,7 @@ require (
 	github.com/libp2p/go-libp2p-kad-dht v0.21.1 // indirect
 	github.com/libp2p/go-libp2p-kbucket v0.5.0 // indirect
 	github.com/libp2p/go-libp2p-record v0.2.0 // indirect
+	github.com/libp2p/go-mplex v0.7.0 // indirect
 	github.com/libp2p/go-msgio v0.3.0 // indirect
 	github.com/libp2p/go-nat v0.1.0 // indirect
 	github.com/libp2p/go-netroute v0.2.1 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -410,6 +410,8 @@ github.com/libp2p/go-libp2p-record v0.2.0/go.mod h1:I+3zMkvvg5m2OcSdoL0KPljyJyvN
 github.com/libp2p/go-libp2p-routing-helpers v0.6.0 h1:Rfyd+wp/cU0PjNjCphGzLYzd7Q51fjOMs5Sjj6zWGT0=
 github.com/libp2p/go-libp2p-routing-helpers v0.6.0/go.mod h1:wwK/XSLt6njjO7sRbjhf8w7PGBOfdntMQ2mOQPZ5s/Q=
 github.com/libp2p/go-libp2p-testing v0.12.0 h1:EPvBb4kKMWO29qP4mZGyhVzUyR25dvfUIK5WDu6iPUA=
+github.com/libp2p/go-mplex v0.7.0 h1:BDhFZdlk5tbr0oyFq/xv/NPGfjbnrsDam1EvutpBDbY=
+github.com/libp2p/go-mplex v0.7.0/go.mod h1:rW8ThnRcYWft/Jb2jeORBmPd6xuG3dGxWN/W168L9EU=
 github.com/libp2p/go-msgio v0.3.0 h1:mf3Z8B1xcFN314sWX+2vOTShIE0Mmn2TXn3YCUQGNj0=
 github.com/libp2p/go-msgio v0.3.0/go.mod h1:nyRM819GmVaF9LX3l03RMh10QdOroF++NBbxAb0mmDM=
 github.com/libp2p/go-nat v0.1.0 h1:MfVsH6DLcpa04Xr+p8hmVRG4juse0s3J8HyNWYHffXg=

--- a/examples/unixfs-file-cid/main.go
+++ b/examples/unixfs-file-cid/main.go
@@ -38,6 +38,7 @@ import (
 	bsnet "github.com/ipfs/boxo/bitswap/network"
 	bsserver "github.com/ipfs/boxo/bitswap/server"
 	"github.com/ipfs/boxo/files"
+	boxolibp2p "github.com/ipfs/boxo/libp2p"
 )
 
 const exampleBinaryName = "unixfs-file-cid"
@@ -111,7 +112,7 @@ func makeHost(listenPort int, randseed int64) (host.Host, error) {
 		libp2p.Identity(priv),
 	}
 
-	return libp2p.New(opts...)
+	return boxolibp2p.NewHost(opts...)
 }
 
 func getHostAddress(h host.Host) string {

--- a/go.mod
+++ b/go.mod
@@ -134,6 +134,7 @@ require (
 	github.com/libp2p/go-flow-metrics v0.1.0 // indirect
 	github.com/libp2p/go-libp2p-asn-util v0.2.0 // indirect
 	github.com/libp2p/go-libp2p-kbucket v0.5.0 // indirect
+	github.com/libp2p/go-mplex v0.7.0 // indirect
 	github.com/libp2p/go-nat v0.1.0 // indirect
 	github.com/libp2p/go-netroute v0.2.1 // indirect
 	github.com/libp2p/go-reuseport v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -461,6 +461,8 @@ github.com/libp2p/go-libp2p-routing-helpers v0.4.0 h1:b7y4aixQ7AwbqYfcOQ6wTw8DQv
 github.com/libp2p/go-libp2p-routing-helpers v0.4.0/go.mod h1:dYEAgkVhqho3/YKxfOEGdFMIcWfAFNlZX8iAIihYA2E=
 github.com/libp2p/go-libp2p-testing v0.12.0 h1:EPvBb4kKMWO29qP4mZGyhVzUyR25dvfUIK5WDu6iPUA=
 github.com/libp2p/go-libp2p-testing v0.12.0/go.mod h1:KcGDRXyN7sQCllucn1cOOS+Dmm7ujhfEyXQL5lvkcPg=
+github.com/libp2p/go-mplex v0.7.0 h1:BDhFZdlk5tbr0oyFq/xv/NPGfjbnrsDam1EvutpBDbY=
+github.com/libp2p/go-mplex v0.7.0/go.mod h1:rW8ThnRcYWft/Jb2jeORBmPd6xuG3dGxWN/W168L9EU=
 github.com/libp2p/go-msgio v0.3.0 h1:mf3Z8B1xcFN314sWX+2vOTShIE0Mmn2TXn3YCUQGNj0=
 github.com/libp2p/go-msgio v0.3.0/go.mod h1:nyRM819GmVaF9LX3l03RMh10QdOroF++NBbxAb0mmDM=
 github.com/libp2p/go-nat v0.1.0 h1:MfVsH6DLcpa04Xr+p8hmVRG4juse0s3J8HyNWYHffXg=

--- a/libp2p/default_host.go
+++ b/libp2p/default_host.go
@@ -1,0 +1,61 @@
+package libp2p
+
+import (
+	"os"
+
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/p2p/muxer/mplex"
+	"github.com/libp2p/go-libp2p/p2p/muxer/yamux"
+)
+
+// Complete list of default options and when to fallback on them.
+//
+// Please *DON'T* specify default options any other way. Putting this all here
+// makes tracking defaults *much* easier.
+var defaults = []struct {
+	fallback func(cfg *libp2p.Config) bool
+	opt      libp2p.Option
+}{
+	{
+		fallback: func(cfg *libp2p.Config) bool { return cfg.Muxers == nil },
+		opt:      libp2p.ChainOptions(libp2p.Muxer(yamux.ID, yamuxTransport()), libp2p.Muxer(mplex.ID, mplex.DefaultTransport)),
+	},
+}
+
+func yamuxTransport() network.Multiplexer {
+	tpt := *yamux.DefaultTransport
+	tpt.AcceptBacklog = 512
+	if os.Getenv("YAMUX_DEBUG") != "" {
+		tpt.LogOutput = os.Stderr
+	}
+	return &tpt
+}
+
+// fallbackDefaults applies default options to the libp2p node if and only if no
+// other relevant options have been applied. will be appended to the options
+// passed into NewHost.
+var fallbackDefaults libp2p.Option = func(cfg *libp2p.Config) error {
+	for _, def := range defaults {
+		if !def.fallback(cfg) {
+			continue
+		}
+		if err := cfg.Apply(def.opt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// NewHost creates a new libp2p host with default options found helpful by some existing IPFS implementations.
+// These defaults are not guaranteed to be stable over time and any new options provided will replace ones
+// of the existing type.
+//
+// For example, adding a new transport will remove all the existing transports unless they are also added back in the
+// passed options.
+//
+// See the libp2p options for more information
+func NewHost(opts ...libp2p.Option) (host.Host, error) {
+	return libp2p.New(append(opts, fallbackDefaults)...)
+}


### PR DESCRIPTION
fixes #208 

Overall idea: Sometimes go-libp2p's defaults are going to make sense for the wider base of users than just the IPFS ecosystem. It'd be nice, as part of providing a toolbox for helping people build IPFS implementations, if we helped them take care of some of the defaults that we've found useful.

The main examples of where this seems particularly useful is if go-libp2p wants to discourage the use of a feature for future implementations that isn't yet practical for IPFS applications.
- Keeping mplex support is the current example
- I don't recall the history here, but it's something that could've happen around the SECIO deprecation as well

In theory this is also true about new features go-libp2p doesn't yet want to enable by default. However, this has not shown to be a strong case so far.

Looking for feedback here for:
1. Are there more/different defaults we should use here?
2. Is this the right API to expose?
3. Is this the right package to put this in?
   - Consider that we probably also want to put in some defaults for DHT construction in anticipation of finally doing https://github.com/libp2p/go-libp2p-kad-dht/issues/597. Where would we want those helpers to land?

As always, other feedback welcome too 😄