### PR TITLE
ci: upload conformance logs

### DIFF
--- a/.github/workflows/gateway-conformance.yml
+++ b/.github/workflows/gateway-conformance.yml
@@ -61,3 +61,9 @@ jobs:
         with:
           name: gateway-conformance.html
           path: output.html
+      - name: Upload JSON report
+        if: failure() || success()
+        uses: actions/upload-artifact@v3
+        with:
+          name: gateway-conformance.json
+          path: output.json


### PR DESCRIPTION
Upload the JSON logs as an artifact that the dashboard generation scripts can retrieve and process.

Support for https://github.com/ipfs/gateway-conformance/pull/146