### PR TITLE
fix(gateway): include CORS on subdomain redirects

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -320,20 +320,22 @@ func cleanHeaderSet(headers []string) []string {
 	return result
 }
 
-// AddAccessControlHeaders adds default HTTP headers used for controlling
-// cross-origin requests. This function adds several values to the
-// [Access-Control-Allow-Headers] and [Access-Control-Expose-Headers] entries.
+// AddAccessControlHeaders ensures safe default HTTP headers are used for
+// controlling cross-origin requests. This function adds several values to the
+// [Access-Control-Allow-Headers] and [Access-Control-Expose-Headers] entries
+// to be exposed on GET and OPTIONS responses, including [CORS Preflight].
 //
-// If the Access-Control-Allow-Origin entry is missing a value of '*' is
+// If the Access-Control-Allow-Origin entry is missing, a default value of '*' is
 // added, indicating that browsers should allow requesting code from any
 // origin to access the resource.
 //
-// If the Access-Control-Allow-Methods entry is missing a value of 'GET' is
-// added, indicating that browsers may use the GET method when issuing cross
+// If the Access-Control-Allow-Methods entry is missing a value, 'GET, HEAD,
+// OPTIONS' is added, indicating that browsers may use them when issuing cross
 // origin requests.
 //
 // [Access-Control-Allow-Headers]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
 // [Access-Control-Expose-Headers]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
+// [CORS Preflight]: https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request
 func AddAccessControlHeaders(headers map[string][]string) {
 	// Hard-coded headers.
 	const ACAHeadersName = "Access-Control-Allow-Headers"
@@ -346,8 +348,12 @@ func AddAccessControlHeaders(headers map[string][]string) {
 		headers[ACAOriginName] = []string{"*"}
 	}
 	if _, ok := headers[ACAMethodsName]; !ok {
-		// Default to GET
-		headers[ACAMethodsName] = []string{http.MethodGet}
+		// Default to GET, HEAD, OPTIONS
+		headers[ACAMethodsName] = []string{
+			http.MethodGet,
+			http.MethodHead,
+			http.MethodOptions,
+		}
 	}
 
 	headers[ACAHeadersName] = cleanHeaderSet(

--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -157,19 +157,25 @@ func (i *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Add("Allow", http.MethodGet)
-	w.Header().Add("Allow", http.MethodHead)
-	w.Header().Add("Allow", http.MethodOptions)
+	addAllowHeader(w)
 
 	errmsg := "Method " + r.Method + " not allowed: read only access"
 	http.Error(w, errmsg, http.StatusMethodNotAllowed)
 }
 
 func (i *handler) optionsHandler(w http.ResponseWriter, r *http.Request) {
+	addAllowHeader(w)
 	// OPTIONS is a noop request that is used by the browsers to check if server accepts
 	// cross-site XMLHttpRequest, which is indicated by the presence of CORS headers:
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Preflighted_requests
-	i.addUserHeaders(w) // return all custom headers (including CORS ones, if set)
+	addCustomHeaders(w, i.config.Headers) // return all custom headers (including CORS ones, if set)
+}
+
+// addAllowHeader sets Allow header with supported HTTP methods
+func addAllowHeader(w http.ResponseWriter) {
+	w.Header().Add("Allow", http.MethodGet)
+	w.Header().Add("Allow", http.MethodHead)
+	w.Header().Add("Allow", http.MethodOptions)
 }
 
 type requestData struct {
@@ -245,7 +251,7 @@ func (i *handler) getOrHeadHandler(w http.ResponseWriter, r *http.Request) {
 	trace.SpanFromContext(r.Context()).SetAttributes(attribute.String("ResponseFormat", responseFormat))
 	i.requestTypeMetric.WithLabelValues(contentPath.Namespace(), responseFormat).Inc()
 
-	i.addUserHeaders(w) // ok, _now_ write user's headers.
+	addCustomHeaders(w, i.config.Headers) // ok, _now_ write user's headers.
 	w.Header().Set("X-Ipfs-Path", contentPath.String())
 
 	// Fail fast if unsupported request type was sent to a Trustless Gateway.
@@ -321,9 +327,9 @@ func (i *handler) getOrHeadHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (i *handler) addUserHeaders(w http.ResponseWriter) {
-	for k, v := range i.config.Headers {
-		w.Header()[k] = v
+func addCustomHeaders(w http.ResponseWriter, headers map[string][]string) {
+	for k, v := range headers {
+		w.Header()[http.CanonicalHeaderKey(k)] = v
 	}
 }
 


### PR DESCRIPTION
This PR closes regression introduced during one of the refactors since Kubo 0.20 and adds dedicated tests for preflight requests on both path and subdomain gateway.

Context: https://github.com/ipfs/kubo/issues/9983#issuecomment-1599673976



