### PR TITLE
Chore/migrate peering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The following emojis are used to highlight certain changes:
   * A new `WithoutDuplicatedBlockStats()` option can be used with `bitswap.New` and `bsclient.New`. This disable accounting for duplicated blocks, which requires a `blockstore.Has()` lookup for every received block and thus, can impact performance.
 * ✨ Migrated repositories into Boxo
   * [`github.com/ipfs/kubo/peering`](https://pkg.go.dev/github.com/ipfs/kubo/peering) => [`./peering`](./peering)
+    A service which establish, overwatch and maintain long lived connections.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The following emojis are used to highlight certain changes:
   * The gateway now sets a `Cache-Control` header for requests under the `/ipns/` namespace if the TTL for the corresponding IPNS Records or DNSLink entities is known.
 * `boxo/bitswap/client`:
   * A new `WithoutDuplicatedBlockStats()` option can be used with `bitswap.New` and `bsclient.New`. This disable accounting for duplicated blocks, which requires a `blockstore.Has()` lookup for every received block and thus, can impact performance.
+* ✨ Migrated repositories into Boxo
+  * [`github.com/ipfs/kubo/peering`](https://pkg.go.dev/github.com/ipfs/kubo/peering) => [`./peering`](./peering)
 
 ### Changed
 

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/ipfs/go-ipld-cbor v0.0.6
 	github.com/ipfs/go-ipld-format v0.5.0
 	github.com/ipfs/go-ipld-legacy v0.2.1
+	github.com/ipfs/go-log v1.0.5
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/ipfs/go-metrics-interface v0.0.1
 	github.com/ipfs/go-peertaskqueue v0.8.1
@@ -107,7 +108,6 @@ require (
 	github.com/huin/goupnp v1.2.0 // indirect
 	github.com/ipfs/go-ipfs-pq v0.0.3 // indirect
 	github.com/ipfs/go-ipfs-util v0.0.2 // indirect
-	github.com/ipfs/go-log v1.0.5 // indirect
 	github.com/ipfs/go-unixfs v0.4.5 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect

--- a/peering/peering.go
+++ b/peering/peering.go
@@ -242,6 +242,17 @@ func (ps *PeeringService) AddPeer(info peer.AddrInfo) {
 	}
 }
 
+// ListPeers lists peers in the peering service.
+func (ps *PeeringService) ListPeers() []peer.AddrInfo {
+	out := make([]peer.AddrInfo, 0, len(ps.peers))
+	for id, addrs := range ps.peers {
+		ai := peer.AddrInfo{ID: id}
+		ai.Addrs = append(ai.Addrs, addrs.addrs...)
+		out = append(out, ai)
+	}
+	return out
+}
+
 // RemovePeer removes a peer from the peering service. This function may be
 // safely called at any time: before the service is started, while running, or
 // after it stops.

--- a/peering/peering.go
+++ b/peering/peering.go
@@ -1,0 +1,259 @@
+package peering
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/ipfs/go-log"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/network"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/multiformats/go-multiaddr"
+)
+
+// maxBackoff is the maximum time between reconnect attempts.
+const (
+	maxBackoff = 10 * time.Minute
+	connmgrTag = "ipfs-peering"
+	// This needs to be sufficient to prevent two sides from simultaneously
+	// dialing.
+	initialDelay = 5 * time.Second
+)
+
+var logger = log.Logger("peering")
+
+type state int
+
+const (
+	stateInit state = iota
+	stateRunning
+	stateStopped
+)
+
+// peerHandler keeps track of all state related to a specific "peering" peer.
+type peerHandler struct {
+	peer   peer.ID
+	host   host.Host
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	mu    sync.Mutex
+	addrs []multiaddr.Multiaddr
+	timer *time.Timer
+
+	nextDelay time.Duration
+}
+
+func (ph *peerHandler) stop() {
+	ph.mu.Lock()
+	defer ph.mu.Unlock()
+
+	if ph.timer != nil {
+		ph.timer.Stop()
+		ph.timer = nil
+	}
+}
+
+func (ph *peerHandler) nextBackoff() time.Duration {
+	// calculate the timeout
+	if ph.nextDelay < maxBackoff {
+		ph.nextDelay += ph.nextDelay/2 + time.Duration(rand.Int63n(int64(ph.nextDelay)))
+	}
+	return ph.nextDelay
+}
+
+func (ph *peerHandler) reconnect() {
+	// Try connecting
+
+	ph.mu.Lock()
+	addrs := append(([]multiaddr.Multiaddr)(nil), ph.addrs...)
+	ph.mu.Unlock()
+
+	logger.Debugw("reconnecting", "peer", ph.peer, "addrs", addrs)
+
+	err := ph.host.Connect(ph.ctx, peer.AddrInfo{ID: ph.peer, Addrs: addrs})
+	if err != nil {
+		logger.Debugw("failed to reconnect", "peer", ph.peer, "error", err)
+		// Ok, we failed. Extend the timeout.
+		ph.mu.Lock()
+		if ph.timer != nil {
+			// Only counts if the timer still exists. If not, a
+			// connection _was_ somehow established.
+			ph.timer.Reset(ph.nextBackoff())
+		}
+		// Otherwise, someone else has stopped us so we can assume that
+		// we're either connected or someone else will start us.
+		ph.mu.Unlock()
+	}
+
+	// Always call this. We could have connected since we processed the
+	// error.
+	ph.stopIfConnected()
+}
+
+func (ph *peerHandler) stopIfConnected() {
+	ph.mu.Lock()
+	defer ph.mu.Unlock()
+
+	if ph.timer != nil && ph.host.Network().Connectedness(ph.peer) == network.Connected {
+		logger.Debugw("successfully reconnected", "peer", ph.peer)
+		ph.timer.Stop()
+		ph.timer = nil
+		ph.nextDelay = initialDelay
+	}
+}
+
+// startIfDisconnected is the inverse of stopIfConnected.
+func (ph *peerHandler) startIfDisconnected() {
+	ph.mu.Lock()
+	defer ph.mu.Unlock()
+
+	if ph.timer == nil && ph.host.Network().Connectedness(ph.peer) != network.Connected {
+		logger.Debugw("disconnected from peer", "peer", ph.peer)
+		// Always start with a short timeout so we can stagger things a bit.
+		ph.timer = time.AfterFunc(ph.nextBackoff(), ph.reconnect)
+	}
+}
+
+// PeeringService maintains connections to specified peers, reconnecting on
+// disconnect with a back-off.
+type PeeringService struct {
+	host host.Host
+
+	mu    sync.RWMutex
+	peers map[peer.ID]*peerHandler
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	state  state
+}
+
+// NewPeeringService constructs a new peering service. Peers can be added and
+// removed immediately, but connections won't be formed until `Start` is called.
+func NewPeeringService(host host.Host) *PeeringService {
+	ps := &PeeringService{host: host, peers: make(map[peer.ID]*peerHandler)}
+	ps.ctx, ps.cancel = context.WithCancel(context.Background())
+	return ps
+}
+
+// Start starts the peering service, connecting and maintaining connections to
+// all registered peers. It returns an error if the service has already been
+// stopped.
+func (ps *PeeringService) Start() error {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+
+	switch ps.state {
+	case stateInit:
+		logger.Infow("starting")
+	case stateRunning:
+		return nil
+	case stateStopped:
+		return errors.New("already stopped")
+	}
+	ps.host.Network().Notify((*netNotifee)(ps))
+	ps.state = stateRunning
+	for _, handler := range ps.peers {
+		go handler.startIfDisconnected()
+	}
+	return nil
+}
+
+// Stop stops the peering service.
+func (ps *PeeringService) Stop() error {
+	ps.cancel()
+	ps.host.Network().StopNotify((*netNotifee)(ps))
+
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+
+	if ps.state == stateRunning {
+		logger.Infow("stopping")
+		for _, handler := range ps.peers {
+			handler.stop()
+		}
+	}
+	return nil
+}
+
+// AddPeer adds a peer to the peering service. This function may be safely
+// called at any time: before the service is started, while running, or after it
+// stops.
+//
+// Add peer may also be called multiple times for the same peer. The new
+// addresses will replace the old.
+func (ps *PeeringService) AddPeer(info peer.AddrInfo) {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+
+	if handler, ok := ps.peers[info.ID]; ok {
+		logger.Infow("updating addresses", "peer", info.ID, "addrs", info.Addrs)
+		handler.addrs = info.Addrs
+	} else {
+		logger.Infow("peer added", "peer", info.ID, "addrs", info.Addrs)
+		ps.host.ConnManager().Protect(info.ID, connmgrTag)
+
+		handler = &peerHandler{
+			host:      ps.host,
+			peer:      info.ID,
+			addrs:     info.Addrs,
+			nextDelay: initialDelay,
+		}
+		handler.ctx, handler.cancel = context.WithCancel(ps.ctx)
+		ps.peers[info.ID] = handler
+		if ps.state == stateRunning {
+			go handler.startIfDisconnected()
+		}
+	}
+}
+
+// RemovePeer removes a peer from the peering service. This function may be
+// safely called at any time: before the service is started, while running, or
+// after it stops.
+func (ps *PeeringService) RemovePeer(id peer.ID) {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+
+	if handler, ok := ps.peers[id]; ok {
+		logger.Infow("peer removed", "peer", id)
+		ps.host.ConnManager().Unprotect(id, connmgrTag)
+
+		handler.stop()
+		handler.cancel()
+		delete(ps.peers, id)
+	}
+}
+
+type netNotifee PeeringService
+
+func (nn *netNotifee) Connected(_ network.Network, c network.Conn) {
+	ps := (*PeeringService)(nn)
+
+	p := c.RemotePeer()
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
+
+	if handler, ok := ps.peers[p]; ok {
+		// use a goroutine to avoid blocking events.
+		go handler.stopIfConnected()
+	}
+}
+func (nn *netNotifee) Disconnected(_ network.Network, c network.Conn) {
+	ps := (*PeeringService)(nn)
+
+	p := c.RemotePeer()
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
+
+	if handler, ok := ps.peers[p]; ok {
+		// use a goroutine to avoid blocking events.
+		go handler.startIfDisconnected()
+	}
+}
+func (nn *netNotifee) OpenedStream(network.Network, network.Stream)     {}
+func (nn *netNotifee) ClosedStream(network.Network, network.Stream)     {}
+func (nn *netNotifee) Listen(network.Network, multiaddr.Multiaddr)      {}
+func (nn *netNotifee) ListenClose(network.Network, multiaddr.Multiaddr) {}

--- a/peering/peering.go
+++ b/peering/peering.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	"github.com/ipfs/go-log"
-	"github.com/libp2p/go-libp2p-core/host"
-	"github.com/libp2p/go-libp2p-core/network"
-	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
 )
 

--- a/peering/peering.go
+++ b/peering/peering.go
@@ -14,8 +14,8 @@ import (
 	"github.com/multiformats/go-multiaddr"
 )
 
-// maxBackoff is the maximum time between reconnect attempts.
 const (
+	// maxBackoff is the maximum time between reconnect attempts.
 	maxBackoff = 10 * time.Minute
 	connmgrTag = "ipfs-peering"
 	// This needs to be sufficient to prevent two sides from simultaneously

--- a/peering/peering.go
+++ b/peering/peering.go
@@ -44,7 +44,7 @@ func (s State) String() string {
 	case StateStopped:
 		return "stopped"
 	default:
-		return "unkown peering state: " + strconv.FormatUint(uint64(s), 10)
+		return "unknown peering state: " + strconv.FormatUint(uint64(s), 10)
 	}
 }
 

--- a/peering/peering.go
+++ b/peering/peering.go
@@ -201,7 +201,7 @@ func (ps *PeeringService) Start() error {
 	return nil
 }
 
-// GetState get the State of the PeeringService
+// GetState get the State of the PeeringService.
 func (ps *PeeringService) GetState() State {
 	ps.mu.RLock()
 	defer ps.mu.RUnlock()
@@ -306,6 +306,7 @@ func (nn *netNotifee) Connected(_ network.Network, c network.Conn) {
 		go handler.stopIfConnected()
 	}
 }
+
 func (nn *netNotifee) Disconnected(_ network.Network, c network.Conn) {
 	ps := (*PeeringService)(nn)
 

--- a/peering/peering.go
+++ b/peering/peering.go
@@ -244,6 +244,9 @@ func (ps *PeeringService) AddPeer(info peer.AddrInfo) {
 
 // ListPeers lists peers in the peering service.
 func (ps *PeeringService) ListPeers() []peer.AddrInfo {
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
+
 	out := make([]peer.AddrInfo, 0, len(ps.peers))
 	for id, addrs := range ps.peers {
 		ai := peer.AddrInfo{ID: id}

--- a/peering/peering.go
+++ b/peering/peering.go
@@ -209,7 +209,7 @@ func (ps *PeeringService) GetState() State {
 }
 
 // Stop stops the peering service.
-func (ps *PeeringService) Stop() error {
+func (ps *PeeringService) Stop() {
 	ps.host.Network().StopNotify((*netNotifee)(ps))
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
@@ -222,7 +222,6 @@ func (ps *PeeringService) Stop() error {
 		}
 		ps.state = StateStopped
 	}
-	return nil
 }
 
 // AddPeer adds a peer to the peering service. This function may be safely

--- a/peering/peering.go
+++ b/peering/peering.go
@@ -15,9 +15,6 @@ import (
 	"github.com/multiformats/go-multiaddr"
 )
 
-// Seed the random number generator.
-//
-// We don't need good randomness, but we do need randomness.
 const (
 	// maxBackoff is the maximum time between reconnect attempts.
 	maxBackoff = 10 * time.Minute

--- a/peering/peering_test.go
+++ b/peering/peering_test.go
@@ -39,6 +39,7 @@ func TestPeeringService(t *testing.T) {
 
 	// peer 1 -> 2
 	ps1.AddPeer(peer.AddrInfo{ID: h2.ID(), Addrs: h2.Addrs()})
+	require.Contains(t, ps1.ListPeers(), peer.AddrInfo{ID: h2.ID(), Addrs: h2.Addrs()})
 
 	// We haven't started so we shouldn't have any peers.
 	require.Never(t, func() bool {
@@ -109,6 +110,7 @@ func TestPeeringService(t *testing.T) {
 
 	// Unprotect 2 from 1.
 	ps1.RemovePeer(h2.ID())
+	require.NotContains(t, ps1.ListPeers(), peer.AddrInfo{ID: h2.ID(), Addrs: h2.Addrs()})
 
 	// Trim connections.
 	h1.ConnManager().TrimOpenConns(ctx)
@@ -127,7 +129,9 @@ func TestPeeringService(t *testing.T) {
 
 	// Until added back
 	ps1.AddPeer(peer.AddrInfo{ID: h2.ID(), Addrs: h2.Addrs()})
+	require.Contains(t, ps1.ListPeers(), peer.AddrInfo{ID: h2.ID(), Addrs: h2.Addrs()})
 	ps1.AddPeer(peer.AddrInfo{ID: h3.ID(), Addrs: h3.Addrs()})
+	require.Contains(t, ps1.ListPeers(), peer.AddrInfo{ID: h3.ID(), Addrs: h3.Addrs()})
 	t.Logf("wait for h1 to connect to h2 and h3 again")
 	require.Eventually(t, func() bool {
 		return h1.Network().Connectedness(h2.ID()) == network.Connected
@@ -142,7 +146,9 @@ func TestPeeringService(t *testing.T) {
 
 	// Adding and removing should work after stopping.
 	ps1.AddPeer(peer.AddrInfo{ID: h4.ID(), Addrs: h4.Addrs()})
+	require.Contains(t, ps1.ListPeers(), peer.AddrInfo{ID: h4.ID(), Addrs: h4.Addrs()})
 	ps1.RemovePeer(h2.ID())
+	require.NotContains(t, ps1.ListPeers(), peer.AddrInfo{ID: h2.ID(), Addrs: h2.Addrs()})
 }
 
 func TestNextBackoff(t *testing.T) {

--- a/peering/peering_test.go
+++ b/peering/peering_test.go
@@ -1,0 +1,6 @@
+package peering
+
+import "testing"
+
+func TestPeeringService(t *testing.T) {
+}

--- a/peering/peering_test.go
+++ b/peering/peering_test.go
@@ -6,20 +6,22 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p"
-	connmgr "github.com/libp2p/go-libp2p-connmgr"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
 
 	"github.com/stretchr/testify/require"
 )
 
-func newNode(ctx context.Context, t *testing.T) host.Host {
+func newNode(t *testing.T) host.Host {
+	cm, err := connmgr.NewConnManager(1, 100, connmgr.WithGracePeriod(0))
+	require.NoError(t, err)
 	h, err := libp2p.New(
 		libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"),
 		// We'd like to set the connection manager low water to 0, but
 		// that would disable the connection manager.
-		libp2p.ConnectionManager(connmgr.NewConnManager(1, 100, 0)),
+		libp2p.ConnectionManager(cm),
 	)
 	require.NoError(t, err)
 	return h
@@ -29,12 +31,12 @@ func TestPeeringService(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	h1 := newNode(ctx, t)
+	h1 := newNode(t)
 	ps1 := NewPeeringService(h1)
 
-	h2 := newNode(ctx, t)
-	h3 := newNode(ctx, t)
-	h4 := newNode(ctx, t)
+	h2 := newNode(t)
+	h3 := newNode(t)
+	h4 := newNode(t)
 
 	// peer 1 -> 2
 	ps1.AddPeer(peer.AddrInfo{ID: h2.ID(), Addrs: h2.Addrs()})

--- a/peering/peering_test.go
+++ b/peering/peering_test.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p"
-	"github.com/libp2p/go-libp2p-core/host"
-	"github.com/libp2p/go-libp2p-core/network"
-	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
 
 	"github.com/stretchr/testify/require"

--- a/peering/peering_test.go
+++ b/peering/peering_test.go
@@ -16,7 +16,6 @@ import (
 
 func newNode(ctx context.Context, t *testing.T) host.Host {
 	h, err := libp2p.New(
-		ctx,
 		libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"),
 		// We'd like to set the connection manager low water to 0, but
 		// that would disable the connection manager.

--- a/peering/peering_test.go
+++ b/peering/peering_test.go
@@ -1,6 +1,139 @@
 package peering
 
-import "testing"
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p"
+	connmgr "github.com/libp2p/go-libp2p-connmgr"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/network"
+	"github.com/libp2p/go-libp2p-core/peer"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newNode(ctx context.Context, t *testing.T) host.Host {
+	h, err := libp2p.New(
+		ctx,
+		libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"),
+		// We'd like to set the connection manager low water to 0, but
+		// that would disable the connection manager.
+		libp2p.ConnectionManager(connmgr.NewConnManager(1, 100, 0)),
+	)
+	require.NoError(t, err)
+	return h
+}
 
 func TestPeeringService(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	h1 := newNode(ctx, t)
+	ps1 := NewPeeringService(h1)
+
+	h2 := newNode(ctx, t)
+	h3 := newNode(ctx, t)
+	h4 := newNode(ctx, t)
+
+	// peer 1 -> 2
+	ps1.AddPeer(peer.AddrInfo{ID: h2.ID(), Addrs: h2.Addrs()})
+
+	// We haven't started so we shouldn't have any peers.
+	require.Never(t, func() bool {
+		return len(h1.Network().Peers()) > 0
+	}, 100*time.Millisecond, 1*time.Second, "expected host 1 to have no peers")
+
+	// Use p4 to take up the one slot we have in the connection manager.
+	for _, h := range []host.Host{h1, h2} {
+		require.NoError(t, h.Connect(ctx, peer.AddrInfo{ID: h4.ID(), Addrs: h4.Addrs()}))
+		h.ConnManager().TagPeer(h4.ID(), "sticky-peer", 1000)
+	}
+
+	// Now start.
+	require.NoError(t, ps1.Start())
+	// starting twice is fine.
+	require.NoError(t, ps1.Start())
+
+	// We should eventually connect.
+	require.Eventually(t, func() bool {
+		return h1.Network().Connectedness(h2.ID()) == network.Connected
+	}, 30*time.Second, 10*time.Millisecond)
+
+	// Now explicitly connect to p3.
+	require.NoError(t, h1.Connect(ctx, peer.AddrInfo{ID: h3.ID(), Addrs: h3.Addrs()}))
+	require.Eventually(t, func() bool {
+		return h1.Network().Connectedness(h2.ID()) == network.Connected
+	}, 30*time.Second, 100*time.Millisecond)
+
+	require.Len(t, h1.Network().Peers(), 3)
+
+	// force a disconnect
+	h1.ConnManager().TrimOpenConns(ctx)
+
+	// Should disconnect from p3.
+	require.Eventually(t, func() bool {
+		return h1.Network().Connectedness(h3.ID()) != network.Connected
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Should remain connected to p2
+	require.Never(t, func() bool {
+		return h1.Network().Connectedness(h2.ID()) != network.Connected
+	}, 5*time.Second, 1*time.Second)
+
+	// Now force h2 to disconnect (we have an asymmetric peering).
+	conns := h2.Network().ConnsToPeer(h1.ID())
+	require.NotEmpty(t, conns)
+	h2.ConnManager().TrimOpenConns(ctx)
+
+	// All conns to peer should eventually close.
+	for _, c := range conns {
+		require.Eventually(t, func() bool {
+			s, err := c.NewStream()
+			if s != nil {
+				_ = s.Reset()
+			}
+			return err != nil
+		}, 5*time.Second, 10*time.Millisecond)
+	}
+
+	// Should eventually re-connect.
+	require.Eventually(t, func() bool {
+		return h1.Network().Connectedness(h2.ID()) == network.Connected
+	}, 30*time.Second, 1*time.Second)
+
+	// Unprotect 2 from 1.
+	ps1.RemovePeer(h2.ID())
+
+	// Trim connections.
+	h1.ConnManager().TrimOpenConns(ctx)
+
+	// Should disconnect
+	require.Eventually(t, func() bool {
+		return h1.Network().Connectedness(h2.ID()) != network.Connected
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Should never reconnect.
+	require.Never(t, func() bool {
+		return h1.Network().Connectedness(h2.ID()) == network.Connected
+	}, 20*time.Second, 1*time.Second)
+
+	// Until added back
+	ps1.AddPeer(peer.AddrInfo{ID: h2.ID(), Addrs: h2.Addrs()})
+	ps1.AddPeer(peer.AddrInfo{ID: h3.ID(), Addrs: h3.Addrs()})
+	require.Eventually(t, func() bool {
+		return h1.Network().Connectedness(h2.ID()) == network.Connected
+	}, 30*time.Second, 1*time.Second)
+	require.Eventually(t, func() bool {
+		return h1.Network().Connectedness(h3.ID()) == network.Connected
+	}, 30*time.Second, 1*time.Second)
+
+	// Should be able to repeatedly stop.
+	require.NoError(t, ps1.Stop())
+	require.NoError(t, ps1.Stop())
+
+	// Adding and removing should work after stopping.
+	ps1.AddPeer(peer.AddrInfo{ID: h4.ID(), Addrs: h4.Addrs()})
+	ps1.RemovePeer(h2.ID())
 }

--- a/peering/peering_test.go
+++ b/peering/peering_test.go
@@ -66,7 +66,7 @@ func TestPeeringService(t *testing.T) {
 	t.Logf("waiting for h1's connection to h3 to work")
 	require.NoError(t, h1.Connect(ctx, peer.AddrInfo{ID: h3.ID(), Addrs: h3.Addrs()}))
 	require.Eventually(t, func() bool {
-		return h1.Network().Connectedness(h2.ID()) == network.Connected
+		return h1.Network().Connectedness(h3.ID()) == network.Connected
 	}, 30*time.Second, 100*time.Millisecond)
 
 	require.Len(t, h1.Network().Peers(), 3)

--- a/peering/peering_test.go
+++ b/peering/peering_test.go
@@ -137,3 +137,22 @@ func TestPeeringService(t *testing.T) {
 	ps1.AddPeer(peer.AddrInfo{ID: h4.ID(), Addrs: h4.Addrs()})
 	ps1.RemovePeer(h2.ID())
 }
+
+func TestNextBackoff(t *testing.T) {
+	minMaxBackoff := (100 - maxBackoffJitter) / 100 * maxBackoff
+	for x := 0; x < 1000; x++ {
+		ph := peerHandler{nextDelay: time.Second}
+		for min, max := time.Second*3/2, time.Second*5/2; min < minMaxBackoff; min, max = min*3/2, max*5/2 {
+			b := ph.nextBackoff()
+			if b > max || b < min {
+				t.Errorf("expected backoff %s to be between %s and %s", b, min, max)
+			}
+		}
+		for i := 0; i < 100; i++ {
+			b := ph.nextBackoff()
+			if b < minMaxBackoff || b > maxBackoff {
+				t.Fatal("failed to stay within max bounds")
+			}
+		}
+	}
+}

--- a/peering/peering_test.go
+++ b/peering/peering_test.go
@@ -90,7 +90,7 @@ func TestPeeringService(t *testing.T) {
 	// All conns to peer should eventually close.
 	for _, c := range conns {
 		require.Eventually(t, func() bool {
-			s, err := c.NewStream()
+			s, err := c.NewStream(context.Background())
 			if s != nil {
 				_ = s.Reset()
 			}

--- a/peering/peering_test.go
+++ b/peering/peering_test.go
@@ -142,8 +142,8 @@ func TestPeeringService(t *testing.T) {
 	}, 30*time.Second, 1*time.Second)
 
 	// Should be able to repeatedly stop.
-	require.NoError(t, ps1.Stop())
-	require.NoError(t, ps1.Stop())
+	ps1.Stop()
+	ps1.Stop()
 
 	// Adding and removing should work after stopping.
 	ps1.AddPeer(peer.AddrInfo{ID: h4.ID(), Addrs: h4.Addrs()})


### PR DESCRIPTION
Migrating `peering` service from kubo. The peering package is used outside of kubo, and should be relocated into boxo so that kubo is not used as an IPFS library.