### PR TITLE
Simplify fetcher setup

### DIFF
--- a/gateway/blocks_backend.go
+++ b/gateway/blocks_backend.go
@@ -137,7 +137,9 @@ func NewBlocksBackend(blockService blockservice.BlockService, opts ...BlocksBack
 	r = compiledOptions.r
 	if r == nil {
 		// Setup the UnixFS resolver.
-		fetcher := bsfetcher.NewFetcherConfig(blockService).WithReifier(unixfsnode.Reify)
+		fetcherCfg := bsfetcher.NewFetcherConfig(blockService)
+		fetcherCfg.PrototypeChooser = dagpb.AddSupportToChooser(bsfetcher.DefaultPrototypeChooser)
+		fetcher := fetcherCfg.WithReifier(unixfsnode.Reify)
 		r = resolver.NewBasicResolver(fetcher)
 	}
 

--- a/gateway/blocks_backend.go
+++ b/gateway/blocks_backend.go
@@ -137,7 +137,7 @@ func NewBlocksBackend(blockService blockservice.BlockService, opts ...BlocksBack
 	r = compiledOptions.r
 	if r == nil {
 		// Setup the UnixFS resolver.
-		fetcher := bsfetcher.NewFetcherConfig(blockService)
+		fetcher := bsfetcher.NewFetcherConfig(blockService).WithReifier(unixfsnode.Reify)
 		r = resolver.NewBasicResolver(fetcher)
 	}
 

--- a/gateway/blocks_backend.go
+++ b/gateway/blocks_backend.go
@@ -109,15 +109,6 @@ func NewBlocksBackend(blockService blockservice.BlockService, opts ...BlocksBack
 	// Setup the DAG services, which use the CAR block store.
 	dagService := merkledag.NewDAGService(blockService)
 
-	// Setup the UnixFS resolver.
-	fetcherConfig := bsfetcher.NewFetcherConfig(blockService)
-	fetcherConfig.PrototypeChooser = dagpb.AddSupportToChooser(func(lnk ipld.Link, lnkCtx ipld.LinkContext) (ipld.NodePrototype, error) {
-		if tlnkNd, ok := lnkCtx.LinkNode.(schema.TypedLinkNode); ok {
-			return tlnkNd.LinkTargetNodePrototype(), nil
-		}
-		return basicnode.Prototype.Any, nil
-	})
-
 	// Setup a name system so that we are able to resolve /ipns links.
 	var (
 		ns namesys.NameSystem
@@ -145,7 +136,8 @@ func NewBlocksBackend(blockService blockservice.BlockService, opts ...BlocksBack
 
 	r = compiledOptions.r
 	if r == nil {
-		fetcher := fetcherConfig.WithReifier(unixfsnode.Reify)
+		// Setup the UnixFS resolver.
+		fetcher := bsfetcher.NewFetcherConfig(blockService)
 		r = resolver.NewBasicResolver(fetcher)
 	}
 


### PR DESCRIPTION
The default fetcher already uses the same PrototypeChooser that we were setting explicitally (https://github.com/ipfs/boxo/blob/main/fetcher/impl/blockservice/fetcher.go#L127).

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
