### PR TITLE
ci: reduce the number of test-examples workflow runs

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -1,5 +1,10 @@
-on: [push, pull_request]
 name: Go Test Examples
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   unit:

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit:
     defaults:


### PR DESCRIPTION
###### Triggers

This PR will reduce the number of workflow runs for `test-examples` workflow. After this change, we will run `test-examples` on every commit in a PR and on every push to the `main` branch. We will stop running `test-examples` on pushes to branches other than `main`.

A similar change is coming soon to the workflows distributed through Unified CI - https://github.com/protocol/.github/pull/489. Once it lands there, I'm going to update `boxo` immediately.

###### Concurrency

This PR also makes sure that we're running `test-example` only for the HEAD of the PR.

Corresponding uCI change - https://github.com/protocol/.github/pull/505.

