### PR TITLE
feat(gateway): IPFSBackend  metrics and HTTP range support

### DIFF
--- a/blockservice/blockservice.go
+++ b/blockservice/blockservice.go
@@ -244,7 +244,7 @@ func getBlock(ctx context.Context, c cid.Cid, bs blockstore.Blockstore, fget fun
 
 		// TODO be careful checking ErrNotFound. If the underlying
 		// implementation changes, this will break.
-		logger.Debug("Blockservice: Searching bitswap")
+		logger.Debug("BlockService: Searching")
 		blk, err := f.GetBlock(ctx, c)
 		if err != nil {
 			return nil, err
@@ -262,7 +262,7 @@ func getBlock(ctx context.Context, c cid.Cid, bs blockstore.Blockstore, fget fun
 		return blk, nil
 	}
 
-	logger.Debug("Blockservice GetBlock: Not found")
+	logger.Debug("BlockService GetBlock: Not found")
 	return nil, err
 }
 

--- a/gateway/blocks_gateway.go
+++ b/gateway/blocks_gateway.go
@@ -139,7 +139,7 @@ func NewBlocksGateway(blockService blockservice.BlockService, opts ...BlockGatew
 	}, nil
 }
 
-func (api *BlocksGateway) Get(ctx context.Context, path ImmutablePath) (ContentPathMetadata, *GetResponse, error) {
+func (api *BlocksGateway) Get(ctx context.Context, path ImmutablePath, ranges ...ByteRange) (ContentPathMetadata, *GetResponse, error) {
 	md, nd, err := api.getNode(ctx, path)
 	if err != nil {
 		return md, nil, err
@@ -178,10 +178,6 @@ func (api *BlocksGateway) Get(ctx context.Context, path ImmutablePath) (ContentP
 	}
 
 	return ContentPathMetadata{}, nil, fmt.Errorf("data was not a valid file or directory: %w", ErrInternalServerError) // TODO: should there be a gateway invalid content type to abstract over the various IPLD error types?
-}
-
-func (api *BlocksGateway) GetRange(ctx context.Context, path ImmutablePath, ranges ...GetRange) (ContentPathMetadata, *GetResponse, error) {
-	return api.Get(ctx, path)
 }
 
 func (api *BlocksGateway) GetAll(ctx context.Context, path ImmutablePath) (ContentPathMetadata, files.Node, error) {

--- a/gateway/blocks_gateway.go
+++ b/gateway/blocks_gateway.go
@@ -180,23 +180,8 @@ func (api *BlocksGateway) Get(ctx context.Context, path ImmutablePath) (ContentP
 	return ContentPathMetadata{}, nil, fmt.Errorf("data was not a valid file or directory: %w", ErrInternalServerError) // TODO: should there be a gateway invalid content type to abstract over the various IPLD error types?
 }
 
-func (api *BlocksGateway) GetRange(ctx context.Context, path ImmutablePath, ranges ...GetRange) (ContentPathMetadata, files.File, error) {
-	md, nd, err := api.getNode(ctx, path)
-	if err != nil {
-		return md, nil, err
-	}
-
-	// This code path covers full graph, single file/directory, and range requests
-	n, err := ufile.NewUnixfsFile(ctx, api.dagService, nd)
-	if err != nil {
-		return md, nil, err
-	}
-	f, ok := n.(files.File)
-	if !ok {
-		return ContentPathMetadata{}, nil, NewErrorResponse(fmt.Errorf("can only do range requests on files, but did not get a file"), http.StatusBadRequest)
-	}
-
-	return md, f, nil
+func (api *BlocksGateway) GetRange(ctx context.Context, path ImmutablePath, ranges ...GetRange) (ContentPathMetadata, *GetResponse, error) {
+	return api.Get(ctx, path)
 }
 
 func (api *BlocksGateway) GetAll(ctx context.Context, path ImmutablePath) (ContentPathMetadata, files.Node, error) {

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -91,10 +91,11 @@ type IPFSBackend interface {
 	// Size, and Cid.
 	Get(context.Context, ImmutablePath) (ContentPathMetadata, *GetResponse, error)
 
-	// GetRange returns a full UnixFS file object. Ranges passed in are advisory for pre-fetching data, however
-	// consumers of this function may require extra data beyond the passed ranges (e.g. the initial bit of the file
-	// might be used for content type sniffing even if only the end of the file is requested).
-	GetRange(context.Context, ImmutablePath, ...GetRange) (ContentPathMetadata, files.File, error)
+	// GetRange returns a full UnixFS file object, or a UnixFS directory. Ranges passed in are advisory for pre-fetching
+	// data, however consumers of this function may require extra data beyond the passed ranges (e.g. the initial bit of
+	// the file might be used for content type sniffing even if only the end of the file is requested).
+	// Note: there is currently no semantic meaning attached to a range request for a directory
+	GetRange(context.Context, ImmutablePath, ...GetRange) (ContentPathMetadata, *GetResponse, error)
 
 	// GetAll returns a UnixFS file or directory depending on what the path is that has been requested. Directories should
 	// include all content recursively.

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -111,7 +111,7 @@ func (api *mockAPI) Get(ctx context.Context, immutablePath ImmutablePath) (Conte
 	return api.gw.Get(ctx, immutablePath)
 }
 
-func (api *mockAPI) GetRange(ctx context.Context, immutablePath ImmutablePath, ranges ...GetRange) (ContentPathMetadata, files.File, error) {
+func (api *mockAPI) GetRange(ctx context.Context, immutablePath ImmutablePath, ranges ...GetRange) (ContentPathMetadata, *GetResponse, error) {
 	return api.gw.GetRange(ctx, immutablePath, ranges...)
 }
 

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -107,12 +107,8 @@ func newMockAPI(t *testing.T) (*mockAPI, cid.Cid) {
 	}, cids[0]
 }
 
-func (api *mockAPI) Get(ctx context.Context, immutablePath ImmutablePath) (ContentPathMetadata, *GetResponse, error) {
-	return api.gw.Get(ctx, immutablePath)
-}
-
-func (api *mockAPI) GetRange(ctx context.Context, immutablePath ImmutablePath, ranges ...GetRange) (ContentPathMetadata, *GetResponse, error) {
-	return api.gw.GetRange(ctx, immutablePath, ranges...)
+func (api *mockAPI) Get(ctx context.Context, immutablePath ImmutablePath, ranges ...ByteRange) (ContentPathMetadata, *GetResponse, error) {
+	return api.gw.Get(ctx, immutablePath, ranges...)
 }
 
 func (api *mockAPI) GetAll(ctx context.Context, immutablePath ImmutablePath) (ContentPathMetadata, files.Node, error) {

--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -20,7 +20,6 @@ import (
 	cid "github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log"
 	prometheus "github.com/prometheus/client_golang/prometheus"
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
@@ -79,6 +78,12 @@ type handler struct {
 	tarStreamGetMetric           *prometheus.HistogramVec
 	jsoncborDocumentGetMetric    *prometheus.HistogramVec
 	ipnsRecordGetMetric          *prometheus.HistogramVec
+}
+
+// NewHandler returns an http.Handler that can act as a gateway to IPFS content
+// offlineApi is a version of the API that should not make network requests for missing data
+func NewHandler(c Config, api IPFSBackend) http.Handler {
+	return newHandlerWithMetrics(c, api)
 }
 
 // StatusResponseWriter enables us to override HTTP Status Code passed to
@@ -147,128 +152,6 @@ func (w *errRecordingResponseWriter) ReadFrom(r io.Reader) (n int64, err error) 
 		w.err = err
 	}
 	return n, err
-}
-
-func newSummaryMetric(name string, help string) *prometheus.SummaryVec {
-	summaryMetric := prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
-			Namespace: "ipfs",
-			Subsystem: "http",
-			Name:      name,
-			Help:      help,
-		},
-		[]string{"gateway"},
-	)
-	if err := prometheus.Register(summaryMetric); err != nil {
-		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
-			summaryMetric = are.ExistingCollector.(*prometheus.SummaryVec)
-		} else {
-			log.Errorf("failed to register ipfs_http_%s: %v", name, err)
-		}
-	}
-	return summaryMetric
-}
-
-func newHistogramMetric(name string, help string) *prometheus.HistogramVec {
-	// We can add buckets as a parameter in the future, but for now using static defaults
-	// suggested in https://github.com/ipfs/kubo/issues/8441
-	defaultBuckets := []float64{0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60}
-	histogramMetric := prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Namespace: "ipfs",
-			Subsystem: "http",
-			Name:      name,
-			Help:      help,
-			Buckets:   defaultBuckets,
-		},
-		[]string{"gateway"},
-	)
-	if err := prometheus.Register(histogramMetric); err != nil {
-		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
-			histogramMetric = are.ExistingCollector.(*prometheus.HistogramVec)
-		} else {
-			log.Errorf("failed to register ipfs_http_%s: %v", name, err)
-		}
-	}
-	return histogramMetric
-}
-
-// NewHandler returns an http.Handler that can act as a gateway to IPFS content
-// offlineApi is a version of the API that should not make network requests for missing data
-func NewHandler(c Config, api IPFSBackend) http.Handler {
-	return newHandler(c, api)
-}
-
-func newHandler(c Config, api IPFSBackend) *handler {
-	i := &handler{
-		config: c,
-		api:    api,
-		// Improved Metrics
-		// ----------------------------
-		// Time till the first content block (bar in /ipfs/cid/foo/bar)
-		// (format-agnostic, across all response types)
-		firstContentBlockGetMetric: newHistogramMetric(
-			"gw_first_content_block_get_latency_seconds",
-			"The time till the first content block is received on GET from the gateway.",
-		),
-
-		// Response-type specific metrics
-		// ----------------------------
-		// Generic: time it takes to execute a successful gateway request (all request types)
-		getMetric: newHistogramMetric(
-			"gw_get_duration_seconds",
-			"The time to GET a successful response to a request (all content types).",
-		),
-		// UnixFS: time it takes to return a file
-		unixfsFileGetMetric: newHistogramMetric(
-			"gw_unixfs_file_get_duration_seconds",
-			"The time to serve an entire UnixFS file from the gateway.",
-		),
-		// UnixFS: time it takes to find and serve an index.html file on behalf of a directory.
-		unixfsDirIndexGetMetric: newHistogramMetric(
-			"gw_unixfs_dir_indexhtml_get_duration_seconds",
-			"The time to serve an index.html file on behalf of a directory from the gateway. This is a subset of gw_unixfs_file_get_duration_seconds.",
-		),
-		// UnixFS: time it takes to generate static HTML with directory listing
-		unixfsGenDirListingGetMetric: newHistogramMetric(
-			"gw_unixfs_gen_dir_listing_get_duration_seconds",
-			"The time to serve a generated UnixFS HTML directory listing from the gateway.",
-		),
-		// CAR: time it takes to return requested CAR stream
-		carStreamGetMetric: newHistogramMetric(
-			"gw_car_stream_get_duration_seconds",
-			"The time to GET an entire CAR stream from the gateway.",
-		),
-		// Block: time it takes to return requested Block
-		rawBlockGetMetric: newHistogramMetric(
-			"gw_raw_block_get_duration_seconds",
-			"The time to GET an entire raw Block from the gateway.",
-		),
-		// TAR: time it takes to return requested TAR stream
-		tarStreamGetMetric: newHistogramMetric(
-			"gw_tar_stream_get_duration_seconds",
-			"The time to GET an entire TAR stream from the gateway.",
-		),
-		// JSON/CBOR: time it takes to return requested DAG-JSON/-CBOR document
-		jsoncborDocumentGetMetric: newHistogramMetric(
-			"gw_jsoncbor_get_duration_seconds",
-			"The time to GET an entire DAG-JSON/CBOR block from the gateway.",
-		),
-		// IPNS Record: time it takes to return IPNS record
-		ipnsRecordGetMetric: newHistogramMetric(
-			"gw_ipns_record_get_duration_seconds",
-			"The time to GET an entire IPNS Record from the gateway.",
-		),
-
-		// Legacy Metrics
-		// ----------------------------
-		unixfsGetMetric: newSummaryMetric( // TODO: remove?
-			// (deprecated, use firstContentBlockGetMetric instead)
-			"unixfs_get_latency_seconds",
-			"DEPRECATED: does not do what you think, use gw_first_content_block_get_latency_seconds instead.",
-		),
-	}
-	return i
 }
 
 func (i *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -886,9 +769,4 @@ func handleSuperfluousNamespace(w http.ResponseWriter, r *http.Request, contentP
 	}
 
 	return true
-}
-
-// spanTrace starts a new span using the standard IPFS tracing conventions.
-func spanTrace(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
-	return otel.Tracer("boxo").Start(ctx, fmt.Sprintf("%s.%s", " Gateway", spanName), opts...)
 }

--- a/gateway/handler_test.go
+++ b/gateway/handler_test.go
@@ -45,11 +45,7 @@ type errorMockAPI struct {
 	err error
 }
 
-func (api *errorMockAPI) Get(ctx context.Context, path ImmutablePath) (ContentPathMetadata, *GetResponse, error) {
-	return ContentPathMetadata{}, nil, api.err
-}
-
-func (api *errorMockAPI) GetRange(ctx context.Context, path ImmutablePath, getRange ...GetRange) (ContentPathMetadata, *GetResponse, error) {
+func (api *errorMockAPI) Get(ctx context.Context, path ImmutablePath, getRange ...ByteRange) (ContentPathMetadata, *GetResponse, error) {
 	return ContentPathMetadata{}, nil, api.err
 }
 
@@ -161,11 +157,7 @@ type panicMockAPI struct {
 	panicOnHostnameHandler bool
 }
 
-func (api *panicMockAPI) Get(ctx context.Context, immutablePath ImmutablePath) (ContentPathMetadata, *GetResponse, error) {
-	panic("i am panicking")
-}
-
-func (api *panicMockAPI) GetRange(ctx context.Context, immutablePath ImmutablePath, ranges ...GetRange) (ContentPathMetadata, *GetResponse, error) {
+func (api *panicMockAPI) Get(ctx context.Context, immutablePath ImmutablePath, ranges ...ByteRange) (ContentPathMetadata, *GetResponse, error) {
 	panic("i am panicking")
 }
 

--- a/gateway/handler_test.go
+++ b/gateway/handler_test.go
@@ -49,7 +49,7 @@ func (api *errorMockAPI) Get(ctx context.Context, path ImmutablePath) (ContentPa
 	return ContentPathMetadata{}, nil, api.err
 }
 
-func (api *errorMockAPI) GetRange(ctx context.Context, path ImmutablePath, getRange ...GetRange) (ContentPathMetadata, files.File, error) {
+func (api *errorMockAPI) GetRange(ctx context.Context, path ImmutablePath, getRange ...GetRange) (ContentPathMetadata, *GetResponse, error) {
 	return ContentPathMetadata{}, nil, api.err
 }
 
@@ -165,7 +165,7 @@ func (api *panicMockAPI) Get(ctx context.Context, immutablePath ImmutablePath) (
 	panic("i am panicking")
 }
 
-func (api *panicMockAPI) GetRange(ctx context.Context, immutablePath ImmutablePath, ranges ...GetRange) (ContentPathMetadata, files.File, error) {
+func (api *panicMockAPI) GetRange(ctx context.Context, immutablePath ImmutablePath, ranges ...GetRange) (ContentPathMetadata, *GetResponse, error) {
 	panic("i am panicking")
 }
 

--- a/gateway/handler_unixfs_dir.go
+++ b/gateway/handler_unixfs_dir.go
@@ -23,7 +23,7 @@ import (
 // serveDirectory returns the best representation of UnixFS directory
 //
 // It will return index.html if present, or generate directory listing otherwise.
-func (i *handler) serveDirectory(ctx context.Context, w http.ResponseWriter, r *http.Request, resolvedPath ipath.Resolved, contentPath ipath.Path, isHeadRequest bool, directoryMetadata *directoryMetadata, ranges []GetRange, begin time.Time, logger *zap.SugaredLogger) bool {
+func (i *handler) serveDirectory(ctx context.Context, w http.ResponseWriter, r *http.Request, resolvedPath ipath.Resolved, contentPath ipath.Path, isHeadRequest bool, directoryMetadata *directoryMetadata, ranges []ByteRange, begin time.Time, logger *zap.SugaredLogger) bool {
 	ctx, span := spanTrace(ctx, "ServeDirectory", trace.WithAttributes(attribute.String("path", resolvedPath.String())))
 	defer span.End()
 
@@ -81,11 +81,7 @@ func (i *handler) serveDirectory(ctx context.Context, w http.ResponseWriter, r *
 		}
 	} else {
 		var getResp *GetResponse
-		if len(ranges) == 0 {
-			_, getResp, err = i.api.Get(ctx, imIndexPath)
-		} else {
-			_, getResp, err = i.api.GetRange(ctx, imIndexPath, ranges...)
-		}
+		_, getResp, err = i.api.Get(ctx, imIndexPath, ranges...)
 		if err == nil {
 			if getResp.bytes == nil {
 				webError(w, fmt.Errorf("%q could not be read: %w", imIndexPath, files.ErrNotReader), http.StatusUnprocessableEntity)

--- a/gateway/handler_unixfs_dir.go
+++ b/gateway/handler_unixfs_dir.go
@@ -23,7 +23,7 @@ import (
 // serveDirectory returns the best representation of UnixFS directory
 //
 // It will return index.html if present, or generate directory listing otherwise.
-func (i *handler) serveDirectory(ctx context.Context, w http.ResponseWriter, r *http.Request, resolvedPath ipath.Resolved, contentPath ipath.Path, isHeadRequest bool, directoryMetadata *directoryMetadata, begin time.Time, logger *zap.SugaredLogger) bool {
+func (i *handler) serveDirectory(ctx context.Context, w http.ResponseWriter, r *http.Request, resolvedPath ipath.Resolved, contentPath ipath.Path, isHeadRequest bool, directoryMetadata *directoryMetadata, ranges []GetRange, begin time.Time, logger *zap.SugaredLogger) bool {
 	ctx, span := spanTrace(ctx, "ServeDirectory", trace.WithAttributes(attribute.String("path", resolvedPath.String())))
 	defer span.End()
 
@@ -81,7 +81,11 @@ func (i *handler) serveDirectory(ctx context.Context, w http.ResponseWriter, r *
 		}
 	} else {
 		var getResp *GetResponse
-		_, getResp, err = i.api.Get(ctx, imIndexPath)
+		if len(ranges) == 0 {
+			_, getResp, err = i.api.Get(ctx, imIndexPath)
+		} else {
+			_, getResp, err = i.api.GetRange(ctx, imIndexPath, ranges...)
+		}
 		if err == nil {
 			if getResp.bytes == nil {
 				webError(w, fmt.Errorf("%q could not be read: %w", imIndexPath, files.ErrNotReader), http.StatusUnprocessableEntity)

--- a/gateway/metrics.go
+++ b/gateway/metrics.go
@@ -1,0 +1,312 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/ipfs/boxo/coreiface/path"
+	"github.com/ipfs/boxo/files"
+	"github.com/ipfs/go-cid"
+	prometheus "github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type ipfsBackendWithMetrics struct {
+	api           IPFSBackend
+	apiCallMetric *prometheus.HistogramVec
+}
+
+func newIPFSBackendWithMetrics(api IPFSBackend) *ipfsBackendWithMetrics {
+	// We can add buckets as a parameter in the future, but for now using static defaults
+	// suggested in https://github.com/ipfs/kubo/issues/8441
+
+	apiCallMetric := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "ipfs",
+			Subsystem: "gw_backend",
+			Name:      "api_call_duration_seconds",
+			Help:      "The time spent in IPFSBackend API calls that returned success.",
+			Buckets:   []float64{0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60},
+		},
+		[]string{"name", "result"},
+	)
+
+	if err := prometheus.Register(apiCallMetric); err != nil {
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			apiCallMetric = are.ExistingCollector.(*prometheus.HistogramVec)
+		} else {
+			log.Errorf("failed to register ipfs_gw_backend_api_call_duration_seconds: %v", err)
+		}
+	}
+
+	return &ipfsBackendWithMetrics{api, apiCallMetric}
+}
+
+func (b *ipfsBackendWithMetrics) updateApiCallMetric(name string, err error, begin time.Time) {
+	end := time.Since(begin).Seconds()
+	if err == nil {
+		b.apiCallMetric.WithLabelValues(name, "success").Observe(end)
+	} else {
+		b.apiCallMetric.WithLabelValues(name, "failure").Observe(end)
+	}
+}
+
+func (b *ipfsBackendWithMetrics) Get(ctx context.Context, path ImmutablePath) (ContentPathMetadata, *GetResponse, error) {
+	begin := time.Now()
+	name := "IPFSBackend.Get"
+	ctx, span := spanTrace(ctx, name, trace.WithAttributes(attribute.String("path", path.String())))
+	defer span.End()
+
+	md, n, err := b.api.Get(ctx, path)
+
+	b.updateApiCallMetric(name, err, begin)
+	return md, n, err
+}
+
+func (b *ipfsBackendWithMetrics) GetRange(ctx context.Context, path ImmutablePath, ranges ...GetRange) (ContentPathMetadata, files.File, error) {
+	begin := time.Now()
+	name := "IPFSBackend.GetRange"
+	ctx, span := spanTrace(ctx, name, trace.WithAttributes(attribute.String("path", path.String())))
+	defer span.End()
+
+	md, f, err := b.api.GetRange(ctx, path, ranges...)
+
+	b.updateApiCallMetric(name, err, begin)
+	return md, f, err
+}
+
+func (b *ipfsBackendWithMetrics) GetAll(ctx context.Context, path ImmutablePath) (ContentPathMetadata, files.Node, error) {
+	begin := time.Now()
+	name := "IPFSBackend.GetAll"
+	ctx, span := spanTrace(ctx, name, trace.WithAttributes(attribute.String("path", path.String())))
+	defer span.End()
+
+	md, n, err := b.api.GetAll(ctx, path)
+
+	b.updateApiCallMetric(name, err, begin)
+	return md, n, err
+}
+
+func (b *ipfsBackendWithMetrics) GetBlock(ctx context.Context, path ImmutablePath) (ContentPathMetadata, files.File, error) {
+	begin := time.Now()
+	name := "IPFSBackend.GetBlock"
+	ctx, span := spanTrace(ctx, name, trace.WithAttributes(attribute.String("path", path.String())))
+	defer span.End()
+
+	md, n, err := b.api.GetBlock(ctx, path)
+
+	b.updateApiCallMetric(name, err, begin)
+	return md, n, err
+}
+
+func (b *ipfsBackendWithMetrics) Head(ctx context.Context, path ImmutablePath) (ContentPathMetadata, files.Node, error) {
+	begin := time.Now()
+	name := "IPFSBackend.Head"
+	ctx, span := spanTrace(ctx, name, trace.WithAttributes(attribute.String("path", path.String())))
+	defer span.End()
+
+	md, n, err := b.api.Head(ctx, path)
+
+	b.updateApiCallMetric(name, err, begin)
+	return md, n, err
+}
+
+func (b *ipfsBackendWithMetrics) ResolvePath(ctx context.Context, path ImmutablePath) (ContentPathMetadata, error) {
+	begin := time.Now()
+	name := "IPFSBackend.ResolvePath"
+	ctx, span := spanTrace(ctx, name, trace.WithAttributes(attribute.String("path", path.String())))
+	defer span.End()
+
+	md, err := b.api.ResolvePath(ctx, path)
+
+	b.updateApiCallMetric(name, err, begin)
+	return md, err
+}
+
+func (b *ipfsBackendWithMetrics) GetCAR(ctx context.Context, path ImmutablePath) (ContentPathMetadata, io.ReadCloser, <-chan error, error) {
+	begin := time.Now()
+	name := "IPFSBackend.GetCAR"
+	ctx, span := spanTrace(ctx, name, trace.WithAttributes(attribute.String("path", path.String())))
+	defer span.End()
+
+	md, rc, errCh, err := b.api.GetCAR(ctx, path)
+
+	// TODO: handle errCh
+	b.updateApiCallMetric(name, err, begin)
+	return md, rc, errCh, err
+}
+
+func (b *ipfsBackendWithMetrics) IsCached(ctx context.Context, path path.Path) bool {
+	begin := time.Now()
+	name := "IPFSBackend.IsCached"
+	ctx, span := spanTrace(ctx, name, trace.WithAttributes(attribute.String("path", path.String())))
+	defer span.End()
+
+	bln := b.api.IsCached(ctx, path)
+
+	b.updateApiCallMetric(name, nil, begin)
+	return bln
+}
+
+func (b *ipfsBackendWithMetrics) GetIPNSRecord(ctx context.Context, cid cid.Cid) ([]byte, error) {
+	begin := time.Now()
+	name := "IPFSBackend.GetIPNSRecord"
+	ctx, span := spanTrace(ctx, name, trace.WithAttributes(attribute.String("cid", cid.String())))
+	defer span.End()
+
+	r, err := b.api.GetIPNSRecord(ctx, cid)
+
+	b.updateApiCallMetric(name, err, begin)
+	return r, err
+}
+
+func (b *ipfsBackendWithMetrics) ResolveMutable(ctx context.Context, path path.Path) (ImmutablePath, error) {
+	begin := time.Now()
+	name := "IPFSBackend.ResolveMutable"
+	ctx, span := spanTrace(ctx, name, trace.WithAttributes(attribute.String("path", path.String())))
+	defer span.End()
+
+	p, err := b.api.ResolveMutable(ctx, path)
+
+	b.updateApiCallMetric(name, err, begin)
+	return p, err
+}
+
+func (b *ipfsBackendWithMetrics) GetDNSLinkRecord(ctx context.Context, fqdn string) (path.Path, error) {
+	begin := time.Now()
+	name := "IPFSBackend.GetDNSLinkRecord"
+	ctx, span := spanTrace(ctx, name, trace.WithAttributes(attribute.String("fqdn", fqdn)))
+	defer span.End()
+
+	p, err := b.api.GetDNSLinkRecord(ctx, fqdn)
+
+	b.updateApiCallMetric(name, err, begin)
+	return p, err
+}
+
+var _ IPFSBackend = (*ipfsBackendWithMetrics)(nil)
+
+func newHandlerWithMetrics(c Config, api IPFSBackend) *handler {
+	i := &handler{
+		config: c,
+		api:    newIPFSBackendWithMetrics(api),
+		// Improved Metrics
+		// ----------------------------
+		// Time till the first content block (bar in /ipfs/cid/foo/bar)
+		// (format-agnostic, across all response types)
+		firstContentBlockGetMetric: newHistogramMetric(
+			"gw_first_content_block_get_latency_seconds",
+			"The time till the first content block is received on GET from the gateway.",
+		),
+
+		// Response-type specific metrics
+		// ----------------------------
+		// Generic: time it takes to execute a successful gateway request (all request types)
+		getMetric: newHistogramMetric(
+			"gw_get_duration_seconds",
+			"The time to GET a successful response to a request (all content types).",
+		),
+		// UnixFS: time it takes to return a file
+		unixfsFileGetMetric: newHistogramMetric(
+			"gw_unixfs_file_get_duration_seconds",
+			"The time to serve an entire UnixFS file from the gateway.",
+		),
+		// UnixFS: time it takes to find and serve an index.html file on behalf of a directory.
+		unixfsDirIndexGetMetric: newHistogramMetric(
+			"gw_unixfs_dir_indexhtml_get_duration_seconds",
+			"The time to serve an index.html file on behalf of a directory from the gateway. This is a subset of gw_unixfs_file_get_duration_seconds.",
+		),
+		// UnixFS: time it takes to generate static HTML with directory listing
+		unixfsGenDirListingGetMetric: newHistogramMetric(
+			"gw_unixfs_gen_dir_listing_get_duration_seconds",
+			"The time to serve a generated UnixFS HTML directory listing from the gateway.",
+		),
+		// CAR: time it takes to return requested CAR stream
+		carStreamGetMetric: newHistogramMetric(
+			"gw_car_stream_get_duration_seconds",
+			"The time to GET an entire CAR stream from the gateway.",
+		),
+		// Block: time it takes to return requested Block
+		rawBlockGetMetric: newHistogramMetric(
+			"gw_raw_block_get_duration_seconds",
+			"The time to GET an entire raw Block from the gateway.",
+		),
+		// TAR: time it takes to return requested TAR stream
+		tarStreamGetMetric: newHistogramMetric(
+			"gw_tar_stream_get_duration_seconds",
+			"The time to GET an entire TAR stream from the gateway.",
+		),
+		// JSON/CBOR: time it takes to return requested DAG-JSON/-CBOR document
+		jsoncborDocumentGetMetric: newHistogramMetric(
+			"gw_jsoncbor_get_duration_seconds",
+			"The time to GET an entire DAG-JSON/CBOR block from the gateway.",
+		),
+		// IPNS Record: time it takes to return IPNS record
+		ipnsRecordGetMetric: newHistogramMetric(
+			"gw_ipns_record_get_duration_seconds",
+			"The time to GET an entire IPNS Record from the gateway.",
+		),
+
+		// Legacy Metrics
+		// ----------------------------
+		unixfsGetMetric: newSummaryMetric( // TODO: remove?
+			// (deprecated, use firstContentBlockGetMetric instead)
+			"unixfs_get_latency_seconds",
+			"DEPRECATED: does not do what you think, use gw_first_content_block_get_latency_seconds instead.",
+		),
+	}
+	return i
+}
+
+func newSummaryMetric(name string, help string) *prometheus.SummaryVec {
+	summaryMetric := prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Namespace: "ipfs",
+			Subsystem: "http",
+			Name:      name,
+			Help:      help,
+		},
+		[]string{"gateway"},
+	)
+	if err := prometheus.Register(summaryMetric); err != nil {
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			summaryMetric = are.ExistingCollector.(*prometheus.SummaryVec)
+		} else {
+			log.Errorf("failed to register ipfs_http_%s: %v", name, err)
+		}
+	}
+	return summaryMetric
+}
+
+func newHistogramMetric(name string, help string) *prometheus.HistogramVec {
+	// We can add buckets as a parameter in the future, but for now using static defaults
+	// suggested in https://github.com/ipfs/kubo/issues/8441
+	defaultBuckets := []float64{0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60}
+	histogramMetric := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "ipfs",
+			Subsystem: "http",
+			Name:      name,
+			Help:      help,
+			Buckets:   defaultBuckets,
+		},
+		[]string{"gateway"},
+	)
+	if err := prometheus.Register(histogramMetric); err != nil {
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			histogramMetric = are.ExistingCollector.(*prometheus.HistogramVec)
+		} else {
+			log.Errorf("failed to register ipfs_http_%s: %v", name, err)
+		}
+	}
+	return histogramMetric
+}
+
+// spanTrace starts a new span using the standard IPFS tracing conventions.
+func spanTrace(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	return otel.Tracer("boxo").Start(ctx, fmt.Sprintf("%s.%s", " Gateway", spanName), opts...)
+}

--- a/gateway/metrics.go
+++ b/gateway/metrics.go
@@ -55,25 +55,13 @@ func (b *ipfsBackendWithMetrics) updateApiCallMetric(name string, err error, beg
 	}
 }
 
-func (b *ipfsBackendWithMetrics) Get(ctx context.Context, path ImmutablePath) (ContentPathMetadata, *GetResponse, error) {
+func (b *ipfsBackendWithMetrics) Get(ctx context.Context, path ImmutablePath, ranges ...ByteRange) (ContentPathMetadata, *GetResponse, error) {
 	begin := time.Now()
 	name := "IPFSBackend.Get"
-	ctx, span := spanTrace(ctx, name, trace.WithAttributes(attribute.String("path", path.String())))
+	ctx, span := spanTrace(ctx, name, trace.WithAttributes(attribute.String("path", path.String()), attribute.Int("ranges", len(ranges))))
 	defer span.End()
 
-	md, n, err := b.api.Get(ctx, path)
-
-	b.updateApiCallMetric(name, err, begin)
-	return md, n, err
-}
-
-func (b *ipfsBackendWithMetrics) GetRange(ctx context.Context, path ImmutablePath, ranges ...GetRange) (ContentPathMetadata, *GetResponse, error) {
-	begin := time.Now()
-	name := "IPFSBackend.GetRange"
-	ctx, span := spanTrace(ctx, name, trace.WithAttributes(attribute.String("path", path.String())))
-	defer span.End()
-
-	md, f, err := b.api.GetRange(ctx, path, ranges...)
+	md, f, err := b.api.Get(ctx, path, ranges...)
 
 	b.updateApiCallMetric(name, err, begin)
 	return md, f, err

--- a/gateway/metrics.go
+++ b/gateway/metrics.go
@@ -67,7 +67,7 @@ func (b *ipfsBackendWithMetrics) Get(ctx context.Context, path ImmutablePath) (C
 	return md, n, err
 }
 
-func (b *ipfsBackendWithMetrics) GetRange(ctx context.Context, path ImmutablePath, ranges ...GetRange) (ContentPathMetadata, files.File, error) {
+func (b *ipfsBackendWithMetrics) GetRange(ctx context.Context, path ImmutablePath, ranges ...GetRange) (ContentPathMetadata, *GetResponse, error) {
 	begin := time.Now()
 	name := "IPFSBackend.GetRange"
 	ctx, span := spanTrace(ctx, name, trace.WithAttributes(attribute.String("path", path.String())))


### PR DESCRIPTION
This PR is part of https://github.com/ipfs/bifrost-gateway/pull/61

- Moves metric-related code to `gateway/metrics.go`
- Adds opentelemetry span for every IPFSBackend API call 
- Adds success/failure histogram for each API call ipfs_gw_backend_api_call_duration_seconds 

## TODO

- [x] `Get` and `GetRange` are now the same, as suggested in https://github.com/ipfs/boxo/pull/240#pullrequestreview-1365554977
- [x] fix tests: check why Kubo sharness fails
  - [x] Kubo sharness / CI  in https://github.com/ipfs/kubo/pull/9786 must be green
