### PR TITLE
Revert "feat(connecteventmanager): block Connected() until accepted (#435)" and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
-- Address a Bitswap findpeers / connect race condition that can prevent peer communication ([#435](https://github.com/ipfs/boxo/issues/435))
 - HTTP Gateway API: Not having a block will result in a 5xx error rather than 404
 - HTTP Gateway API: CAR requests will return 200s and a CAR file proving a requested path does not exist rather than returning an error
 

--- a/bitswap/network/connecteventmanager_test.go
+++ b/bitswap/network/connecteventmanager_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ipfs/boxo/bitswap/internal/testutil"
+	"github.com/ipfs/boxo/internal/test"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
 )
@@ -17,8 +18,7 @@ type mockConnEvent struct {
 
 type mockConnListener struct {
 	sync.Mutex
-	events          []mockConnEvent
-	peerConnectedCb func(p peer.ID)
+	events []mockConnEvent
 }
 
 func newMockConnListener() *mockConnListener {
@@ -29,9 +29,6 @@ func (cl *mockConnListener) PeerConnected(p peer.ID) {
 	cl.Lock()
 	defer cl.Unlock()
 	cl.events = append(cl.events, mockConnEvent{connected: true, peer: p})
-	if cl.peerConnectedCb != nil {
-		cl.peerConnectedCb(p)
-	}
 }
 
 func (cl *mockConnListener) PeerDisconnected(p peer.ID) {
@@ -49,6 +46,8 @@ func wait(t *testing.T, c *connectEventManager) {
 }
 
 func TestConnectEventManagerConnectDisconnect(t *testing.T) {
+	test.Flaky(t)
+
 	connListener := newMockConnListener()
 	peers := testutil.GeneratePeers(2)
 	cem := newConnectEventManager(connListener)
@@ -65,26 +64,31 @@ func TestConnectEventManagerConnectDisconnect(t *testing.T) {
 		connected: true,
 	})
 
+	// Flush the event queue.
+	wait(t, cem)
 	require.Equal(t, expectedEvents, connListener.events)
 
+	// Block up the event loop.
+	connListener.Lock()
 	cem.Connected(peers[1])
 	expectedEvents = append(expectedEvents, mockConnEvent{
 		peer:      peers[1],
 		connected: true,
 	})
-	require.Equal(t, expectedEvents, connListener.events)
 
+	// We don't expect this to show up.
 	cem.Disconnected(peers[0])
-	expectedEvents = append(expectedEvents, mockConnEvent{
-		peer:      peers[0],
-		connected: false,
-	})
-	// Flush the event queue.
+	cem.Connected(peers[0])
+
+	connListener.Unlock()
+
 	wait(t, cem)
 	require.Equal(t, expectedEvents, connListener.events)
 }
 
 func TestConnectEventManagerMarkUnresponsive(t *testing.T) {
+	test.Flaky(t)
+
 	connListener := newMockConnListener()
 	p := testutil.GeneratePeers(1)[0]
 	cem := newConnectEventManager(connListener)
@@ -134,6 +138,8 @@ func TestConnectEventManagerMarkUnresponsive(t *testing.T) {
 }
 
 func TestConnectEventManagerDisconnectAfterMarkUnresponsive(t *testing.T) {
+	test.Flaky(t)
+
 	connListener := newMockConnListener()
 	p := testutil.GeneratePeers(1)[0]
 	cem := newConnectEventManager(connListener)
@@ -165,53 +171,5 @@ func TestConnectEventManagerDisconnectAfterMarkUnresponsive(t *testing.T) {
 	cem.Disconnected(p)
 	wait(t, cem)
 	require.Empty(t, cem.peers) // all disconnected
-	require.Equal(t, expectedEvents, connListener.events)
-}
-
-func TestConnectEventManagerConnectFlowSynchronous(t *testing.T) {
-	connListener := newMockConnListener()
-	actionsCh := make(chan string)
-	connListener.peerConnectedCb = func(p peer.ID) {
-		actionsCh <- "PeerConnected:" + p.String()
-		time.Sleep(time.Millisecond * 50)
-	}
-
-	peers := testutil.GeneratePeers(2)
-	cem := newConnectEventManager(connListener)
-	cem.Start()
-	t.Cleanup(cem.Stop)
-
-	go func() {
-		actionsCh <- "Connected:" + peers[0].String()
-		cem.Connected(peers[0])
-		actionsCh <- "Done:" + peers[0].String()
-		actionsCh <- "Connected:" + peers[1].String()
-		cem.Connected(peers[1])
-		actionsCh <- "Done:" + peers[1].String()
-		close(actionsCh)
-	}()
-
-	// We expect Done to be sent _after_ PeerConnected, which demonstrates the
-	// call to Connected() blocks until PeerConnected() returns.
-	gotActions := make([]string, 0, 3)
-	for event := range actionsCh {
-		gotActions = append(gotActions, event)
-	}
-	expectedActions := []string{
-		"Connected:" + peers[0].String(),
-		"PeerConnected:" + peers[0].String(),
-		"Done:" + peers[0].String(),
-		"Connected:" + peers[1].String(),
-		"PeerConnected:" + peers[1].String(),
-		"Done:" + peers[1].String(),
-	}
-	require.Equal(t, expectedActions, gotActions)
-
-	// Flush the event queue.
-	wait(t, cem)
-	expectedEvents := []mockConnEvent{
-		{peer: peers[0], connected: true},
-		{peer: peers[1], connected: true},
-	}
 	require.Equal(t, expectedEvents, connListener.events)
 }


### PR DESCRIPTION
This reverts commit 7ec68c5e5adfb13e52f93c20e7c5aadf4860a871.
This reverts commit 59a2bca3f0924d5a9cc61bbb6c33dbd483f4a0f4.
This reverts commit 1d2f5e511e9fb0e1ff4c2b93aea421fc2091e3f5.

See https://github.com/ipfs/boxo/pull/436#issuecomment-1683116240

cc @hannahhoward @rvagg if the fix were working out for you, I think you can continue to run the previous commit while a proper fix is made.