### PR TITLE
rename dagpb protobuf to merkledag.v1

### DIFF
--- a/ipld/merkledag/pb/merkledag.pb.go
+++ b/ipld/merkledag/pb/merkledag.pb.go
@@ -160,8 +160,8 @@ func (m *PBNode) GetData() []byte {
 }
 
 func init() {
-	proto.RegisterType((*PBLink)(nil), "merkledag.pb.PBLink")
-	proto.RegisterType((*PBNode)(nil), "merkledag.pb.PBNode")
+	proto.RegisterType((*PBLink)(nil), "merkledag.v1.pb.PBLink")
+	proto.RegisterType((*PBNode)(nil), "merkledag.v1.pb.PBNode")
 }
 
 func init() { proto.RegisterFile("merkledag.proto", fileDescriptor_10837cc3557cec00) }


### PR DESCRIPTION
<!--
PR Creation Checklist
- [ ] Update Changelog
-->

This prevents collisions with the go-merkledag protobuf names. Similar to #318 and #212 and part of resolving #291.

Note: unlike with #318 the protobufs here cannot be regenerated without changing the hashes of tooling like `ipfs add <file>`. Regeneration would also likely result in a violation of the [dag-pb spec](https://github.com/ipld/ipld/blob/312d5d29943c1f38fe437e802483c86959b6403d/specs/codecs/dag-pb/spec.md?plain=1#L64) since field 2 is supposed to come before 1 even though spec violations occur in the wild and implementations should parse even if 1 comes before 2.

We should test this in kubo to make sure all those test fixtures pass, but any 👀 on if there are more manual changes to be made here would be appreciated (e.g. the .proto file and the file descriptor are left untouched when compared with the ipld/unixfs PR).

Note: this was tested in https://github.com/ipfs/kubo/pull/9907 which is passing.