### PR TITLE
fix(gw):  IPIP-402 CARs return useful blocks on not found errors

### DIFF
--- a/.github/workflows/gateway-conformance.yml
+++ b/.github/workflows/gateway-conformance.yml
@@ -40,7 +40,7 @@ jobs:
 
       # 4. Run the gateway-conformance tests
       - name: Run gateway-conformance tests
-        uses: ipfs/gateway-conformance/.github/actions/test@261cc49391dcd2bddd7704ad28b236dc4a63c424
+        uses: ipfs/gateway-conformance/.github/actions/test@v0.3
         with:
           gateway-url: http://127.0.0.1:8040
           json: output.json

--- a/.github/workflows/gateway-conformance.yml
+++ b/.github/workflows/gateway-conformance.yml
@@ -40,7 +40,7 @@ jobs:
 
       # 4. Run the gateway-conformance tests
       - name: Run gateway-conformance tests
-        uses: ipfs/gateway-conformance/.github/actions/test@v0.3
+        uses: ipfs/gateway-conformance/.github/actions/test@261cc49391dcd2bddd7704ad28b236dc4a63c424
         with:
           gateway-url: http://127.0.0.1:8040
           json: output.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The following emojis are used to highlight certain changes:
 
 - Address a Bitswap findpeers / connect race condition that can prevent peer communication ([#435](https://github.com/ipfs/boxo/issues/435))
 - HTTP Gateway API: Not having a block will result in a 5xx error rather than 404
+- HTTP Gateway API: CAR requests will return 200s and a CAR file proving a requested path does not exist rather than returning an error
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The following emojis are used to highlight certain changes:
 ### Fixed
 
 - Address a Bitswap findpeers / connect race condition that can prevent peer communication ([#435](https://github.com/ipfs/boxo/issues/435))
+- HTTP Gateway API: Not having a block will result in a 5xx error rather than 404
 
 ### Security
 

--- a/gateway/blocks_backend.go
+++ b/gateway/blocks_backend.go
@@ -232,9 +232,45 @@ func (bb *BlocksBackend) Head(ctx context.Context, path ImmutablePath) (ContentP
 	return md, fileNode, nil
 }
 
+// emptyRoot is a CAR root with the empty identity CID. CAR files are recommended
+// to always include a CID in their root, even if it's just the empty CID.
+// https://ipld.io/specs/transport/car/carv1/#number-of-roots
+var emptyRoot = []cid.Cid{cid.MustParse("bafkqaaa")}
+
 func (bb *BlocksBackend) GetCAR(ctx context.Context, p ImmutablePath, params CarParams) (ContentPathMetadata, io.ReadCloser, error) {
 	pathMetadata, err := bb.ResolvePath(ctx, p)
 	if err != nil {
+		rootCid, err := cid.Decode(strings.Split(p.String(), "/")[2])
+		if err != nil {
+			return ContentPathMetadata{}, nil, err
+		}
+
+		var buf bytes.Buffer
+		cw, err := storage.NewWritable(&buf, emptyRoot, car.WriteAsCarV1(true))
+		if err != nil {
+			return ContentPathMetadata{}, nil, err
+		}
+
+		blockGetter := merkledag.NewDAGService(bb.blockService).Session(ctx)
+
+		blockGetter = &nodeGetterToCarExporer{
+			ng: blockGetter,
+			cw: cw,
+		}
+
+		// Setup the UnixFS resolver.
+		f := newNodeGetterFetcherSingleUseFactory(ctx, blockGetter)
+		pathResolver := resolver.NewBasicResolver(f)
+		ip := ipfspath.FromString(p.String())
+		_, _, err = pathResolver.ResolveToLastNode(ctx, ip)
+
+		if isErrNotFound(err) {
+			return ContentPathMetadata{
+				PathSegmentRoots: nil,
+				LastSegment:      ifacepath.NewResolvedPath(ip, rootCid, rootCid, ""),
+				ContentType:      "",
+			}, io.NopCloser(&buf), nil
+		}
 		return ContentPathMetadata{}, nil, err
 	}
 

--- a/gateway/errors.go
+++ b/gateway/errors.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ipfs/boxo/gateway/assets"
 	"github.com/ipfs/boxo/path/resolver"
 	"github.com/ipfs/go-cid"
-	ipld "github.com/ipfs/go-ipld-format"
 	"github.com/ipld/go-ipld-prime/datamodel"
 )
 
@@ -177,11 +176,9 @@ func webError(w http.ResponseWriter, r *http.Request, c *Config, err error, defa
 	}
 }
 
+// isErrNotFound returns true for IPLD errors that should return 4xx errors (e.g. the path doesn't exist, the data is
+// the wrong type, etc.), rather than issues with just finding and retrieving the data.
 func isErrNotFound(err error) bool {
-	if ipld.IsNotFound(err) {
-		return true
-	}
-
 	// Checks if err is of a type that does not implement the .Is interface and
 	// cannot be directly compared to. Therefore, errors.Is cannot be used.
 	for {

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -763,7 +763,7 @@ func TestErrorBubblingFromBackend(t *testing.T) {
 		})
 	}
 
-	testError("404 Not Found from IPLD", &ipld.ErrNotFound{}, http.StatusNotFound)
+	testError("500 Not Found from IPLD", &ipld.ErrNotFound{}, http.StatusInternalServerError)
 	testError("404 Not Found from path resolver", resolver.ErrNoLink{}, http.StatusNotFound)
 	testError("502 Bad Gateway", ErrBadGateway, http.StatusBadGateway)
 	testError("504 Gateway Timeout", ErrGatewayTimeout, http.StatusGatewayTimeout)


### PR DESCRIPTION
<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->

Fix extracted from #369 that could be suitable for a patch release.