### PR TITLE
fix(gw): widen duration histograms and cleanup

### DIFF
--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -64,10 +64,6 @@ type handler struct {
 	config Config
 	api    IPFSBackend
 
-	// generic metrics
-	firstContentBlockGetMetric *prometheus.HistogramVec
-	unixfsGetMetric            *prometheus.SummaryVec // deprecated, use firstContentBlockGetMetric
-
 	// response type metrics
 	getMetric                    *prometheus.HistogramVec
 	unixfsFileGetMetric          *prometheus.HistogramVec


### PR DESCRIPTION
This PR 

- **fix:** widens the duration histogram by adding buckets that cover durations between 1-30 minutes (geometric progression, closes remaining issues from https://github.com/ipfs/bifrost-gateway/issues/76)

- **cleanup:** removes deprecated and unused legacy histograms: after https://github.com/ipfs/boxo/pull/176 and https://github.com/ipfs/boxo/pull/245 we now have api_call_duration_seconds histograms for higher resolution info per backend operation
