### PR TITLE
fix: gateway panic because of overshadowed err

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,12 @@ The following emojis are used to highlight certain changes:
 ### Changed
 
 ### Removed
+
 * 🛠 `boxo/gateway`: removed support for undocumented legacy `ipfs-404.html`. Use [`_redirects`](https://specs.ipfs.tech/http-gateways/web-redirects-file/) instead.
 
 ### Fixed
+
+* `boxo/gateway`: a request-only panic could sporadically be triggered inside a CAR request, if the right [conditions were met](https://github.com/ipfs/boxo/pull/511).
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
-* `boxo/gateway`: a request-only panic could sporadically be triggered inside a CAR request, if the right [conditions were met](https://github.com/ipfs/boxo/pull/511).
+* `boxo/gateway`: a panic (which is recovered) could sporadically be triggered inside a CAR request, if the right [conditions were met](https://github.com/ipfs/boxo/pull/511). 
 
 ### Security
 

--- a/gateway/blocks_backend.go
+++ b/gateway/blocks_backend.go
@@ -296,8 +296,8 @@ func (bb *BlocksBackend) Head(ctx context.Context, path path.ImmutablePath) (Con
 var emptyRoot = []cid.Cid{cid.MustParse("bafkqaaa")}
 
 func (bb *BlocksBackend) GetCAR(ctx context.Context, p path.ImmutablePath, params CarParams) (ContentPathMetadata, io.ReadCloser, error) {
-	pathMetadata, err := bb.ResolvePath(ctx, p)
-	if err != nil {
+	pathMetadata, resolveErr := bb.ResolvePath(ctx, p)
+	if resolveErr != nil {
 		rootCid, err := cid.Decode(strings.Split(p.String(), "/")[2])
 		if err != nil {
 			return ContentPathMetadata{}, nil, err
@@ -327,8 +327,11 @@ func (bb *BlocksBackend) GetCAR(ctx context.Context, p path.ImmutablePath, param
 				LastSegment:      path.FromCid(rootCid),
 				ContentType:      "",
 			}, io.NopCloser(&buf), nil
+		} else if err != nil {
+			return ContentPathMetadata{}, nil, err
+		} else {
+			return ContentPathMetadata{}, nil, resolveErr
 		}
-		return ContentPathMetadata{}, nil, err
 	}
 
 	if p.Namespace() != path.IPFSNamespace {


### PR DESCRIPTION
This PR corrects error handling in the `GetCAR` implementation of the block backend. 

NOTE: sporadic panics, occurring during CAR requests under specific conditions, were harmless thanks to panic-recovery logic in the gateway handler, but created unnecessary noise in logs.