### PR TITLE
feat!: remove util.MultiErr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ The following emojis are used to highlight certain changes:
 
 ### Removed
 
+* 🛠 `util.MultiErr` has been removed. Please use Go's native support for wrapping errors, or `errors.Join` instead.
+
 ### Fixed
 
 ### Security

--- a/util/util.go
+++ b/util/util.go
@@ -89,24 +89,6 @@ func GetenvBool(name string) bool {
 	return v == "true" || v == "t" || v == "1"
 }
 
-// MultiErr is a util to return multiple errors
-type MultiErr []error
-
-func (m MultiErr) Error() string {
-	if len(m) == 0 {
-		return "no errors"
-	}
-
-	s := "Multiple errors: "
-	for i, e := range m {
-		if i != 0 {
-			s += ", "
-		}
-		s += e.Error()
-	}
-	return s
-}
-
 // Partition splits a subject 3 parts: prefix, separator, suffix.
 // The first occurrence of the separator will be matched.
 // ie. Partition("Ready, steady, go!", ", ") -> ["Ready", ", ", "steady, go!"]


### PR DESCRIPTION
Self-explanatory. Not used anywhere I could find. Boxo supports Go 1.21+. There are native ways of doing this. Cleanup is always good. It's funny we have our own multi error while we've just been using Uber's and others this whole time.