### PR TITLE
fix(routing): return 404 when no record is found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
+* `routing/http/server` now returns 404 Status Not Found when no records can be found.
+
 ### Security
 
 ## [v0.19.0]

--- a/routing/http/server/server.go
+++ b/routing/http/server/server.go
@@ -546,6 +546,10 @@ func writeJSONResult(w http.ResponseWriter, method string, val interface{ Length
 }
 
 func writeErr(w http.ResponseWriter, method string, statusCode int, cause error) {
+	if errors.Is(cause, routing.ErrNotFound) {
+		setCacheControl(w, maxAgeWithoutResults, maxStale)
+	}
+
 	w.WriteHeader(statusCode)
 	causeStr := cause.Error()
 	if len(causeStr) > 1024 {


### PR DESCRIPTION
Addresses https://github.com/ipfs/someguy/issues/58.

Sets 404 if the router returns `routing.ErrNotFound` or if the list of providers is empty.