### PR TITLE
blockservice/test: passthrough blockservice options [skip changelog]

### DIFF
--- a/blockservice/test/mock.go
+++ b/blockservice/test/mock.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Mocks returns |n| connected mock Blockservices
-func Mocks(n int) []blockservice.BlockService {
+func Mocks(n int, opts ...blockservice.Option) []blockservice.BlockService {
 	net := tn.VirtualNetwork(mockrouting.NewServer(), delay.Fixed(0))
 	sg := testinstance.NewTestInstanceGenerator(net, nil, nil)
 
@@ -17,7 +17,7 @@ func Mocks(n int) []blockservice.BlockService {
 
 	var servs []blockservice.BlockService
 	for _, i := range instances {
-		servs = append(servs, blockservice.New(i.Blockstore(), i.Exchange))
+		servs = append(servs, blockservice.New(i.Blockstore(), i.Exchange, opts...))
 	}
 	return servs
 }


### PR DESCRIPTION
Self-explanatory