### PR TITLE
ci: remove obsolete protocol/cache-go-action

### DIFF
--- a/.github/workflows/gateway-sharness.yml
+++ b/.github/workflows/gateway-sharness.yml
@@ -16,7 +16,7 @@ jobs:
         shell: bash
     steps:
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.19.1
       - name: Checkout boxo
@@ -30,10 +30,6 @@ jobs:
           path: kubo
       - name: Install Missing Tools
         run: sudo apt install -y socat net-tools fish libxml2-utils
-      - name: Restore Go Cache
-        uses: protocol/cache-go-action@v1
-        with:
-          name: ${{ github.job }}
       - name: Replace boxo in Kubo go.mod
         run: |
           go mod edit -replace=github.com/ipfs/boxo=../boxo


### PR DESCRIPTION
setup-go@v4 comes with Go modules caching enabled by default.