### PR TITLE
feat(gateway): add DisableHTMLErrors option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ The following emojis are used to highlight certain changes:
 ### Added
 
 * ✨ The `routing/http` implements Delegated Peer Routing introduced in [IPIP-417](https://github.com/ipfs/specs/pull/417).
+* An option `DisableHTMLErrors` has been added to `gateway.Config`. When this option
+  is `true`, pretty HTML error pages for web browsers are disabled. Instead, a
+  `text/plain` page with the raw error message as the body is returned.
 
 ### Changed
 

--- a/gateway/errors.go
+++ b/gateway/errors.go
@@ -159,7 +159,7 @@ func webError(w http.ResponseWriter, r *http.Request, c *Config, err error, defa
 		code = gwErr.StatusCode
 	}
 
-	acceptsHTML := strings.Contains(r.Header.Get("Accept"), "text/html")
+	acceptsHTML := !c.DisableHTMLErrors && strings.Contains(r.Header.Get("Accept"), "text/html")
 	if acceptsHTML {
 		w.Header().Set("Content-Type", "text/html")
 		w.WriteHeader(code)

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -40,6 +40,11 @@ type Config struct {
 	// overridden per FQDN in PublicGateways. To be used with WithHostname.
 	NoDNSLink bool
 
+	// DisableHTMLErrors disables pretty HTML pages when an error occurs. Instead, a `text/plain`
+	// page will be sent with the raw error message. This can be useful if this gateway
+	// is being proxied by other service, which wants to use the error message.
+	DisableHTMLErrors bool
+
 	// PublicGateways configures the behavior of known public gateways. Each key is
 	// a fully qualified domain name (FQDN). To be used with WithHostname.
 	PublicGateways map[string]*PublicGateway


### PR DESCRIPTION
This adds a new option `DisableHTMLErrors ` to `gateway.Config`. If this is `true`, then the errors will always be returned as `text/plain` with the raw error message. This will need to be bubbled up to Kubo, which will then allow `ipfs.io` to have a better insight into the error messages.

This also allows users of `boxo/gateway` library to do white-label hosting, without IPFS branding on error pages.

cc @cewood @mcamou