### PR TITLE
blockservice: move to single unique struct and add `WithContentBlocker` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The following emojis are used to highlight certain changes:
 
 - `blockservice` now has `ContextWithSession` and `EmbedSessionInContext` functions, which allows to embed a session in a context. Future calls to `BlockGetter.GetBlock`, `BlockGetter.GetBlocks` and `NewSession` will use the session in the context.
 - `blockservice.NewWritethrough` deprecated function has been removed, instead you can do `blockservice.New(..., ..., WriteThrough())` like previously.
+- `blockservice` now has `WithContentBlocker` option which allows to filter Add and Get requests by CID.
 
 ### Changed
 

--- a/blockservice/test/mock.go
+++ b/blockservice/test/mock.go
@@ -9,13 +9,13 @@ import (
 )
 
 // Mocks returns |n| connected mock Blockservices
-func Mocks(n int, opts ...blockservice.Option) []blockservice.BlockService {
+func Mocks(n int, opts ...blockservice.Option) []*blockservice.BlockService {
 	net := tn.VirtualNetwork(mockrouting.NewServer(), delay.Fixed(0))
 	sg := testinstance.NewTestInstanceGenerator(net, nil, nil)
 
 	instances := sg.Instances(n)
 
-	var servs []blockservice.BlockService
+	var servs []*blockservice.BlockService
 	for _, i := range instances {
 		servs = append(servs, blockservice.New(i.Blockstore(), i.Exchange, opts...))
 	}

--- a/fetcher/impl/blockservice/fetcher.go
+++ b/fetcher/impl/blockservice/fetcher.go
@@ -23,13 +23,13 @@ type fetcherSession struct {
 
 // FetcherConfig defines a configuration object from which Fetcher instances are constructed
 type FetcherConfig struct {
-	blockService     blockservice.BlockService
+	blockService     *blockservice.BlockService
 	NodeReifier      ipld.NodeReifier
 	PrototypeChooser traversal.LinkTargetNodePrototypeChooser
 }
 
 // NewFetcherConfig creates a FetchConfig from which session may be created and nodes retrieved.
-func NewFetcherConfig(blockService blockservice.BlockService) FetcherConfig {
+func NewFetcherConfig(blockService *blockservice.BlockService) FetcherConfig {
 	return FetcherConfig{
 		blockService:     blockService,
 		PrototypeChooser: DefaultPrototypeChooser,
@@ -39,7 +39,7 @@ func NewFetcherConfig(blockService blockservice.BlockService) FetcherConfig {
 // NewSession creates a session from which nodes may be retrieved.
 // The session ends when the provided context is canceled.
 func (fc FetcherConfig) NewSession(ctx context.Context) fetcher.Fetcher {
-	return fc.FetcherWithSession(ctx, blockservice.NewSession(ctx, fc.blockService))
+	return fc.FetcherWithSession(ctx, fc.blockService.NewSession(ctx))
 }
 
 func (fc FetcherConfig) FetcherWithSession(ctx context.Context, s *blockservice.Session) fetcher.Fetcher {

--- a/gateway/blocks_backend.go
+++ b/gateway/blocks_backend.go
@@ -52,7 +52,7 @@ import (
 // BlocksBackend is an [IPFSBackend] implementation based on a [blockservice.BlockService].
 type BlocksBackend struct {
 	blockStore   blockstore.Blockstore
-	blockService blockservice.BlockService
+	blockService *blockservice.BlockService
 	dagService   format.DAGService
 	resolver     resolver.Resolver
 
@@ -97,7 +97,7 @@ func WithResolver(r resolver.Resolver) BlocksBackendOption {
 
 type BlocksBackendOption func(options *blocksBackendOptions) error
 
-func NewBlocksBackend(blockService blockservice.BlockService, opts ...BlocksBackendOption) (*BlocksBackend, error) {
+func NewBlocksBackend(blockService *blockservice.BlockService, opts ...BlocksBackendOption) (*BlocksBackend, error) {
 	var compiledOptions blocksBackendOptions
 	for _, o := range opts {
 		if err := o(&compiledOptions); err != nil {
@@ -687,7 +687,7 @@ func (bb *BlocksBackend) IsCached(ctx context.Context, p path.Path) bool {
 var _ WithContextHint = (*BlocksBackend)(nil)
 
 func (bb *BlocksBackend) WrapContextForRequest(ctx context.Context) context.Context {
-	return blockservice.ContextWithSession(ctx, bb.blockService)
+	return bb.blockService.ContextWithSession(ctx)
 }
 
 func (bb *BlocksBackend) ResolvePath(ctx context.Context, path path.ImmutablePath) (ContentPathMetadata, error) {

--- a/ipld/merkledag/merkledag.go
+++ b/ipld/merkledag/merkledag.go
@@ -35,7 +35,7 @@ const progressContextKey contextKey = "progress"
 
 // NewDAGService constructs a new DAGService (using the default implementation).
 // Note that the default implementation is also an ipld.LinkGetter.
-func NewDAGService(bs bserv.BlockService) *dagService {
+func NewDAGService(bs *bserv.BlockService) *dagService {
 	return &dagService{
 		Blocks:  bs,
 		decoder: ipldLegacyDecoder,
@@ -49,7 +49,7 @@ func NewDAGService(bs bserv.BlockService) *dagService {
 //
 //	able to free some of them when vm pressure is high
 type dagService struct {
-	Blocks  bserv.BlockService
+	Blocks  *bserv.BlockService
 	decoder *legacy.Decoder
 }
 
@@ -162,7 +162,7 @@ func WrapSession(s *bserv.Session) format.NodeGetter {
 
 // Session returns a NodeGetter using a new session for block fetches.
 func (n *dagService) Session(ctx context.Context) format.NodeGetter {
-	session := bserv.NewSession(ctx, n.Blocks)
+	session := n.Blocks.NewSession(ctx)
 	return &sesGetter{
 		bs:      session,
 		decoder: n.decoder,

--- a/ipld/merkledag/test/utils.go
+++ b/ipld/merkledag/test/utils.go
@@ -17,7 +17,7 @@ func Mock() ipld.DAGService {
 }
 
 // Bserv returns a new, thread-safe, mock BlockService.
-func Bserv() bsrv.BlockService {
+func Bserv() *bsrv.BlockService {
 	bstore := blockstore.NewBlockstore(dssync.MutexWrap(ds.NewMapDatastore()))
 	return bsrv.New(bstore, offline.Exchange(bstore))
 }


### PR DESCRIPTION
This is the first option to fix the blockservice mess here.

The idea is to have a THE blockservice object, this means we wont ever have an issue where multiple competitive features play poorly with each other due to how nested blockservices could do.
    
Let's say we add multi-exchange based on content routing, do we want to have to handle the mess this could create with nested blockservices ?
    
It implements features for https://github.com/ipfs-shipyard/nopfs/issues/34

I'll add changelog if we decide this is the option we want to go with.
