### PR TITLE
gateway: remove workaround for go bugs on ranges on empty files

### DIFF
--- a/gateway/handler_unixfs_file.go
+++ b/gateway/handler_unixfs_file.go
@@ -28,15 +28,6 @@ func (i *handler) serveFile(ctx context.Context, w http.ResponseWriter, r *http.
 	// Set Content-Disposition
 	name := addContentDispositionHeader(w, r, rq.contentPath)
 
-	if fileSize == 0 {
-		// We override null files to 200 to avoid issues with fragment caching reverse proxies.
-		// Also whatever you are asking for, it's cheaper to just give you the complete file (nothing).
-		// TODO: remove this if clause once https://github.com/golang/go/issues/54794 is fixed in two latest releases of go
-		w.Header().Set("Content-Type", "text/plain")
-		w.WriteHeader(http.StatusOK)
-		return true
-	}
-
 	var content io.Reader = fileBytes
 	// Calculate deterministic value for Content-Type HTTP header
 	// (we prefer to do it here, rather than using implicit sniffing in http.ServeContent)


### PR DESCRIPTION
https://github.com/golang/go/commit/edfe07834905809d687b30632ccb849b84ebd4f2 was released in go1.20 and our `go.mod` file indicates:
```
go 1.20
```
So this is not needed anymore.

However none of this matter since c28c847582f0512d7f4a0e25b45aebae2ca7ca04 embeded and modified the ServeContent function in our codebase.
So I copied my upstream fix there.