### PR TITLE
feat: create pull_request_template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+<!--
+PR Creation Checklist
+- [ ] Update Changelog
+-->


### PR DESCRIPTION
This PR adds a Pull Request Template to boxo. It's the same template we use in Kubo. All it does right now is to suggest updating changelog. The suggestion is only visible to the PR creator. 