### PR TITLE
Provides new query param feature of redirects file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The following emojis are used to highlight certain changes:
 
 ## [Unreleased]
 
+* ❔ Allows redirects of URLs by query parameter (in addition to path). A `_redirects` file containing `/from type=:type /to/:type.html 200` will respond to a request of `/from?type=thing` with `/to/thing.html`.
+
 ### Added
 
 ### Changed

--- a/gateway/handler_unixfs__redirects.go
+++ b/gateway/handler_unixfs__redirects.go
@@ -99,7 +99,7 @@ func (i *handler) handleRedirectsFileRules(w http.ResponseWriter, r *http.Reques
 
 		for _, rule := range redirectRules {
 			// Error right away if the rule is invalid
-			if !rule.MatchAndExpandPlaceholders(urlPath) {
+			if !rule.MatchAndExpandPlaceholders(urlPath, r.URL.Query()) {
 				continue
 			}
 


### PR DESCRIPTION
**⚠️ Please ignore:** Cannot be completed/will not be ready until the PR below is merged, and a new version released (so go.mod/go.sum can be updated here)

Draft PR for using ipfs/go-ipfs-redirects-file#21 to allow query parameters in redirects.

