### PR TITLE
docs(readme): new logo and header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 <h1 align="center">
-Boxo 🍌
+<img src="https://github.com/ipfs/boxo/assets/157609/3c5e7391-fbc2-405b-9efc-920f4fd13b39" alt="Boxo logo" title="Boxo logo" width="200">
 <br>
-<img src="https://raw.githubusercontent.com/ipfs/boxo/main/logo.svg" alt="Boxo logo" title="Boxo logo" width="200">
-<br>
+BOXO: IPFS SDK for GO
 </h1>
-<p align="center" style="font-size: 1.2rem;">A library for building IPFS applications and implementations.</p>
+<p align="center" style="font-size: 1.2rem;">A set of libraries for building IPFS applications and implementations in GO.</p>
 
 <hr />
 


### PR DESCRIPTION
This is the temporary logo until we decide we want to rename the project again  :upside_down_face: 

Assets: [Boxo SVG.zip](https://github.com/ipfs/boxo/files/11918742/Boxo.SVG.zip)

I went with grey+red variant, to make this distinct and SDK-like, and different from Kubo (right)  and the IPFS Cube,
but we also have blue version in case others feel strongly about keeping the color theme.

## VOTE WITH EMOJI

- :rocket:  - grey+red
- :tada:  – blueish

| :rocket: grey+red | :tada: blueish | kubo | ipfs | 
| ---- | ---- | ---- | ---- | 
| ![](https://github.com/ipfs/boxo/assets/157609/3c5e7391-fbc2-405b-9efc-920f4fd13b39) |  ![boxo-blue-hex](https://github.com/ipfs/boxo/assets/157609/40f4d736-0371-4770-8923-e32e7782d334) |  ![Kubo_Icon_Multi-Color_Wordmark](https://github.com/ipfs/boxo/assets/157609/d6d12db8-fdcf-4be3-8546-2550b69845d8) |  ![ipfs-logo](https://github.com/ipfs/boxo/assets/157609/121fed52-ba38-4cc3-85ed-43223489adbb) |

cc @ipfs/kubo-maintainers 
