### PR TITLE
Update tracing.md

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -4,7 +4,7 @@ Tracing across the stack follows, as much as possible, the [Open Telemetry]
 specifications. Configuration environment variables are specified in the
 [OpenTelemetry Environment Variable Specification].
 
-We use the [opentelemtry-go] package, which currently does not have default support
+We use the [opentelemetry-go] package, which currently does not have default support
 for the `OTEL_TRACES_EXPORTER` environment variables. Therefore, we provide some
 helper functions under [`boxo/tracing`](../tracing/) to support these.
 


### PR DESCRIPTION
It appears there's a typo in the package name. It should be opentelemetry-go instead of opentelemtry-go.

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
