### PR TITLE
fix: recursive directory filtering in `ShouldExclude`

### DIFF
--- a/files/filter.go
+++ b/files/filter.go
@@ -1,6 +1,7 @@
 package files
 
 import (
+	"fmt"
 	"os"
 
 	ignore "github.com/crackcomm/go-gitignore"
@@ -44,6 +45,9 @@ func (filter *Filter) ShouldExclude(fileInfo os.FileInfo) (result bool) {
 	path := fileInfo.Name()
 	if !filter.IncludeHidden && isHidden(fileInfo) {
 		return true
+	}
+	if fileInfo.IsDir() {
+		path = fmt.Sprintf("%s/", path)
 	}
 	return filter.Rules.MatchesPath(path)
 }


### PR DESCRIPTION
Ensure ignore rule `bar/` matches directories by appending `/`. Addresses issue where `bar/` didn't catch directories. After this change, both `bar` and `bar/` rules filter out the `bar` directory and its contents.

Note: This is required because git would skip empty directories and use full paths relative to repo.
I'm not sure how much I could break the API but it's still just using file names as opposed to full relative paths for filtering which is not ideal.