### PR TITLE
feat(gw): Ipfs-Gateway-Mode: path|trustless

### DIFF
--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -343,8 +343,13 @@ func addCustomHeaders(w http.ResponseWriter, headers map[string][]string) {
 
 // isDeserializedResponsePossible returns true if deserialized responses
 // are allowed on the specified hostname, or globally. Host-specific rules
-// override global config.
+// or client preference override global config.
 func (i *handler) isDeserializedResponsePossible(r *http.Request) bool {
+	// If client requested trustless mode, we return false immediatelly
+	if r.Header.Get(GatewayModeHeader) == "trustless" {
+		return false
+	}
+
 	// Get the value from HTTP Host header
 	host := r.Host
 

--- a/gateway/headers.go
+++ b/gateway/headers.go
@@ -1,0 +1,8 @@
+package gateway
+
+const (
+
+	// GatewayMode header allows client and server to opt-in into specific
+	// more strict mode, such as limiting responses to trustless ones.
+	GatewayModeHeader = "Ipfs-Gateway-Mode"
+)

--- a/gateway/hostname.go
+++ b/gateway/hostname.go
@@ -48,6 +48,14 @@ func NewHostnameHandler(c Config, backend IPFSBackend, next http.Handler) http.H
 			host = xHost
 		}
 
+		// Comply with user agents that explicitly requested plain path processing
+		// (used by CLI and non-browser tools to disable Host-based subdomain redirects etc)
+		switch r.Header.Get(GatewayModeHeader) {
+		case "path", "trustless":
+			next.ServeHTTP(w, withHostnameContext(r, host))
+			return
+		}
+
 		// HTTP Host & Path check: is this one of our  "known gateways"?
 		if gw, ok := gateways.isKnownHostname(host); ok {
 			// This is a known gateway but request is not using


### PR DESCRIPTION
This PR adds `boxo/gateway` support for an opt-in HTTP header that CLI tools like CURL can send to disable browser-specific redirect to subdomain.

As suggested by @markg85  in https://curl.se/mail/lib-2023-10/0038.html
An IPIP and gateway conformance tests will follow.


## Concerns

It assumes every HTTP Cache will be aware of user opt-in, and that is not the case. 
HTTP caching is complex, there are many implementations, only a small of HTTP caching works reliably across vendors. 

What happens when HTTP cache in front of gateway (CDN, nginx, loadbalancer etc) caches response produced for client with `Ipfs-Gateway-Mode`  and then returns it for clients that did not request with  `Ipfs-Gateway-Mode`?

Suggestions welcome, but unless we resolve below, the `Ipfs-Gateway-Mode` has no future.

### Denial of Service 

Many websites require Origin isolation and URL root to be at `/` and not `/ip*s/name/`.

A malicious actor could request popular websites over and over again with `Ipfs-Gateway-Mode: path` to force invalid payload to be placed in cache, effectively breaking them for other users.

### Origin Isolation breakage and reveal of user secrets

A malicious actor could request `/ipfs/cid/malicious-payload.html` and `/ipns/wallet.example.com` with `Ipfs-Gateway-Mode: path`, and both responses are cached by middleware/CDN in front of a gateway. 

Users who open /ipns/wallet.example.com` would get a cached response that does not redirect them to gateway, allowing `/ipfs/cid/malicious-payload.html` (which is now in the same shared origin) to read all cookies, and private keys from local storage etc. 

Tricking user into opening `/ipfs/cid/malicious-payload.html` will enable exfiltration of secrets.

## Explored mitigations 

- :red_circle:  Force `content-disposition: attachement` on responses when `Ipfs-Gateway-Mode` header is set, this way browser will never render such payload. 
  - This fixes secret leak, but makes denial of service even easier – cached response with `content-disposition: attachement` will NEVER render.
  
  
- :orange_circle:    return `Vary` header to indicate which other HTTP headers should be used in caching decisions
  - This works on paper, does not work in practice. [Vary header history here](https://www.smashingmagazine.com/2017/11/understanding-vary-header/) is  a good primer on the problem space. tldr: we could return `Vary: Ipfs-Gateway-Mode` but can't assume this works reliably across the stack, which means we would be gambling with security of end user.

## TODO

- [ ] Understand risks and mitigations.  Decide if this is feasible at all.
- [ ] Write IPIP
- [ ] Gateway conformance
