### PR TITLE
namesys: add WithMaxCacheTTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The following emojis are used to highlight certain changes:
 - `blockservice` now has `ContextWithSession` and `EmbedSessionInContext` functions, which allows to embed a session in a context. Future calls to `BlockGetter.GetBlock`, `BlockGetter.GetBlocks` and `NewSession` will use the session in the context.
 - `blockservice.NewWritethrough` deprecated function has been removed, instead you can do `blockservice.New(..., ..., WriteThrough())` like previously.
 - `gateway`: a new header configuration middleware has been added to replace the existing header configuration, which can be used more generically.
+- `namesys` now has a `WithMaxCacheTTL` option, which allows you to define a maximum TTL that will be used for caching IPNS entries.
 
 ### Changed
 

--- a/namesys/namesys.go
+++ b/namesys/namesys.go
@@ -48,8 +48,9 @@ type namesys struct {
 	dnsResolver, ipnsResolver resolver
 	ipnsPublisher             Publisher
 
-	staticMap map[string]*cacheEntry
-	cache     *lru.Cache[string, cacheEntry]
+	staticMap   map[string]*cacheEntry
+	cache       *lru.Cache[string, cacheEntry]
+	maxCacheTTL *time.Duration
 }
 
 var _ NameSystem = &namesys{}
@@ -69,6 +70,20 @@ func WithCache(size int) Option {
 		}
 
 		ns.cache = cache
+		return nil
+	}
+}
+
+// WithMaxCacheTTL configures the maximum cache TTL. By default, if the cache is
+// enabled, the entry TTL will be used for caching. By setting this option, you
+// can limit how long that TTL is.
+//
+// For example, if you configure a maximum cache TTL of 1 minute:
+//   - Entry TTL is 5 minutes -> Cache TTL is 1 minute
+//   - Entry TTL is 30 seconds -> Cache TTL is 30 seconds
+func WithMaxCacheTTL(dur time.Duration) Option {
+	return func(n *namesys) error {
+		n.maxCacheTTL = &dur
 		return nil
 	}
 }

--- a/namesys/namesys_cache.go
+++ b/namesys/namesys_cache.go
@@ -60,12 +60,20 @@ func (ns *namesys) cacheSet(name string, val path.Path, ttl time.Duration, lastM
 		}
 	}
 
+	// The cache TTL is capped at the configured maxCacheTTL. If not
+	// configured, the entry TTL will always be used.
+	cacheTTL := ttl
+	if ns.maxCacheTTL != nil && cacheTTL > *ns.maxCacheTTL {
+		cacheTTL = *ns.maxCacheTTL
+	}
+	cacheEOL := time.Now().Add(cacheTTL)
+
 	// Add automatically evicts previous entry, so it works for updating.
 	ns.cache.Add(name, cacheEntry{
 		val:      val,
 		ttl:      ttl,
 		lastMod:  lastMod,
-		cacheEOL: time.Now().Add(ttl),
+		cacheEOL: cacheEOL,
 	})
 }
 


### PR DESCRIPTION
Boxo part of #545.

I want to note that this TTL does not apply to DNS **ONLY** because the DNSResolver does not provide TTL values. It's important to note that the Namesys cache is oblivious regarding which resolver is backing it. In practice, it only caches IPNS records.

Kubo https://github.com/ipfs/kubo/pull/10321