### PR TITLE
routing/http/client: avoid race by not using global http.Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The following emojis are used to highlight certain changes:
 
 - 🛠 `boxo/gateway`: when making a trustless CAR request with the "entity-bytes" parameter, using a negative index greater than the underlying entity length could trigger reading more data than intended
 - 🛠 `boxo/gateway`: the header configuration `Config.Headers` and `AddAccessControlHeaders` has been replaced by the new middleware provided by `NewHeaders`.
+- 🛠 `routing/http/client`: a potential race condition has been fixed when creating multiple clients within the same process. With this change, `WithHTTPClient` and `WithUserAgent` will no longer work with each other. If you use your custom HTTP Client, you are also responsible for configuring the user agent that it uses.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ The following emojis are used to highlight certain changes:
 
 - 🛠 `boxo/gateway`: when making a trustless CAR request with the "entity-bytes" parameter, using a negative index greater than the underlying entity length could trigger reading more data than intended
 - 🛠 `boxo/gateway`: the header configuration `Config.Headers` and `AddAccessControlHeaders` has been replaced by the new middleware provided by `NewHeaders`.
-- 🛠 `routing/http/client`: a potential race condition has been fixed when creating multiple clients within the same process. With this change, `WithHTTPClient` and `WithUserAgent` may not always work with each other. More details can be found in the documentation.
+- 🛠 `routing/http/client`: the default HTTP client is no longer a global singleton. Therefore, using `WithUserAgent` won't modify the user agent of existing routing clients. This will also prevent potential race conditions. In addition, incompatible options will now return errors instead of silently failing.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ The following emojis are used to highlight certain changes:
 
 - 🛠 `boxo/gateway`: when making a trustless CAR request with the "entity-bytes" parameter, using a negative index greater than the underlying entity length could trigger reading more data than intended
 - 🛠 `boxo/gateway`: the header configuration `Config.Headers` and `AddAccessControlHeaders` has been replaced by the new middleware provided by `NewHeaders`.
-- 🛠 `routing/http/client`: a potential race condition has been fixed when creating multiple clients within the same process. With this change, `WithHTTPClient` and `WithUserAgent` will no longer work with each other. If you use your custom HTTP Client, you are also responsible for configuring the user agent that it uses.
+- 🛠 `routing/http/client`: a potential race condition has been fixed when creating multiple clients within the same process. With this change, `WithHTTPClient` and `WithUserAgent` may not always work with each other. More details can be found in the documentation.
 
 ### Security
 

--- a/routing/http/client/client.go
+++ b/routing/http/client/client.go
@@ -91,9 +91,12 @@ func WithHTTPClient(h httpClient) Option {
 	}
 }
 
-// WithUserAgent sets a custom user agent to use with the HTTP Client. This only
-// works if using a [http.Client] with a [ResponseBodyLimitedTransport] set as its
-// transport. Otherwise, an error will be returned.
+// WithUserAgent sets a custom user agent to use with the HTTP Client. This modifies
+// the underlying [http.Client]. Therefore, you should not use the same HTTP Client
+// with multiple routing clients.
+//
+// This only works if using a [http.Client] with a [ResponseBodyLimitedTransport]
+// set as its transport. Otherwise, an error will be returned.
 func WithUserAgent(ua string) Option {
 	return func(c *Client) error {
 		if ua == "" {

--- a/routing/http/client/client_test.go
+++ b/routing/http/client/client_test.go
@@ -109,11 +109,10 @@ func makeTestDeps(t *testing.T, clientsOpts []Option, serverOpts []server.Option
 	server := httptest.NewServer(recordingHandler)
 	t.Cleanup(server.Close)
 	serverAddr := "http://" + server.Listener.Addr().String()
-	recordingHTTPClient := &recordingHTTPClient{httpClient: defaultHTTPClient}
+	recordingHTTPClient := &recordingHTTPClient{httpClient: newDefaultHTTPClient(testUserAgent)}
 	defaultClientOpts := []Option{
 		WithProviderInfo(peerID, addrs),
 		WithIdentity(identity),
-		WithUserAgent(testUserAgent),
 		WithHTTPClient(recordingHTTPClient),
 	}
 	c, err := New(serverAddr, append(defaultClientOpts, clientsOpts...)...)


### PR DESCRIPTION
Fixes the race condition observed in the tests in https://github.com/ipfs/rainbow/pull/87.

It could've been fixed in rainbow, but that doesn't fix the source issue: we use the same global default HTTP client, while giving an option that can override its user agent. This option changes the user agent of the global variable, which may be used by multiple clients.

In addition, I updated the tests and documentations to reflect how `WithUserAgent` and `WithHTTPClient` work. The tests were passing until now by mistake and only because we were using the **global** `defaultHTTPClient `.