### PR TITLE
ci: add gateway-conformance tests for car-gateway

### DIFF
--- a/.github/workflows/gateway-conformance.yml
+++ b/.github/workflows/gateway-conformance.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   gateway-conformance:
     runs-on: ubuntu-latest

--- a/.github/workflows/gateway-conformance.yml
+++ b/.github/workflows/gateway-conformance.yml
@@ -1,0 +1,58 @@
+name: Gateway Conformance
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  gateway-conformance:
+    runs-on: ubuntu-latest
+    steps:
+      # 1. Download the gateway-conformance fixtures
+      - name: Download gateway-conformance fixtures
+        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.0
+        with:
+          output: fixtures
+          merged: true
+
+      # 2. Build the car-gateway
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19.x
+      - name: Checkout boxo
+        uses: actions/checkout@v3
+        with:
+          path: boxo
+      - name: Build car-gateway
+        run: go build -o car-gateway
+        working-directory: boxo/examples/gateway/car
+
+      # 3. Start the car-gateway
+      - name: Start car-gateway
+        run: boxo/examples/gateway/car/car-gateway -c fixtures/fixtures.car -p 8040 &
+
+      # 4. Run the gateway-conformance tests
+      - name: Run gateway-conformance tests
+        uses: ipfs/gateway-conformance/.github/actions/test@v0.0
+        with:
+          gateway-url: http://127.0.0.1:8040
+          json: output.json
+          xml: output.xml
+          html: output.html
+          markdown: output.md
+          specs: -subdomain-gateway
+          args: -skip 'TestGatewayCar/GET_response_for_application/vnd.ipld.car/Header_Content-Length'
+
+      # 5. Upload the results
+      - name: Upload MD summary
+        if: failure() || success()
+        run: cat output.md >> $GITHUB_STEP_SUMMARY
+      - name: Upload HTML report
+        if: failure() || success()
+        uses: actions/upload-artifact@v3
+        with:
+          name: gateway-conformance.html
+          path: output.html


### PR DESCRIPTION
This PR adds https://github.com/ipfs/gateway-conformance tests for CAR gateway example.

Note that `subdomain-gateway` spec is currently disabled in the `gateway-conformance` suite. 