### PR TITLE
routing/http: add more type and WithDynamicProviderInfo

### DIFF
--- a/routing/http/contentrouter/contentrouter.go
+++ b/routing/http/contentrouter/contentrouter.go
@@ -124,9 +124,9 @@ func readProviderResponses(iter iter.ResultIter[types.ProviderResponse], ch chan
 				continue
 			}
 
-			var addrs []multiaddr.Multiaddr
-			for _, a := range result.Addrs {
-				addrs = append(addrs, a.Multiaddr)
+			addrs := make([]multiaddr.Multiaddr, len(result.Addrs))
+			for i, a := range result.Addrs {
+				addrs[i] = a.Multiaddr
 			}
 
 			ch <- peer.AddrInfo{

--- a/routing/http/contentrouter/contentrouter_test.go
+++ b/routing/http/contentrouter/contentrouter_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ipfs/boxo/routing/http/types/iter"
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
 	"github.com/multiformats/go-multihash"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -135,8 +136,8 @@ func TestFindProvidersAsync(t *testing.T) {
 	}
 
 	expected := []peer.AddrInfo{
-		{ID: p1},
-		{ID: p2},
+		{ID: p1, Addrs: []multiaddr.Multiaddr{}},
+		{ID: p2, Addrs: []multiaddr.Multiaddr{}},
 	}
 
 	require.Equal(t, expected, actualAIs)

--- a/routing/http/internal/drjson/json.go
+++ b/routing/http/internal/drjson/json.go
@@ -5,22 +5,22 @@ import (
 	"encoding/json"
 )
 
-func marshalJSON(val any) (*bytes.Buffer, error) {
+func marshalJSON(val any) ([]byte, error) {
 	buf := &bytes.Buffer{}
 	enc := json.NewEncoder(buf)
 	enc.SetEscapeHTML(false)
 	err := enc.Encode(val)
-	return buf, err
+	return buf.Bytes(), err
 }
 
 // MarshalJSONBytes is needed to avoid changes
 // on the original bytes due to HTML escapes.
 func MarshalJSONBytes(val any) ([]byte, error) {
-	buf, err := marshalJSON(val)
+	bytes, err := marshalJSON(val)
 	if err != nil {
 		return nil, err
 	}
 
 	// remove last \n added by Encode
-	return buf.Bytes()[:buf.Len()-1], nil
+	return bytes[:len(bytes)-1], nil
 }


### PR DESCRIPTION
This is required to fix a bug in Kubo where we advertise the *listening* addresses.
We can't pass our real addresses once since thing like autonat takes time.