### PR TITLE
feat: pass records limit on routing.FindProviders

### DIFF
--- a/routing/http/client/client_test.go
+++ b/routing/http/client/client_test.go
@@ -27,8 +27,8 @@ import (
 
 type mockContentRouter struct{ mock.Mock }
 
-func (m *mockContentRouter) FindProviders(ctx context.Context, key cid.Cid) (iter.ResultIter[types.ProviderResponse], error) {
-	args := m.Called(ctx, key)
+func (m *mockContentRouter) FindProviders(ctx context.Context, key cid.Cid, stream bool) (iter.ResultIter[types.ProviderResponse], error) {
+	args := m.Called(ctx, key, stream)
 	return args.Get(0).(iter.ResultIter[types.ProviderResponse]), args.Error(1)
 }
 func (m *mockContentRouter) ProvideBitswap(ctx context.Context, req *server.BitswapWriteProvideRequest) (time.Duration, error) {
@@ -302,7 +302,7 @@ func TestClient_FindProviders(t *testing.T) {
 
 			findProvsIter := iter.FromSlice(c.routerProvs)
 
-			router.On("FindProviders", mock.Anything, cid).
+			router.On("FindProviders", mock.Anything, cid, c.expStreamingResponse).
 				Return(findProvsIter, c.routerErr)
 
 			provsIter, err := client.FindProviders(ctx, cid)

--- a/routing/http/client/client_test.go
+++ b/routing/http/client/client_test.go
@@ -27,8 +27,8 @@ import (
 
 type mockContentRouter struct{ mock.Mock }
 
-func (m *mockContentRouter) FindProviders(ctx context.Context, key cid.Cid, stream bool) (iter.ResultIter[types.ProviderResponse], error) {
-	args := m.Called(ctx, key, stream)
+func (m *mockContentRouter) FindProviders(ctx context.Context, key cid.Cid, limit int) (iter.ResultIter[types.ProviderResponse], error) {
+	args := m.Called(ctx, key, limit)
 	return args.Get(0).(iter.ResultIter[types.ProviderResponse]), args.Error(1)
 }
 func (m *mockContentRouter) ProvideBitswap(ctx context.Context, req *server.BitswapWriteProvideRequest) (time.Duration, error) {
@@ -302,8 +302,11 @@ func TestClient_FindProviders(t *testing.T) {
 
 			findProvsIter := iter.FromSlice(c.routerProvs)
 
-			router.On("FindProviders", mock.Anything, cid, c.expStreamingResponse).
-				Return(findProvsIter, c.routerErr)
+			if c.expStreamingResponse {
+				router.On("FindProviders", mock.Anything, cid, 0).Return(findProvsIter, c.routerErr)
+			} else {
+				router.On("FindProviders", mock.Anything, cid, 20).Return(findProvsIter, c.routerErr)
+			}
 
 			provsIter, err := client.FindProviders(ctx, cid)
 


### PR DESCRIPTION
While working on https://github.com/ipfs/kubo/pull/9877, I noticed that the `ContentRouter` interface required in order to implement the Routing V1 server does not provide enough information to make an education decision about how many providers to return.

This did not use to be an issue because the API was non-streamed so we could hardcode a value on the implementation (or timeout). Now that the server also supports streaming requests, it would be great to be able to differentiate both.

After talking to @lidel, we talked about adding a `count int` parameter in the `FindProviders`. By default, `count` will be 20 for non-streamable requests and 0 (unbounded) for streaming requests. ~However, I find that that introduces unnecessary complexity here. So I just added a `stream bool` parameter to `FindProviders` instead, and we let the implementer of `ContentRouter` decide what to do with it.~ See https://github.com/ipfs/boxo/pull/299#discussion_r1203134561.

Note that existing tests that I updated test this too.