### PR TITLE
feat(ipns): helper ValidateWithPeerID and UnmarshalIpnsEntry

### DIFF
--- a/gateway/handler_ipns_record.go
+++ b/gateway/handler_ipns_record.go
@@ -10,9 +10,8 @@ import (
 	"time"
 
 	"github.com/cespare/xxhash/v2"
-	"github.com/gogo/protobuf/proto"
 	ipath "github.com/ipfs/boxo/coreiface/path"
-	ipns_pb "github.com/ipfs/boxo/ipns/pb"
+	"github.com/ipfs/boxo/ipns"
 	"github.com/ipfs/go-cid"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -50,8 +49,7 @@ func (i *handler) serveIpnsRecord(ctx context.Context, w http.ResponseWriter, r 
 		return false
 	}
 
-	var record ipns_pb.IpnsEntry
-	err = proto.Unmarshal(rawRecord, &record)
+	record, err := ipns.UnmarshalIpnsEntry(rawRecord)
 	if err != nil {
 		webError(w, err, http.StatusInternalServerError)
 		return false

--- a/ipns/ipns.go
+++ b/ipns/ipns.go
@@ -130,6 +130,16 @@ func createCborDataForIpnsEntry(e *pb.IpnsEntry) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// ValidateWithPeerID validates the given IPNS entry against the given peer ID.
+func ValidateWithPeerID(pid peer.ID, entry *pb.IpnsEntry) error {
+	pk, err := ExtractPublicKey(pid, entry)
+	if err != nil {
+		return err
+	}
+
+	return Validate(pk, entry)
+}
+
 // Validates validates the given IPNS entry against the given public key.
 func Validate(pk ic.PubKey, entry *pb.IpnsEntry) error {
 	// Make sure max size is respected
@@ -285,6 +295,17 @@ func EmbedPublicKey(pk ic.PubKey, entry *pb.IpnsEntry) error {
 	}
 	entry.PubKey = pkBytes
 	return nil
+}
+
+// UnmarshalIpnsEntry unmarshalls an IPNS entry from a slice of bytes.
+func UnmarshalIpnsEntry(data []byte) (*pb.IpnsEntry, error) {
+	var entry pb.IpnsEntry
+	err := proto.Unmarshal(data, &entry)
+	if err != nil {
+		return nil, err
+	}
+
+	return &entry, nil
 }
 
 // ExtractPublicKey extracts a public key matching `pid` from the IPNS record,


### PR DESCRIPTION
After my overly excited merge and revert of #292, I looked at the code and saw we were already duplicating existing code. E.g. the key extraction logic already existed and was being duplicated. This PR adds two helper functions `ValidateWithPeerID` and `UnmarshalIpnsEntry`. They already use existing functionality. I also added tests.

I did not include `IpnsInspectEntry` for the reasons here: https://github.com/ipfs/boxo/pull/292#issuecomment-1541581206 - it doesn't make sense for us to be adding it here since it is tightly related to the type we use in `ipfs name inspect`. We only created it in first place to simplify the type used by the RPC client in Kubo.

I also enabled a test that has been disabled for 5 years in 032060566e194f69bb3fd22c6d238eed9a10dcf6. It seems to pass now, and reading the commit description, I don't think it is a problem due to the way Peer IDs are encoded nowadays.

Tested in Kubo here: https://github.com/ipfs/kubo/pull/9867