### PR TITLE
blockservice: fix panic when closing an offline blockservice

### DIFF
--- a/blockservice/blockservice.go
+++ b/blockservice/blockservice.go
@@ -422,6 +422,9 @@ func (s *blockService) DeleteBlock(ctx context.Context, c cid.Cid) error {
 
 func (s *blockService) Close() error {
 	logger.Debug("blockservice is shutting down...")
+	if s.exchange == nil {
+		return nil
+	}
 	return s.exchange.Close()
 }
 


### PR DESCRIPTION
blockservice is explicitely tolerent to having a nil exchange. The constructor even logs that as running an offline blockservice.

Everything is tolerent except close, which panics.

It is confusing for consumers to only have to call close based on if it's online or offline. They could also instead call close directly on the exchange (then we could remove blockservice's Close method).

Anyway here is as a simple fix, add a nil check.
