### PR TITLE
fix!: add escaped abspath header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ The following emojis are used to highlight certain changes:
 
 - HTTP Gateway API: Not having a block will result in a 5xx error rather than 404
 - HTTP Gateway API: CAR requests will return 200s and a CAR file proving a requested path does not exist rather than returning an error
+- 🛠 `MultiFileReader` has been updated with a new header with the encoded file name instead of the plain filename, due to a regression found in  [`net/textproto`](https://github.com/golang/go/issues/60674). This only affects files with binary characters in their name. By keeping the old header, we maximize backwards compatibility.
+  |            | New Client | Old Client  |
+  |------------|------------|-------------|
+  | New Server | ✅         | 🟡*         |
+  | Old Server | ✅         | ✅          |
+   *Old clients can only send Unicode file paths to the server.
 
 ### Security
 

--- a/files/multifilereader_binary_go119_test.go
+++ b/files/multifilereader_binary_go119_test.go
@@ -1,0 +1,10 @@
+//go:build !go1.20
+
+package files
+
+import "testing"
+
+func TestAbspathHeaderWithBinaryFilenameSucceeds(t *testing.T) {
+	// Simulates old client talking to old server (< Go 1.20).
+	runMultiFileReaderToMultiFileTest(t, true, true, false)
+}

--- a/files/multifilereader_binary_go120_test.go
+++ b/files/multifilereader_binary_go120_test.go
@@ -1,0 +1,13 @@
+//go:build go1.20
+
+package files
+
+import (
+	"testing"
+)
+
+func TestAbspathHeaderWithBinaryFilenameFails(t *testing.T) {
+	// Simulates old client talking to new server (>= Go 1.20). Old client will
+	// send the binary filename in the regular headers and the new server will error.
+	runMultiFileReaderToMultiFileTest(t, true, true, true)
+}

--- a/files/multifilereader_test.go
+++ b/files/multifilereader_test.go
@@ -1,6 +1,7 @@
 package files
 
 import (
+	"bytes"
 	"io"
 	"mime/multipart"
 	"testing"
@@ -10,6 +11,10 @@ import (
 
 var text = "Some text! :)"
 
+func newBytesFileWithPath(abspath string, b []byte) File {
+	return &ReaderFile{abspath, bytesReaderCloser{bytes.NewReader(b)}, nil, int64(len(b))}
+}
+
 func makeMultiFileReader(t *testing.T, binaryFileName, rawAbsPath bool) (string, *MultiFileReader) {
 	var (
 		filename string
@@ -18,19 +23,19 @@ func makeMultiFileReader(t *testing.T, binaryFileName, rawAbsPath bool) (string,
 
 	if binaryFileName {
 		filename = "bad\x7fname.txt"
-		file = NewBytesFileWithPath("/my/path/boop/bad\x7fname.txt", []byte("bloop"))
+		file = newBytesFileWithPath("/my/path/boop/bad\x7fname.txt", []byte("bloop"))
 	} else {
 		filename = "résumé🥳.txt"
-		file = NewBytesFileWithPath("/my/path/boop/résumé🥳.txt", []byte("bloop"))
+		file = newBytesFileWithPath("/my/path/boop/résumé🥳.txt", []byte("bloop"))
 	}
 
 	sf := NewMapDirectory(map[string]Node{
-		"file.txt": NewBytesFileWithPath("/my/path/file.txt", []byte(text)),
+		"file.txt": newBytesFileWithPath("/my/path/file.txt", []byte(text)),
 		"boop": NewMapDirectory(map[string]Node{
-			"a.txt":  NewBytesFileWithPath("/my/path/boop/a.txt", []byte("bleep")),
+			"a.txt":  newBytesFileWithPath("/my/path/boop/a.txt", []byte("bleep")),
 			filename: file,
 		}),
-		"beep.txt": NewBytesFileWithPath("/my/path/beep.txt", []byte("beep")),
+		"beep.txt": newBytesFileWithPath("/my/path/beep.txt", []byte("beep")),
 	})
 
 	return filename, NewMultiFileReader(sf, true, rawAbsPath)

--- a/files/multifilereader_test.go
+++ b/files/multifilereader_test.go
@@ -4,9 +4,99 @@ import (
 	"io"
 	"mime/multipart"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 var text = "Some text! :)"
+
+func TestMultiFileReaderToMultiFile(t *testing.T) {
+	do := func(t *testing.T, binaryFileName, rawAbsPath, expectFailure bool) {
+		var (
+			filename string
+			file     File
+		)
+
+		if binaryFileName {
+			filename = "bad\x7fname.txt"
+			file = NewBytesFileWithPath("/my/path/boop/bad\x7fname.txt", []byte("bloop"))
+		} else {
+			filename = "résumé🥳.txt"
+			file = NewBytesFileWithPath("/my/path/boop/résumé🥳.txt", []byte("bloop"))
+		}
+
+		sf := NewMapDirectory(map[string]Node{
+			"file.txt": NewBytesFileWithPath("/my/path/file.txt", []byte(text)),
+			"boop": NewMapDirectory(map[string]Node{
+				"a.txt":  NewBytesFileWithPath("/my/path/boop/a.txt", []byte("bleep")),
+				filename: file,
+			}),
+			"beep.txt": NewBytesFileWithPath("/my/path/beep.txt", []byte("beep")),
+		})
+
+		mfr := NewMultiFileReader(sf, true, rawAbsPath)
+		mpReader := multipart.NewReader(mfr, mfr.Boundary())
+		mf, err := NewFileFromPartReader(mpReader, multipartFormdataType)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		it := mf.Entries()
+
+		require.True(t, it.Next())
+		require.Equal(t, "beep.txt", it.Name())
+		require.True(t, it.Next())
+		require.Equal(t, "boop", it.Name())
+		require.NotNil(t, DirFromEntry(it))
+
+		subIt := DirFromEntry(it).Entries()
+		require.True(t, subIt.Next(), subIt.Err())
+		require.Equal(t, "a.txt", subIt.Name())
+		require.Nil(t, DirFromEntry(subIt))
+
+		if expectFailure {
+			require.False(t, subIt.Next())
+			require.Error(t, subIt.Err())
+		} else {
+			require.True(t, subIt.Next(), subIt.Err())
+			require.Equal(t, filename, subIt.Name())
+			require.Nil(t, DirFromEntry(subIt))
+
+			require.False(t, subIt.Next())
+			require.Nil(t, it.Err())
+
+			// try to break internal state
+			require.False(t, subIt.Next())
+			require.Nil(t, it.Err())
+
+			require.True(t, it.Next())
+			require.Equal(t, "file.txt", it.Name())
+			require.Nil(t, DirFromEntry(it))
+			require.Nil(t, it.Err())
+
+			require.False(t, it.Next())
+			require.Nil(t, it.Err())
+		}
+	}
+
+	t.Run("Header 'abspath' with unicode filename succeeds", func(t *testing.T) {
+		do(t, false, true, false)
+	})
+
+	t.Run("Header 'abspath-encoded' with unicode filename succeeds", func(t *testing.T) {
+		do(t, false, false, false)
+	})
+
+	t.Run("Header 'abspath' with binary filename fails", func(t *testing.T) {
+		// Simulates old client talking to new server. Old client will send the
+		// binary filename in the regular headers and the new server will error.
+		do(t, true, true, true)
+	})
+
+	t.Run("Header 'abspath-encoded' with binary filename succeeds", func(t *testing.T) {
+		do(t, true, false, false)
+	})
+}
 
 func getTestMultiFileReader(t *testing.T) *MultiFileReader {
 	sf := NewMapDirectory(map[string]Node{
@@ -19,53 +109,7 @@ func getTestMultiFileReader(t *testing.T) *MultiFileReader {
 	})
 
 	// testing output by reading it with the go stdlib "mime/multipart" Reader
-	return NewMultiFileReader(sf, true)
-}
-
-func TestMultiFileReaderToMultiFile(t *testing.T) {
-	mfr := getTestMultiFileReader(t)
-	mpReader := multipart.NewReader(mfr, mfr.Boundary())
-	mf, err := NewFileFromPartReader(mpReader, multipartFormdataType)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	it := mf.Entries()
-
-	if !it.Next() || it.Name() != "beep.txt" {
-		t.Fatal("iterator didn't work as expected")
-	}
-
-	if !it.Next() || it.Name() != "boop" || DirFromEntry(it) == nil {
-		t.Fatal("iterator didn't work as expected")
-	}
-
-	subIt := DirFromEntry(it).Entries()
-
-	if !subIt.Next() || subIt.Name() != "a.txt" || DirFromEntry(subIt) != nil {
-		t.Fatal("iterator didn't work as expected")
-	}
-
-	if !subIt.Next() || subIt.Name() != "b.txt" || DirFromEntry(subIt) != nil {
-		t.Fatal("iterator didn't work as expected")
-	}
-
-	if subIt.Next() || it.Err() != nil {
-		t.Fatal("iterator didn't work as expected")
-	}
-
-	// try to break internal state
-	if subIt.Next() || it.Err() != nil {
-		t.Fatal("iterator didn't work as expected")
-	}
-
-	if !it.Next() || it.Name() != "file.txt" || DirFromEntry(it) != nil || it.Err() != nil {
-		t.Fatal("iterator didn't work as expected")
-	}
-
-	if it.Next() || it.Err() != nil {
-		t.Fatal("iterator didn't work as expected")
-	}
+	return NewMultiFileReader(sf, true, false)
 }
 
 func TestMultiFileReaderToMultiFileSkip(t *testing.T) {
@@ -164,7 +208,7 @@ func TestCommonPrefix(t *testing.T) {
 			"aaa": NewBytesFile([]byte("bleep")),
 		}),
 	})
-	mfr := NewMultiFileReader(sf, true)
+	mfr := NewMultiFileReader(sf, true, false)
 	reader, err := NewFileFromPartReader(multipart.NewReader(mfr, mfr.Boundary()), multipartFormdataType)
 	if err != nil {
 		t.Fatal(err)

--- a/files/multipartfile.go
+++ b/files/multipartfile.go
@@ -100,9 +100,19 @@ func (w *multipartWalker) nextFile() (Node, error) {
 
 		return NewLinkFile(string(out), nil), nil
 	default:
+		var absPath string
+		if absPathEncoded := part.Header.Get("abspath-encoded"); absPathEncoded != "" {
+			absPath, err = url.QueryUnescape(absPathEncoded)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			absPath = part.Header.Get("abspath")
+		}
+
 		return &ReaderFile{
 			reader:  part,
-			abspath: part.Header.Get("abspath"),
+			abspath: absPath,
 		}, nil
 	}
 }

--- a/files/readerfile.go
+++ b/files/readerfile.go
@@ -21,10 +21,6 @@ func NewBytesFile(b []byte) File {
 	return &ReaderFile{"", bytesReaderCloser{bytes.NewReader(b)}, nil, int64(len(b))}
 }
 
-func NewBytesFileWithPath(abspath string, b []byte) File {
-	return &ReaderFile{abspath, bytesReaderCloser{bytes.NewReader(b)}, nil, int64(len(b))}
-}
-
 // TODO: Is this the best way to fix this bug?
 // The bug is we want to be an io.ReadSeekCloser, but bytes.NewReader only gives a io.ReadSeeker and io.NopCloser
 // effectively removes the io.Seeker ability from the passed in io.Reader

--- a/files/readerfile.go
+++ b/files/readerfile.go
@@ -21,6 +21,10 @@ func NewBytesFile(b []byte) File {
 	return &ReaderFile{"", bytesReaderCloser{bytes.NewReader(b)}, nil, int64(len(b))}
 }
 
+func NewBytesFileWithPath(abspath string, b []byte) File {
+	return &ReaderFile{abspath, bytesReaderCloser{bytes.NewReader(b)}, nil, int64(len(b))}
+}
+
 // TODO: Is this the best way to fix this bug?
 // The bug is we want to be an io.ReadSeekCloser, but bytes.NewReader only gives a io.ReadSeeker and io.NopCloser
 // effectively removes the io.Seeker ability from the passed in io.Reader


### PR DESCRIPTION
See https://github.com/ipfs/kubo/issues/10065 and https://github.com/golang/go/issues/60674.

**Problem:** we used to send binary data in `abspath` header when sending multipart requests. This is not compliant to the RFC but used to be allowed by Go (see linked issue). It is no longer possible to read multipart requests with binary data on their headers from Go 1.20.

**Solution:** add a new header with the encoded version of the `abspath`. Unfortunately, we cannot send both the old and the new header, as Go 1.20 parses all headers when reading the multipart "part" and immediately fails. Therefore, we have to be careful. In this PR, we add an option to `NewMultiFileReader`: this option will tell which header to use. See code for more details.
