### PR TITLE
wip: update release workflows to reflect the process

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,10 +1,9 @@
-# File managed by web3-bot. DO NOT EDIT.
-# See https://github.com/protocol/.github/ for details.
-
 name: Release Checker
 on:
   pull_request_target:
     paths: [ 'version.json' ]
+    # Do not allow releases on any other branches
+    branches: [ 'release', 'release-*' ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,3 +14,5 @@ jobs:
     uses: protocol/.github/.github/workflows/release-check.yml@master
     with:
       go-version: 1.20.x
+      # Do not require release label for releases on these branches
+      branches: release,release-*

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -1,10 +1,9 @@
-# File managed by web3-bot. DO NOT EDIT.
-# See https://github.com/protocol/.github/ for details.
-
 name: Releaser
 on:
   push:
     paths: [ 'version.json' ]
+    # Do not allow releases on any other branches
+    branches: [ 'release', 'release-*' ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.sha }}
@@ -13,3 +12,6 @@ concurrency:
 jobs:
   releaser:
     uses: protocol/.github/.github/workflows/releaser.yml@master
+    with:
+      # Do not require release label for releases on these branches
+      branches: release,release-*


### PR DESCRIPTION
Requires https://github.com/protocol/.github/pull/512 and https://github.com/protocol/.github/pull/511

With this PR, we'd only run release check on PRs to `release` or `release-*` branches and release on merges to `release` or `release-*` branches. We wouldn't allow releases on any other branches either.