### PR TITLE
ipns: fix test by using global random reader

### DIFF
--- a/ipns/record_test.go
+++ b/ipns/record_test.go
@@ -2,6 +2,7 @@ package ipns
 
 import (
 	"bytes"
+	"crypto/rand"
 	"testing"
 	"time"
 
@@ -30,8 +31,7 @@ func init() {
 }
 
 func mustKeyPair(t *testing.T, typ int) (ic.PrivKey, ic.PubKey, Name) {
-	sr := util.NewTimeSeededRand()
-	sk, pk, err := ic.GenerateKeyPairWithReader(typ, 2048, sr)
+	sk, pk, err := ic.GenerateKeyPairWithReader(typ, 2048, rand.Reader)
 	require.NoError(t, err)
 
 	pid, err := peer.IDFromPublicKey(pk)


### PR DESCRIPTION
I think this may fix the test that was intermittently failing on Windows. By using the global `crypto/rand.Reader` we avoid creating two different random generators seeded with the same time, and therefore likely generating the same key.