### PR TITLE
feat: basic support for Ipfs-Path-Affinity from IPIP-462

### DIFF
--- a/.github/workflows/gateway-sharness.yml
+++ b/.github/workflows/gateway-sharness.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Checkout boxo
         uses: actions/checkout@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The following emojis are used to highlight certain changes:
 ### Added
 
 * `routing/http/server` now adds `Cache-Control` HTTP header to GET requests: 15 seconds for empty responses, or 5 minutes for responses with providers.
+* `gateway` now supports optional `Ipfs-Path-Affinity` hints from [IPIP-462](https://github.com/ipfs/specs/pull/462).
 
 ### Changed
 


### PR DESCRIPTION
This PR aims to kick-off discussion how we would support [IPIP-462](https://github.com/ipfs/specs/pull/462) in `boxo/gateway`. 

For more info and header semantics, see https://github.com/ipfs/specs/pull/462

## proposed scope

What I want to do for now is to add minimal code to start leveraging `Ipfs-Path-Affinity` hints within existing `boxo/gateway` codebase, so we cna deploy it to our gateways and allow clients like [service-worker-gateway](https://github.com/ipfs-shipyard/helia-service-worker-gateway) or [ipfs-chromium](https://github.com/little-bear-labs/ipfs-chromium) to pass hint and retrieve content even when internal CID was not announced directly.


- [x] support percent-encoded values
- [x] limit to 3 hints per request 
- [x] cancel work if original request finished
- [x] skip work that would not produce any benefit in routing (if path from hint is already cached it won't trigger any additional provider lookups)

## future scope

We may formalize this by extending `IPFSBackend` with explicit place to pass this hint, and then wire it up into routing system of Kubo, but it feels more involved and would like to do that in follow-up, rather than block on it here.  