### PR TITLE
bitswap/network: split Routing in two in interface

### DIFF
--- a/bitswap/network/interface.go
+++ b/bitswap/network/interface.go
@@ -49,7 +49,11 @@ type BitSwapNetwork interface {
 
 	Stats() Stats
 
-	Routing
+	// FindProvidersAsync returns a channel of providers for the given key.
+	FindProvidersAsync(context.Context, cid.Cid, int) <-chan peer.ID
+
+	// Provide provides the key to the network.
+	Provide(context.Context, cid.Cid) error
 
 	Pinger
 }


### PR DESCRIPTION
This change does nothing, the reason it exists is because two different branches want to independently remove methods from this interface, this decouple the two methods allowing to do so without git conflicts.