### PR TITLE
feat(verifcid): AddGoodHash

### DIFF
--- a/verifcid/validate.go
+++ b/verifcid/validate.go
@@ -33,6 +33,13 @@ var goodset = map[uint64]bool{
 	mh.SHA1: true, // not really secure but still useful
 }
 
+func AddGoodHash(code uint64) {
+	good, found := goodset[code]
+	if !found || !good {
+		goodset[code] = true
+	}
+}
+
 func IsGoodHash(code uint64) bool {
 	good, found := goodset[code]
 	if good {


### PR DESCRIPTION
Allows Boxo users to expand the set of secure hash functions without having to fork Boxo.

Users may introduce new hashes to multishash registry but won't be able to use them as Blockservice layer is strict about which hashes are allowed via `verifcid` pkg. 

Now anyone can add new hashes globally, potentially degrading security, which is a tradeoff of this solution. Open to alternatives that do not involve forking.

I didn't add any godocing as none of the funcs in the pkg has it, but happy to populate all of them, as a side quest.