### PR TITLE
feat(gateway)!: deserialised responses turned off by default

### DIFF
--- a/gateway/handler_unixfs__redirects.go
+++ b/gateway/handler_unixfs__redirects.go
@@ -210,10 +210,10 @@ func (i *handler) serve4xx(w http.ResponseWriter, r *http.Request, content4xxPat
 }
 
 func hasOriginIsolation(r *http.Request) bool {
-	_, gw := r.Context().Value(GatewayHostnameKey).(string)
+	_, subdomainGw := r.Context().Value(SubdomainHostnameKey).(string)
 	_, dnslink := r.Context().Value(DNSLinkHostnameKey).(string)
 
-	if gw || dnslink {
+	if subdomainGw || dnslink {
 		return true
 	}
 

--- a/gateway/handler_unixfs_dir.go
+++ b/gateway/handler_unixfs_dir.go
@@ -186,8 +186,10 @@ func (i *handler) serveDirectory(ctx context.Context, w http.ResponseWriter, r *
 	// for this request.
 	var gwURL string
 
-	// Get gateway hostname and build gateway URL.
-	if h, ok := r.Context().Value(GatewayHostnameKey).(string); ok {
+	// Ensure correct URL in DNSLink and Subdomain Gateways.
+	if h, ok := r.Context().Value(SubdomainHostnameKey).(string); ok {
+		gwURL = "//" + h
+	} else if h, ok := r.Context().Value(DNSLinkHostnameKey).(string); ok {
 		gwURL = "//" + h
 	} else {
 		gwURL = ""


### PR DESCRIPTION
Closes #225. Adds support for [trustless and trusted](https://specs.ipfs.tech/http-gateways/trustless-gateway/) gateway modes.

- Default is Trustless Mode as per #225. In addition,
	- Can be globally overwritten by setting `Config.TrustedMode` to `true`
	- Can be overwritten per known gateway by setting `gateway.TrustedMode` to `true/false`
	- ~`localhost`, `127.0.0.1` and `::1` are implicit trusted mode.~
- Cleans up the following:
	- Moves all gateway configuration to `Config`, including `NoDNSLink` and `PublicGateways`. This is motivated by the fact that we now need to access this information from the main handler in order to determine if it's a trustless or trusted gateway.
	- Reworked the context hostname keys. See code comments for explanation.
- Examples are set in trusted mode because that's what our tests expect.
	- Perhaps in a separate PR we could rework the tests for the proxy version to instead use the trustless gateway as it is a perfect example.
- In trustless mode, requests for trusted resources return <del>501</del> 406.
- Includes many tests, except for `/ipns/{cid}?format=ipns-key` because we still don't have a good way of doing that.

Sharness will fail here because structures and defaults have changed. Kubo PR: https://github.com/ipfs/kubo/pull/9789

@lidel @aschmahmann I may have missed some very specific case. Please take a look at let me know what you think.