### PR TITLE
refactor(gateway): consistent tracing names

### DIFF
--- a/gateway/handler_block.go
+++ b/gateway/handler_block.go
@@ -12,7 +12,7 @@ import (
 
 // serveRawBlock returns bytes behind a raw block
 func (i *handler) serveRawBlock(ctx context.Context, w http.ResponseWriter, r *http.Request, imPath ImmutablePath, contentPath ipath.Path, begin time.Time) bool {
-	ctx, span := spanTrace(ctx, "ServeRawBlock", trace.WithAttributes(attribute.String("path", imPath.String())))
+	ctx, span := spanTrace(ctx, "Handler.ServeRawBlock", trace.WithAttributes(attribute.String("path", imPath.String())))
 	defer span.End()
 
 	pathMetadata, data, err := i.api.GetBlock(ctx, imPath)

--- a/gateway/handler_car.go
+++ b/gateway/handler_car.go
@@ -15,7 +15,7 @@ import (
 
 // serveCAR returns a CAR stream for specific DAG+selector
 func (i *handler) serveCAR(ctx context.Context, w http.ResponseWriter, r *http.Request, imPath ImmutablePath, contentPath ipath.Path, carVersion string, begin time.Time) bool {
-	ctx, span := spanTrace(ctx, "ServeCAR", trace.WithAttributes(attribute.String("path", imPath.String())))
+	ctx, span := spanTrace(ctx, "Handler.ServeCAR", trace.WithAttributes(attribute.String("path", imPath.String())))
 	defer span.End()
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/gateway/handler_codec.go
+++ b/gateway/handler_codec.go
@@ -58,7 +58,7 @@ var contentTypeToExtension = map[string]string{
 }
 
 func (i *handler) serveCodec(ctx context.Context, w http.ResponseWriter, r *http.Request, imPath ImmutablePath, contentPath ipath.Path, begin time.Time, requestedContentType string) bool {
-	ctx, span := spanTrace(ctx, "ServeCodec", trace.WithAttributes(attribute.String("path", imPath.String()), attribute.String("requestedContentType", requestedContentType)))
+	ctx, span := spanTrace(ctx, "Handler.ServeCodec", trace.WithAttributes(attribute.String("path", imPath.String()), attribute.String("requestedContentType", requestedContentType)))
 	defer span.End()
 
 	pathMetadata, data, err := i.api.GetBlock(ctx, imPath)
@@ -77,7 +77,7 @@ func (i *handler) serveCodec(ctx context.Context, w http.ResponseWriter, r *http
 }
 
 func (i *handler) renderCodec(ctx context.Context, w http.ResponseWriter, r *http.Request, resolvedPath ipath.Resolved, blockData io.ReadSeekCloser, contentPath ipath.Path, begin time.Time, requestedContentType string) bool {
-	ctx, span := spanTrace(ctx, "RenderCodec", trace.WithAttributes(attribute.String("path", resolvedPath.String()), attribute.String("requestedContentType", requestedContentType)))
+	ctx, span := spanTrace(ctx, "Handler.RenderCodec", trace.WithAttributes(attribute.String("path", resolvedPath.String()), attribute.String("requestedContentType", requestedContentType)))
 	defer span.End()
 
 	blockCid := resolvedPath.Cid()

--- a/gateway/handler_defaults.go
+++ b/gateway/handler_defaults.go
@@ -20,7 +20,7 @@ import (
 )
 
 func (i *handler) serveDefaults(ctx context.Context, w http.ResponseWriter, r *http.Request, maybeResolvedImPath ImmutablePath, immutableContentPath ImmutablePath, contentPath ipath.Path, begin time.Time, requestedContentType string, logger *zap.SugaredLogger) bool {
-	ctx, span := spanTrace(ctx, "ServeDefaults", trace.WithAttributes(attribute.String("path", contentPath.String())))
+	ctx, span := spanTrace(ctx, "Handler.ServeDefaults", trace.WithAttributes(attribute.String("path", contentPath.String())))
 	defer span.End()
 
 	var (
@@ -113,7 +113,7 @@ func (i *handler) serveDefaults(ctx context.Context, w http.ResponseWriter, r *h
 		return i.renderCodec(r.Context(), w, r, resolvedPath, bytesResponse, contentPath, begin, requestedContentType)
 	default:
 		logger.Debugw("serving unixfs", "path", contentPath)
-		ctx, span := spanTrace(ctx, "ServeUnixFS", trace.WithAttributes(attribute.String("path", resolvedPath.String())))
+		ctx, span := spanTrace(ctx, "Handler.ServeUnixFS", trace.WithAttributes(attribute.String("path", resolvedPath.String())))
 		defer span.End()
 
 		// Handling Unixfs file

--- a/gateway/handler_ipns_record.go
+++ b/gateway/handler_ipns_record.go
@@ -20,7 +20,7 @@ import (
 )
 
 func (i *handler) serveIpnsRecord(ctx context.Context, w http.ResponseWriter, r *http.Request, contentPath ipath.Path, begin time.Time, logger *zap.SugaredLogger) bool {
-	ctx, span := spanTrace(ctx, "ServeIPNSRecord", trace.WithAttributes(attribute.String("path", contentPath.String())))
+	ctx, span := spanTrace(ctx, "Handler.ServeIPNSRecord", trace.WithAttributes(attribute.String("path", contentPath.String())))
 	defer span.End()
 
 	if contentPath.Namespace() != "ipns" {

--- a/gateway/handler_tar.go
+++ b/gateway/handler_tar.go
@@ -16,7 +16,7 @@ import (
 var unixEpochTime = time.Unix(0, 0)
 
 func (i *handler) serveTAR(ctx context.Context, w http.ResponseWriter, r *http.Request, imPath ImmutablePath, contentPath ipath.Path, begin time.Time, logger *zap.SugaredLogger) bool {
-	ctx, span := spanTrace(ctx, "ServeTAR", trace.WithAttributes(attribute.String("path", imPath.String())))
+	ctx, span := spanTrace(ctx, "Handler.ServeTAR", trace.WithAttributes(attribute.String("path", imPath.String())))
 	defer span.End()
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/gateway/handler_unixfs_dir.go
+++ b/gateway/handler_unixfs_dir.go
@@ -24,7 +24,7 @@ import (
 //
 // It will return index.html if present, or generate directory listing otherwise.
 func (i *handler) serveDirectory(ctx context.Context, w http.ResponseWriter, r *http.Request, resolvedPath ipath.Resolved, contentPath ipath.Path, isHeadRequest bool, directoryMetadata *directoryMetadata, ranges []ByteRange, begin time.Time, logger *zap.SugaredLogger) bool {
-	ctx, span := spanTrace(ctx, "ServeDirectory", trace.WithAttributes(attribute.String("path", resolvedPath.String())))
+	ctx, span := spanTrace(ctx, "Handler.ServeDirectory", trace.WithAttributes(attribute.String("path", resolvedPath.String())))
 	defer span.End()
 
 	// HostnameOption might have constructed an IPNS/IPFS path using the Host header.

--- a/gateway/handler_unixfs_file.go
+++ b/gateway/handler_unixfs_file.go
@@ -20,7 +20,7 @@ import (
 // serveFile returns data behind a file along with HTTP headers based on
 // the file itself, its CID and the contentPath used for accessing it.
 func (i *handler) serveFile(ctx context.Context, w http.ResponseWriter, r *http.Request, resolvedPath ipath.Resolved, contentPath ipath.Path, file files.File, fileContentType string, begin time.Time) bool {
-	_, span := spanTrace(ctx, "ServeFile", trace.WithAttributes(attribute.String("path", resolvedPath.String())))
+	_, span := spanTrace(ctx, "Handler.ServeFile", trace.WithAttributes(attribute.String("path", resolvedPath.String())))
 	defer span.End()
 
 	// Set Cache-Control and read optional Last-Modified time

--- a/gateway/metrics.go
+++ b/gateway/metrics.go
@@ -262,7 +262,8 @@ func newHistogramMetric(name string, help string) *prometheus.HistogramVec {
 	return histogramMetric
 }
 
-// spanTrace starts a new span using the standard IPFS tracing conventions.
+var tracer = otel.Tracer("boxo/gateway")
+
 func spanTrace(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
-	return otel.Tracer("boxo").Start(ctx, fmt.Sprintf("%s.%s", " Gateway", spanName), opts...)
+	return tracer.Start(ctx, fmt.Sprintf("Gateway.%s", spanName), opts...)
 }


### PR DESCRIPTION
In the context of https://github.com/ipfs/bifrost-gateway/issues/68, I decided to make the tracing names more consistent. When we moved the gateway to boxo, and then on #176, we added and changed some of the tracings, but they were not consistent.

What I did here:

- Prepended `Handler.` to all handler tracings, similar to what we had on the `IPFSBackend` with `IPFSBackend.`.
- Changed the tracer name to `boxo/gateway` to clearly indicate the sub-package ~~and stopped pre-pending `Gateway.` in the tracing name, since we already have the gateway part in the tracer name.~~.