### PR TITLE
feat(session): do not record erroneous session want sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
+- Do not erroneously update the state of sent wants when a send a peer disconnected and the send did not happen. [#452](https://github.com/ipfs/boxo/pull/452)
+
 ### Security
 
 ## [v0.24.3]

--- a/bitswap/client/internal/peermanager/peermanager.go
+++ b/bitswap/client/internal/peermanager/peermanager.go
@@ -2,6 +2,7 @@ package peermanager
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	logging "github.com/ipfs/go-log/v2"
@@ -143,13 +144,15 @@ func (pm *PeerManager) BroadcastWantHaves(ctx context.Context, wantHaves []cid.C
 
 // SendWants sends the given want-blocks and want-haves to the given peer.
 // It filters out wants that have previously been sent to the peer.
-func (pm *PeerManager) SendWants(ctx context.Context, p peer.ID, wantBlocks []cid.Cid, wantHaves []cid.Cid) {
+func (pm *PeerManager) SendWants(ctx context.Context, p peer.ID, wantBlocks []cid.Cid, wantHaves []cid.Cid) error {
 	pm.pqLk.Lock()
 	defer pm.pqLk.Unlock()
 
-	if _, ok := pm.peerQueues[p]; ok {
-		pm.pwm.sendWants(p, wantBlocks, wantHaves)
+	if _, ok := pm.peerQueues[p]; !ok {
+		return fmt.Errorf("No peer queue for %s", p)
 	}
+	pm.pwm.sendWants(p, wantBlocks, wantHaves)
+	return nil
 }
 
 // SendCancels sends cancels for the given keys to all peers who had previously

--- a/bitswap/client/internal/peermanager/peermanager.go
+++ b/bitswap/client/internal/peermanager/peermanager.go
@@ -149,7 +149,7 @@ func (pm *PeerManager) SendWants(ctx context.Context, p peer.ID, wantBlocks []ci
 	defer pm.pqLk.Unlock()
 
 	if _, ok := pm.peerQueues[p]; !ok {
-		return fmt.Errorf("No peer queue for %s", p)
+		return fmt.Errorf("no peer queue for %s", p)
 	}
 	pm.pwm.sendWants(p, wantBlocks, wantHaves)
 	return nil

--- a/bitswap/client/internal/peermanager/peermanager.go
+++ b/bitswap/client/internal/peermanager/peermanager.go
@@ -2,7 +2,6 @@ package peermanager
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	logging "github.com/ipfs/go-log/v2"
@@ -144,15 +143,15 @@ func (pm *PeerManager) BroadcastWantHaves(ctx context.Context, wantHaves []cid.C
 
 // SendWants sends the given want-blocks and want-haves to the given peer.
 // It filters out wants that have previously been sent to the peer.
-func (pm *PeerManager) SendWants(ctx context.Context, p peer.ID, wantBlocks []cid.Cid, wantHaves []cid.Cid) error {
+func (pm *PeerManager) SendWants(ctx context.Context, p peer.ID, wantBlocks []cid.Cid, wantHaves []cid.Cid) bool {
 	pm.pqLk.Lock()
 	defer pm.pqLk.Unlock()
 
 	if _, ok := pm.peerQueues[p]; !ok {
-		return fmt.Errorf("no peer queue for %s", p)
+		return false
 	}
 	pm.pwm.sendWants(p, wantBlocks, wantHaves)
-	return nil
+	return true
 }
 
 // SendCancels sends cancels for the given keys to all peers who had previously

--- a/bitswap/client/internal/session/session.go
+++ b/bitswap/client/internal/session/session.go
@@ -38,7 +38,7 @@ type PeerManager interface {
 	// interested in a peer's connection state
 	UnregisterSession(uint64)
 	// SendWants tells the PeerManager to send wants to the given peer
-	SendWants(ctx context.Context, peerId peer.ID, wantBlocks []cid.Cid, wantHaves []cid.Cid) error
+	SendWants(ctx context.Context, peerId peer.ID, wantBlocks []cid.Cid, wantHaves []cid.Cid) bool
 	// BroadcastWantHaves sends want-haves to all connected peers (used for
 	// session discovery)
 	BroadcastWantHaves(context.Context, []cid.Cid)

--- a/bitswap/client/internal/session/session.go
+++ b/bitswap/client/internal/session/session.go
@@ -38,7 +38,7 @@ type PeerManager interface {
 	// interested in a peer's connection state
 	UnregisterSession(uint64)
 	// SendWants tells the PeerManager to send wants to the given peer
-	SendWants(ctx context.Context, peerId peer.ID, wantBlocks []cid.Cid, wantHaves []cid.Cid)
+	SendWants(ctx context.Context, peerId peer.ID, wantBlocks []cid.Cid, wantHaves []cid.Cid) error
 	// BroadcastWantHaves sends want-haves to all connected peers (used for
 	// session discovery)
 	BroadcastWantHaves(context.Context, []cid.Cid)

--- a/bitswap/client/internal/session/session_test.go
+++ b/bitswap/client/internal/session/session_test.go
@@ -141,9 +141,11 @@ func newFakePeerManager() *fakePeerManager {
 	}
 }
 
-func (pm *fakePeerManager) RegisterSession(peer.ID, bspm.Session)                    {}
-func (pm *fakePeerManager) UnregisterSession(uint64)                                 {}
-func (pm *fakePeerManager) SendWants(context.Context, peer.ID, []cid.Cid, []cid.Cid) {}
+func (pm *fakePeerManager) RegisterSession(peer.ID, bspm.Session) {}
+func (pm *fakePeerManager) UnregisterSession(uint64)              {}
+func (pm *fakePeerManager) SendWants(context.Context, peer.ID, []cid.Cid, []cid.Cid) error {
+	return nil
+}
 func (pm *fakePeerManager) BroadcastWantHaves(ctx context.Context, cids []cid.Cid) {
 	select {
 	case pm.wantReqs <- wantReq{cids}:

--- a/bitswap/client/internal/session/session_test.go
+++ b/bitswap/client/internal/session/session_test.go
@@ -143,8 +143,8 @@ func newFakePeerManager() *fakePeerManager {
 
 func (pm *fakePeerManager) RegisterSession(peer.ID, bspm.Session) {}
 func (pm *fakePeerManager) UnregisterSession(uint64)              {}
-func (pm *fakePeerManager) SendWants(context.Context, peer.ID, []cid.Cid, []cid.Cid) error {
-	return nil
+func (pm *fakePeerManager) SendWants(context.Context, peer.ID, []cid.Cid, []cid.Cid) bool {
+	return true
 }
 func (pm *fakePeerManager) BroadcastWantHaves(ctx context.Context, cids []cid.Cid) {
 	select {

--- a/bitswap/client/internal/session/sessionwantsender.go
+++ b/bitswap/client/internal/session/sessionwantsender.go
@@ -513,6 +513,7 @@ func (sws *sessionWantSender) processExhaustedWants(exhausted []cid.Cid) {
 type wantSets struct {
 	wantBlocks *cid.Set
 	wantHaves  *cid.Set
+	result     error
 }
 
 type allWants map[peer.ID]*wantSets
@@ -551,9 +552,6 @@ func (sws *sessionWantSender) sendNextWants(newlyAvailable []peer.ID) {
 			continue
 		}
 
-		// Record that we are sending a want-block for this want to the peer
-		sws.setWantSentTo(c, wi.bestPeer)
-
 		// Send a want-block to the chosen peer
 		toSend.forPeer(wi.bestPeer).wantBlocks.Add(c)
 
@@ -567,6 +565,16 @@ func (sws *sessionWantSender) sendNextWants(newlyAvailable []peer.ID) {
 
 	// Send any wants we've collected
 	sws.sendWants(toSend)
+
+	for c, wi := range sws.wants {
+		if wi.bestPeer != "" && wi.sentTo == "" {
+			// check if a want block was successfully sent to the best peer
+			if toSend.forPeer(wi.bestPeer).result == nil {
+				// Record that we are sending a want-block for this want to the peer
+				sws.setWantSentTo(c, wi.bestPeer)
+			}
+		}
+	}
 }
 
 // sendWants sends want-have and want-blocks to the appropriate peers
@@ -584,13 +592,16 @@ func (sws *sessionWantSender) sendWants(sends allWants) {
 		// precedence over want-haves.
 		wblks := snd.wantBlocks.Keys()
 		whaves := snd.wantHaves.Keys()
-		sws.pm.SendWants(sws.ctx, p, wblks, whaves)
+		snd.result = sws.pm.SendWants(sws.ctx, p, wblks, whaves)
 
-		// Inform the session that we've sent the wants
-		sws.onSend(p, wblks, whaves)
+		// only update state if the wants really sent
+		if snd.result == nil {
+			// Inform the session that we've sent the wants
+			sws.onSend(p, wblks, whaves)
 
-		// Record which peers we send want-block to
-		sws.swbt.addSentWantBlocksTo(p, wblks)
+			// Record which peers we send want-block to
+			sws.swbt.addSentWantBlocksTo(p, wblks)
+		}
 	}
 }
 

--- a/bitswap/client/internal/session/sessionwantsender.go
+++ b/bitswap/client/internal/session/sessionwantsender.go
@@ -513,7 +513,7 @@ func (sws *sessionWantSender) processExhaustedWants(exhausted []cid.Cid) {
 type wantSets struct {
 	wantBlocks *cid.Set
 	wantHaves  *cid.Set
-	err        error
+	sent       bool
 }
 
 type allWants map[peer.ID]*wantSets
@@ -569,7 +569,7 @@ func (sws *sessionWantSender) sendNextWants(newlyAvailable []peer.ID) {
 	for c, wi := range sws.wants {
 		if wi.bestPeer != "" && wi.sentTo == "" {
 			// check if a want block was successfully sent to the best peer
-			if toSend.forPeer(wi.bestPeer).err == nil {
+			if toSend.forPeer(wi.bestPeer).sent {
 				// Record that we are sending a want-block for this want to the peer
 				sws.setWantSentTo(c, wi.bestPeer)
 			}
@@ -592,8 +592,8 @@ func (sws *sessionWantSender) sendWants(sends allWants) {
 		// precedence over want-haves.
 		wblks := snd.wantBlocks.Keys()
 		whaves := snd.wantHaves.Keys()
-		snd.err = sws.pm.SendWants(sws.ctx, p, wblks, whaves)
-		if snd.err != nil {
+		snd.sent = sws.pm.SendWants(sws.ctx, p, wblks, whaves)
+		if !snd.sent {
 			// Do not update state if the wants not sent.
 			continue
 		}

--- a/bitswap/client/internal/session/sessionwantsender.go
+++ b/bitswap/client/internal/session/sessionwantsender.go
@@ -513,7 +513,7 @@ func (sws *sessionWantSender) processExhaustedWants(exhausted []cid.Cid) {
 type wantSets struct {
 	wantBlocks *cid.Set
 	wantHaves  *cid.Set
-	result     error
+	err        error
 }
 
 type allWants map[peer.ID]*wantSets
@@ -569,7 +569,7 @@ func (sws *sessionWantSender) sendNextWants(newlyAvailable []peer.ID) {
 	for c, wi := range sws.wants {
 		if wi.bestPeer != "" && wi.sentTo == "" {
 			// check if a want block was successfully sent to the best peer
-			if toSend.forPeer(wi.bestPeer).result == nil {
+			if toSend.forPeer(wi.bestPeer).err == nil {
 				// Record that we are sending a want-block for this want to the peer
 				sws.setWantSentTo(c, wi.bestPeer)
 			}
@@ -592,16 +592,16 @@ func (sws *sessionWantSender) sendWants(sends allWants) {
 		// precedence over want-haves.
 		wblks := snd.wantBlocks.Keys()
 		whaves := snd.wantHaves.Keys()
-		snd.result = sws.pm.SendWants(sws.ctx, p, wblks, whaves)
-
-		// only update state if the wants really sent
-		if snd.result == nil {
-			// Inform the session that we've sent the wants
-			sws.onSend(p, wblks, whaves)
-
-			// Record which peers we send want-block to
-			sws.swbt.addSentWantBlocksTo(p, wblks)
+		snd.err = sws.pm.SendWants(sws.ctx, p, wblks, whaves)
+		if snd.err != nil {
+			// Do not update state if the wants not sent.
+			continue
 		}
+		// Inform the session that we've sent the wants
+		sws.onSend(p, wblks, whaves)
+
+		// Record which peers we send want-block to
+		sws.swbt.addSentWantBlocksTo(p, wblks)
 	}
 }
 

--- a/bitswap/client/internal/session/sessionwantsender_test.go
+++ b/bitswap/client/internal/session/sessionwantsender_test.go
@@ -82,7 +82,7 @@ func (*mockPeerManager) UnregisterSession(uint64)                      {}
 func (*mockPeerManager) BroadcastWantHaves(context.Context, []cid.Cid) {}
 func (*mockPeerManager) SendCancels(context.Context, []cid.Cid)        {}
 
-func (pm *mockPeerManager) SendWants(ctx context.Context, p peer.ID, wantBlocks []cid.Cid, wantHaves []cid.Cid) {
+func (pm *mockPeerManager) SendWants(ctx context.Context, p peer.ID, wantBlocks []cid.Cid, wantHaves []cid.Cid) error {
 	pm.lk.Lock()
 	defer pm.lk.Unlock()
 
@@ -92,6 +92,7 @@ func (pm *mockPeerManager) SendWants(ctx context.Context, p peer.ID, wantBlocks 
 		pm.peerSends[p] = sw
 	}
 	sw.add(wantBlocks, wantHaves)
+	return nil
 }
 
 func (pm *mockPeerManager) waitNextWants() map[peer.ID]*sentWants {

--- a/bitswap/client/internal/session/sessionwantsender_test.go
+++ b/bitswap/client/internal/session/sessionwantsender_test.go
@@ -82,7 +82,7 @@ func (*mockPeerManager) UnregisterSession(uint64)                      {}
 func (*mockPeerManager) BroadcastWantHaves(context.Context, []cid.Cid) {}
 func (*mockPeerManager) SendCancels(context.Context, []cid.Cid)        {}
 
-func (pm *mockPeerManager) SendWants(ctx context.Context, p peer.ID, wantBlocks []cid.Cid, wantHaves []cid.Cid) error {
+func (pm *mockPeerManager) SendWants(ctx context.Context, p peer.ID, wantBlocks []cid.Cid, wantHaves []cid.Cid) bool {
 	pm.lk.Lock()
 	defer pm.lk.Unlock()
 
@@ -92,7 +92,7 @@ func (pm *mockPeerManager) SendWants(ctx context.Context, p peer.ID, wantBlocks 
 		pm.peerSends[p] = sw
 	}
 	sw.add(wantBlocks, wantHaves)
-	return nil
+	return true
 }
 
 func (pm *mockPeerManager) waitNextWants() map[peer.ID]*sentWants {

--- a/bitswap/client/internal/sessionmanager/sessionmanager_test.go
+++ b/bitswap/client/internal/sessionmanager/sessionmanager_test.go
@@ -66,10 +66,10 @@ type fakePeerManager struct {
 	cancels []cid.Cid
 }
 
-func (*fakePeerManager) RegisterSession(peer.ID, bspm.Session)                    {}
-func (*fakePeerManager) UnregisterSession(uint64)                                 {}
-func (*fakePeerManager) SendWants(context.Context, peer.ID, []cid.Cid, []cid.Cid) {}
-func (*fakePeerManager) BroadcastWantHaves(context.Context, []cid.Cid)            {}
+func (*fakePeerManager) RegisterSession(peer.ID, bspm.Session)                          {}
+func (*fakePeerManager) UnregisterSession(uint64)                                       {}
+func (*fakePeerManager) SendWants(context.Context, peer.ID, []cid.Cid, []cid.Cid) error { return nil }
+func (*fakePeerManager) BroadcastWantHaves(context.Context, []cid.Cid)                  {}
 func (fpm *fakePeerManager) SendCancels(ctx context.Context, cancels []cid.Cid) {
 	fpm.lk.Lock()
 	defer fpm.lk.Unlock()

--- a/bitswap/client/internal/sessionmanager/sessionmanager_test.go
+++ b/bitswap/client/internal/sessionmanager/sessionmanager_test.go
@@ -66,10 +66,10 @@ type fakePeerManager struct {
 	cancels []cid.Cid
 }
 
-func (*fakePeerManager) RegisterSession(peer.ID, bspm.Session)                          {}
-func (*fakePeerManager) UnregisterSession(uint64)                                       {}
-func (*fakePeerManager) SendWants(context.Context, peer.ID, []cid.Cid, []cid.Cid) error { return nil }
-func (*fakePeerManager) BroadcastWantHaves(context.Context, []cid.Cid)                  {}
+func (*fakePeerManager) RegisterSession(peer.ID, bspm.Session)                         {}
+func (*fakePeerManager) UnregisterSession(uint64)                                      {}
+func (*fakePeerManager) SendWants(context.Context, peer.ID, []cid.Cid, []cid.Cid) bool { return true }
+func (*fakePeerManager) BroadcastWantHaves(context.Context, []cid.Cid)                 {}
 func (fpm *fakePeerManager) SendCancels(ctx context.Context, cancels []cid.Cid) {
 	fpm.lk.Lock()
 	defer fpm.lk.Unlock()


### PR DESCRIPTION
# Goals

Find acceptable fix for #432 

# Implementation

The basic idea here is there's nothing wrong with the connection event manager -- the problem lies in the fact that the PeerManager never tells the caller it didn't actually send anything cause the peer appeared disconnected. The SessionWantSender in turn updates the state of sent wants based on incorrect assumption something actually happened. This PR deals with the problem by helping the SessionWantSender avoid getting into an incorrect state by not updating its state when SendWants does nothing.

The subsequent connect event should trigger the sending of the WantBlock then.

# For discussion

This is just an experiment and a suggestion for someone else to pick up, to help solve #432 more quickly -- I'm not doing the leg work of testing and change log etc