### PR TITLE
feat(gw): add ipfs_http_gw_request_types metric

### DIFF
--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -67,6 +67,7 @@ type handler struct {
 	api    IPFSBackend
 
 	// response type metrics
+	requestTypeMetric            *prometheus.CounterVec
 	getMetric                    *prometheus.HistogramVec
 	unixfsFileGetMetric          *prometheus.HistogramVec
 	unixfsDirIndexGetMetric      *prometheus.HistogramVec
@@ -234,6 +235,7 @@ func (i *handler) getOrHeadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	trace.SpanFromContext(r.Context()).SetAttributes(attribute.String("ResponseFormat", responseFormat))
+	i.requestTypeMetric.WithLabelValues(contentPath.Namespace(), responseFormat).Inc()
 
 	i.addUserHeaders(w) // ok, _now_ write user's headers.
 	w.Header().Set("X-Ipfs-Path", contentPath.String())


### PR DESCRIPTION
This PR adds an explicit request type metric, a counter of how many requests of a specific format hit the gateway.
When no explicit format is requested, the type is empty string `""`.

This is useful on its own, allowing gateway operators to reason what request types are the most popular, but also helps with debugging described in  https://github.com/ipfs/boxo/issues/288.
