### PR TITLE
refactor: golang-lru → golang-lru/v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
+- Removed mentions of unused ARC algorithm ([#336](https://github.com/ipfs/boxo/issues/366#issuecomment-1597253540))
+
 ### Security
 
 ## [0.10.1] - 2023-06-19

--- a/blockstore/bloom_cache_test.go
+++ b/blockstore/bloom_cache_test.go
@@ -21,7 +21,7 @@ func testBloomCached(ctx context.Context, bs Blockstore) (*bloomcache, error) {
 		ctx = context.Background()
 	}
 	opts := DefaultCacheOpts()
-	opts.HasARCCacheSize = 0
+	opts.HasTwoQueueCacheSize = 0
 	bbs, err := CachedBlockstore(ctx, bs, opts)
 	if err == nil {
 		return bbs.(*bloomcache), nil

--- a/blockstore/caching.go
+++ b/blockstore/caching.go
@@ -12,7 +12,7 @@ import (
 type CacheOpts struct {
 	HasBloomFilterSize   int // 1 byte
 	HasBloomFilterHashes int // No size, 7 is usually best, consult bloom papers
-	HasARCCacheSize      int // 32 bytes
+	HasTwoQueueCacheSize int // 32 bytes
 }
 
 // DefaultCacheOpts returns a CacheOpts initialized with default values.
@@ -20,11 +20,11 @@ func DefaultCacheOpts() CacheOpts {
 	return CacheOpts{
 		HasBloomFilterSize:   512 << 10,
 		HasBloomFilterHashes: 7,
-		HasARCCacheSize:      64 << 10,
+		HasTwoQueueCacheSize: 64 << 10,
 	}
 }
 
-// CachedBlockstore returns a blockstore wrapped in an ARCCache and
+// CachedBlockstore returns a blockstore wrapped in an TwoQueueCache and
 // then in a bloom filter cache, if the options indicate it.
 func CachedBlockstore(
 	ctx context.Context,
@@ -33,7 +33,7 @@ func CachedBlockstore(
 	cbs = bs
 
 	if opts.HasBloomFilterSize < 0 || opts.HasBloomFilterHashes < 0 ||
-		opts.HasARCCacheSize < 0 {
+		opts.HasTwoQueueCacheSize < 0 {
 		return nil, errors.New("all options for cache need to be greater than zero")
 	}
 
@@ -43,8 +43,8 @@ func CachedBlockstore(
 
 	ctx = metrics.CtxSubScope(ctx, "bs.cache")
 
-	if opts.HasARCCacheSize > 0 {
-		cbs, err = newARCCachedBS(ctx, cbs, opts.HasARCCacheSize)
+	if opts.HasTwoQueueCacheSize > 0 {
+		cbs, err = newTwoQueueCachedBS(ctx, cbs, opts.HasTwoQueueCacheSize)
 	}
 	if opts.HasBloomFilterSize != 0 {
 		// *8 because of bytes to bits conversion

--- a/blockstore/caching_test.go
+++ b/blockstore/caching_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestCachingOptsLessThanZero(t *testing.T) {
 	opts := DefaultCacheOpts()
-	opts.HasARCCacheSize = -1
+	opts.HasTwoQueueCacheSize = -1
 
 	if _, err := CachedBlockstore(context.TODO(), nil, opts); err == nil {
 		t.Error("wrong ARC setting was not detected")

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.1 // indirect
 	github.com/huin/goupnp v1.0.3 // indirect
 	github.com/ipfs/bbloom v0.0.4 // indirect
 	github.com/ipfs/go-bitfield v1.1.0 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -268,6 +268,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.1 h1:5pv5N1lT1fjLg2VQ5KWc7kmucp2x/kvFOnxuVTqZ6x4=
+github.com/hashicorp/golang-lru/v2 v2.0.1/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/huin/goupnp v1.0.0/go.mod h1:n9v9KO1tAxYH82qOn+UTIFQDmx5n1Zxd/ClZDMX7Bnc=
 github.com/huin/goupnp v1.0.3 h1:N8No57ls+MnjlB+JPiCVSOyy/ot7MJTqlo7rn+NYSqQ=
 github.com/huin/goupnp v1.0.3/go.mod h1:ZxNlw5WqJj6wSsRK5+YfflQGXYfccj5VgQsMNixHM7Y=

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
-	github.com/hashicorp/golang-lru v0.5.4
+	github.com/hashicorp/golang-lru/v2 v2.0.1
 	github.com/ipfs/bbloom v0.0.4
 	github.com/ipfs/go-bitfield v1.1.0
 	github.com/ipfs/go-block-format v0.1.2
@@ -106,6 +106,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/huin/goupnp v1.0.3 // indirect
 	github.com/ipfs/go-ipfs-blockstore v1.3.0 // indirect
 	github.com/ipfs/go-ipfs-chunker v0.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -272,6 +272,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.1 h1:5pv5N1lT1fjLg2VQ5KWc7kmucp2x/kvFOnxuVTqZ6x4=
+github.com/hashicorp/golang-lru/v2 v2.0.1/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/huin/goupnp v1.0.0/go.mod h1:n9v9KO1tAxYH82qOn+UTIFQDmx5n1Zxd/ClZDMX7Bnc=
 github.com/huin/goupnp v1.0.3 h1:N8No57ls+MnjlB+JPiCVSOyy/ot7MJTqlo7rn+NYSqQ=
 github.com/huin/goupnp v1.0.3/go.mod h1:ZxNlw5WqJj6wSsRK5+YfflQGXYfccj5VgQsMNixHM7Y=

--- a/namesys/namesys.go
+++ b/namesys/namesys.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"time"
 
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 	opts "github.com/ipfs/boxo/coreiface/options/namesys"
 	"github.com/ipfs/boxo/path"
 	"github.com/ipfs/go-cid"
@@ -48,7 +48,7 @@ type mpns struct {
 	ipnsPublisher             Publisher
 
 	staticMap map[string]path.Path
-	cache     *lru.Cache
+	cache     *lru.Cache[string, any]
 }
 
 type Option func(*mpns) error
@@ -60,7 +60,7 @@ func WithCache(size int) Option {
 			return fmt.Errorf("invalid cache size %d; must be > 0", size)
 		}
 
-		cache, err := lru.New(size)
+		cache, err := lru.New[string, any](size)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The goal of this PR is to emove ARC patent annoyance from boxo users. Even tho we do not use ARC (we use TwoQueue cache instead), automated testing tools still flag boxo as it imports library which has ARC implementatation.

- [x] switch to  v2 of golang-lru without arc code (https://github.com/ipfs/boxo/issues/366#issuecomment-1597253540)
- [x] remove mentions of ARC in comments and func/var names, make it clear we use TwoQueue 
- [x] Update Changelog

Closes #366
