### PR TITLE
fix(gateway): do not act on template errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
-* `boxo/gateway`: a panic (which is recovered) could sporadically be triggered inside a CAR request, if the right [conditions were met](https://github.com/ipfs/boxo/pull/511). 
+* `boxo/gateway`
+  * a panic (which is recovered) could sporadically be triggered inside a CAR request, if the right [conditions were met](https://github.com/ipfs/boxo/pull/511). 
+  * no longer emits `http: superfluous response.WriteHeader` warnings when an error happens.
 
 ### Security
 

--- a/gateway/assets/test/main.go
+++ b/gateway/assets/test/main.go
@@ -157,7 +157,10 @@ func runTemplate(w http.ResponseWriter, filename string, data interface{}) {
 		http.Error(w, fmt.Sprintf("failed to parse template file: %s", err), http.StatusInternalServerError)
 		return
 	}
-	_ = tpl.Execute(w, data)
+	err = tpl.Execute(w, data)
+	if err != nil {
+		_, _ = w.Write([]byte(fmt.Sprintf("error during body generation: %v", err)))
+	}
 }
 
 func main() {

--- a/gateway/assets/test/main.go
+++ b/gateway/assets/test/main.go
@@ -157,11 +157,7 @@ func runTemplate(w http.ResponseWriter, filename string, data interface{}) {
 		http.Error(w, fmt.Sprintf("failed to parse template file: %s", err), http.StatusInternalServerError)
 		return
 	}
-	err = tpl.Execute(w, data)
-	if err != nil {
-		http.Error(w, fmt.Sprintf("failed to execute template: %s", err), http.StatusInternalServerError)
-		return
-	}
+	_ = tpl.Execute(w, data)
 }
 
 func main() {

--- a/gateway/errors.go
+++ b/gateway/errors.go
@@ -165,7 +165,7 @@ func webError(w http.ResponseWriter, r *http.Request, c *Config, err error, defa
 	if acceptsHTML {
 		w.Header().Set("Content-Type", "text/html")
 		w.WriteHeader(code)
-		_ = assets.ErrorTemplate.Execute(w, assets.ErrorTemplateData{
+		err = assets.ErrorTemplate.Execute(w, assets.ErrorTemplateData{
 			GlobalData: assets.GlobalData{
 				Menu: c.Menu,
 			},
@@ -173,6 +173,9 @@ func webError(w http.ResponseWriter, r *http.Request, c *Config, err error, defa
 			StatusText: http.StatusText(code),
 			Error:      err.Error(),
 		})
+		if err != nil {
+			_, _ = w.Write([]byte(fmt.Sprintf("error during body generation: %v", err)))
+		}
 	} else {
 		http.Error(w, err.Error(), code)
 	}

--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -912,13 +912,11 @@ func (i *handler) handleSuperfluousNamespace(w http.ResponseWriter, r *http.Requ
 	// - redirects to intendedURL after a short delay
 
 	w.WriteHeader(http.StatusBadRequest)
-	if err := redirectTemplate.Execute(w, redirectTemplateData{
+	_ = redirectTemplate.Execute(w, redirectTemplateData{
 		RedirectURL:   intendedURL,
 		SuggestedPath: intendedPath.String(),
 		ErrorMsg:      fmt.Sprintf("invalid path: %q should be %q", r.URL.Path, intendedPath.String()),
-	}); err != nil {
-		i.webError(w, r, fmt.Errorf("failed to redirect when fixing superfluous namespace: %w", err), http.StatusBadRequest)
-	}
+	})
 
 	return true
 }

--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -912,11 +912,14 @@ func (i *handler) handleSuperfluousNamespace(w http.ResponseWriter, r *http.Requ
 	// - redirects to intendedURL after a short delay
 
 	w.WriteHeader(http.StatusBadRequest)
-	_ = redirectTemplate.Execute(w, redirectTemplateData{
+	err = redirectTemplate.Execute(w, redirectTemplateData{
 		RedirectURL:   intendedURL,
 		SuggestedPath: intendedPath.String(),
 		ErrorMsg:      fmt.Sprintf("invalid path: %q should be %q", r.URL.Path, intendedPath.String()),
 	})
+	if err != nil {
+		_, _ = w.Write([]byte(fmt.Sprintf("error during body generation: %v", err)))
+	}
 
 	return true
 }

--- a/gateway/handler_codec.go
+++ b/gateway/handler_codec.go
@@ -195,20 +195,16 @@ func (i *handler) serveCodecHTML(ctx context.Context, w http.ResponseWriter, r *
 	w.Header().Del("Cache-Control")
 
 	cidCodec := mc.Code(resolvedPath.RootCid().Prefix().Codec)
-	if err := assets.DagTemplate.Execute(w, assets.DagTemplateData{
+	err = assets.DagTemplate.Execute(w, assets.DagTemplateData{
 		GlobalData: i.getTemplateGlobalData(r, contentPath),
 		Path:       contentPath.String(),
 		CID:        resolvedPath.RootCid().String(),
 		CodecName:  cidCodec.String(),
 		CodecHex:   fmt.Sprintf("0x%x", uint64(cidCodec)),
 		Node:       parseNode(blockCid, blockData),
-	}); err != nil {
-		err = fmt.Errorf("failed to generate HTML listing for this DAG: try fetching raw block with ?format=raw: %w", err)
-		i.webError(w, r, err, http.StatusInternalServerError)
-		return false
-	}
+	})
 
-	return true
+	return err == nil
 }
 
 // parseNode does a best effort attempt to parse this request's block such that

--- a/gateway/handler_codec.go
+++ b/gateway/handler_codec.go
@@ -203,6 +203,9 @@ func (i *handler) serveCodecHTML(ctx context.Context, w http.ResponseWriter, r *
 		CodecHex:   fmt.Sprintf("0x%x", uint64(cidCodec)),
 		Node:       parseNode(blockCid, blockData),
 	})
+	if err != nil {
+		_, _ = w.Write([]byte(fmt.Sprintf("error during body generation: %v", err)))
+	}
 
 	return err == nil
 }

--- a/gateway/handler_unixfs_dir.go
+++ b/gateway/handler_unixfs_dir.go
@@ -212,7 +212,6 @@ func (i *handler) serveDirectory(ctx context.Context, w http.ResponseWriter, r *
 	rq.logger.Debugw("request processed", "tplDataDNSLink", globalData.DNSLink, "tplDataSize", size, "tplDataBackLink", backLink, "tplDataHash", hash)
 
 	if err := assets.DirectoryTemplate.Execute(w, tplData); err != nil {
-		i.webError(w, r, err, http.StatusInternalServerError)
 		return false
 	}
 

--- a/gateway/handler_unixfs_dir.go
+++ b/gateway/handler_unixfs_dir.go
@@ -212,6 +212,7 @@ func (i *handler) serveDirectory(ctx context.Context, w http.ResponseWriter, r *
 	rq.logger.Debugw("request processed", "tplDataDNSLink", globalData.DNSLink, "tplDataSize", size, "tplDataBackLink", backLink, "tplDataHash", hash)
 
 	if err := assets.DirectoryTemplate.Execute(w, tplData); err != nil {
+		_, _ = w.Write([]byte(fmt.Sprintf("error during body generation: %v", err)))
 		return false
 	}
 


### PR DESCRIPTION
Fixes #487. When we try to execute a template, we have already written the header. In some places, we were already ignoring the template execution error. In others, we were calling `webError`. That would lead to a duplicate header writing warning.

There is not much that can be done if a template fails to execute: we could perhaps log it, but so far what we've done in other places is to ignore. A way to circumvent this would be to write to a buffer and then write to `http.ResponseWriter`. That would allow us to catch the template error, but writing can always fail (e.g., broken connection).

I wouldn't care much about this and I think just ignoring the template writing error is probably fine. If errors happen, they will most likely be writing errors, so broken connections and other network issues, most likely.