### PR TITLE
fix(gw): entity-bytes with negative indexes beyond file size

### DIFF
--- a/.github/workflows/gateway-conformance.yml
+++ b/.github/workflows/gateway-conformance.yml
@@ -16,18 +16,18 @@ jobs:
     steps:
       # 1. Download the gateway-conformance fixtures
       - name: Download gateway-conformance fixtures
-        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.4
+        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.5
         with:
           output: fixtures
           merged: true
 
       # 2. Build the car-gateway
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.21.x
       - name: Checkout boxo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: boxo
       - name: Build car-gateway
@@ -40,7 +40,7 @@ jobs:
 
       # 4. Run the gateway-conformance tests
       - name: Run gateway-conformance tests
-        uses: ipfs/gateway-conformance/.github/actions/test@v0.4
+        uses: ipfs/gateway-conformance/.github/actions/test@v0.5
         with:
           gateway-url: http://127.0.0.1:8040
           json: output.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ The following emojis are used to highlight certain changes:
 
 ### Removed
 
+### Fixed
+
+* `boxo/gateway`
+  * when making a trustless CAR request with the "entity-bytes" parameter, using a negative index greater than the underlying entity length could trigger reading more data than intended
+
 ### Security
 
 ## [v0.17.0]

--- a/gateway/blocks_backend.go
+++ b/gateway/blocks_backend.go
@@ -508,6 +508,9 @@ func walkGatewaySimpleSelector(ctx context.Context, p path.ImmutablePath, params
 					return err
 				}
 				from = fileLength + entityRange.From
+				if from < 0 {
+					from = 0
+				}
 				foundFileLength = true
 			}
 

--- a/gateway/blocks_backend.go
+++ b/gateway/blocks_backend.go
@@ -524,13 +524,15 @@ func walkGatewaySimpleSelector(ctx context.Context, p path.ImmutablePath, params
 			}
 
 			to := *entityRange.To
-			if (*entityRange.To) < 0 && !foundFileLength {
-				fileLength, err = f.Seek(0, io.SeekEnd)
-				if err != nil {
-					return err
+			if (*entityRange.To) < 0 {
+				if !foundFileLength {
+					fileLength, err = f.Seek(0, io.SeekEnd)
+					if err != nil {
+						return err
+					}
+					foundFileLength = true
 				}
 				to = fileLength + *entityRange.To
-				foundFileLength = true
 			}
 
 			numToRead := 1 + to - from


### PR DESCRIPTION
# Goal

Fix the following problem:
- I pass a pair of negative indexs to the `entity-bytes` parameter of a trustless HTTP request.
- The start index is MORE negative than the length of the underlying entity (i.e. file) -- so `entity-bytes=-1000,-50` on a 100 byte file
- The code will see the start index is negative and add the entity length, but that will still leave it negative (https://github.com/ipfs/boxo/blob/main/gateway/blocks_backend.go#L510) -- in our example case from is no `-900`
- The calculation of bytes to read will be higher than it should be -- https://github.com/ipfs/boxo/blob/main/gateway/blocks_backend.go#L533 -- in our example case, `1 + 50 - -900` = 951
- When executed, this will simply read all 100 bytes of the underlying entity, instead of the intended behavior to read only the first 50 (i.e everything up to the -50 index)

# Implementation

Very simple fix -- if after adding the entity length, the from is still negative, simply set it to 0.

This is the logic already implemented in the IPLD selector for ranges -- https://github.com/ipld/go-ipld-prime/blob/master/traversal/selector/matcher.go#L49

# For discussion

This wil cause a gateway conformance test to fail, which is due to a failure in the way the test is setup -- the issue is documented here: https://github.com/ipfs/gateway-conformance/issues/189