### PR TITLE
feat(gw): add ipfs_http_gw_car_stream_fail_duration_seconds

### DIFF
--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -73,8 +73,10 @@ type handler struct {
 	unixfsDirIndexGetMetric      *prometheus.HistogramVec
 	unixfsGenDirListingGetMetric *prometheus.HistogramVec
 	carStreamGetMetric           *prometheus.HistogramVec
+	carStreamFailMetric          *prometheus.HistogramVec
 	rawBlockGetMetric            *prometheus.HistogramVec
 	tarStreamGetMetric           *prometheus.HistogramVec
+	tarStreamFailMetric          *prometheus.HistogramVec
 	jsoncborDocumentGetMetric    *prometheus.HistogramVec
 	ipnsRecordGetMetric          *prometheus.HistogramVec
 }

--- a/gateway/handler_car.go
+++ b/gateway/handler_car.go
@@ -81,6 +81,9 @@ func (i *handler) serveCAR(ctx context.Context, w http.ResponseWriter, r *http.R
 	carErr := <-errCh
 	streamErr := multierr.Combine(carErr, copyErr)
 	if streamErr != nil {
+		// Update fail metric
+		i.carStreamFailMetric.WithLabelValues(contentPath.Namespace()).Observe(time.Since(begin).Seconds())
+
 		// We return error as a trailer, however it is not something browsers can access
 		// (https://github.com/mdn/browser-compat-data/issues/14703)
 		// Due to this, we suggest client always verify that

--- a/gateway/handler_tar.go
+++ b/gateway/handler_tar.go
@@ -81,6 +81,9 @@ func (i *handler) serveTAR(ctx context.Context, w http.ResponseWriter, r *http.R
 
 	// The TAR has a top-level directory (or file) named by the CID.
 	if err := tarw.WriteFile(file, rootCid.String()); err != nil {
+		// Update fail metric
+		i.tarStreamFailMetric.WithLabelValues(contentPath.Namespace()).Observe(time.Since(begin).Seconds())
+
 		w.Header().Set("X-Stream-Error", err.Error())
 		// Trailer headers do not work in web browsers
 		// (see https://github.com/mdn/browser-compat-data/issues/14703)

--- a/gateway/metrics.go
+++ b/gateway/metrics.go
@@ -219,6 +219,10 @@ func newHandlerWithMetrics(c Config, api IPFSBackend) *handler {
 			"gw_car_stream_get_duration_seconds",
 			"The time to GET an entire CAR stream from the gateway.",
 		),
+		carStreamFailMetric: newHistogramMetric(
+			"gw_car_stream_fail_duration_seconds",
+			"How long a CAR was streamed before failing mid-stream.",
+		),
 		// Block: time it takes to return requested Block
 		rawBlockGetMetric: newHistogramMetric(
 			"gw_raw_block_get_duration_seconds",
@@ -228,6 +232,11 @@ func newHandlerWithMetrics(c Config, api IPFSBackend) *handler {
 		tarStreamGetMetric: newHistogramMetric(
 			"gw_tar_stream_get_duration_seconds",
 			"The time to GET an entire TAR stream from the gateway.",
+		),
+		// TAR: time it takes to return requested TAR stream
+		tarStreamFailMetric: newHistogramMetric(
+			"gw_tar_stream_fail_duration_seconds",
+			"How long a TAR was streamed before failing mid-stream.",
 		),
 		// JSON/CBOR: time it takes to return requested DAG-JSON/-CBOR document
 		jsoncborDocumentGetMetric: newHistogramMetric(


### PR DESCRIPTION
This PR  adds failure metrics to streaming response types (CAR and TAR)
to give us better visibility (histograms) into how long it takes for CAR to fail mid-stream.

Closes  #288