### PR TITLE
bitswap/server: allow overriding peer ledger with WithPeerLedger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ The following emojis are used to highlight certain changes:
   * `NewRemoteCarBackend` allows you to create a gateway backend that uses one or multiple Trustless Gateways as backend. These gateways must support CAR requests (`application/vnd.ipld.car`), as well as the extensions describe in [IPIP-402](https://specs.ipfs.tech/ipips/ipip-0402/). With this, we also introduced `NewCarBackend`, `NewRemoteCarFetcher` and `NewRetryCarFetcher`.
 * `gateway` now sets the [`Content-Location`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Location) header for requests with non-default content format, as a result of content negotiation. This allows generic and misconfigured HTTP caches to store Deserialized, CAR and Block responses separately, under distinct cache keys.
 * `gateway` now supports `car-dups`, `car-order` and `car-version` as query parameters in addition to the `application/vnd.ipld.car` parameters sent via `Accept` header. The parameters in the `Accept` header have always priority, but including them in URL simplifies HTTP caching and allows use in `Content-Location` header on CAR responses to maximize interoperability with wide array of HTTP caches.
-
+* `bitswap/server` now has two new options: `WithNotifyNewBlocks` and `WithNoPeerLedger` to allow disabling notifying new blocks and the usage of the peer ledger, respectively.
+ 
 ### Changed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The following emojis are used to highlight certain changes:
   * `NewRemoteCarBackend` allows you to create a gateway backend that uses one or multiple Trustless Gateways as backend. These gateways must support CAR requests (`application/vnd.ipld.car`), as well as the extensions describe in [IPIP-402](https://specs.ipfs.tech/ipips/ipip-0402/). With this, we also introduced `NewCarBackend`, `NewRemoteCarFetcher` and `NewRetryCarFetcher`.
 * `gateway` now sets the [`Content-Location`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Location) header for requests with non-default content format, as a result of content negotiation. This allows generic and misconfigured HTTP caches to store Deserialized, CAR and Block responses separately, under distinct cache keys.
 * `gateway` now supports `car-dups`, `car-order` and `car-version` as query parameters in addition to the `application/vnd.ipld.car` parameters sent via `Accept` header. The parameters in the `Accept` header have always priority, but including them in URL simplifies HTTP caching and allows use in `Content-Location` header on CAR responses to maximize interoperability with wide array of HTTP caches.
-* `bitswap/server` now has two new options: `WithNotifyNewBlocks` and `WithNoPeerLedger` to allow disabling notifying new blocks and the usage of the peer ledger, respectively.
+* `bitswap/server` now allows to override the default peer ledger with `WithPeerLedger`.
  
 ### Changed
 

--- a/bitswap/options.go
+++ b/bitswap/options.go
@@ -55,6 +55,10 @@ func WithNotifyNewBlocks(notify bool) Option {
 	return Option{server.WithNotifyNewBlocks(notify)}
 }
 
+func WithNoPeerLedger() Option {
+	return Option{server.WithNoPeerLedger()}
+}
+
 func WithPeerBlockRequestFilter(pbrf server.PeerBlockRequestFilter) Option {
 	return Option{server.WithPeerBlockRequestFilter(pbrf)}
 }

--- a/bitswap/options.go
+++ b/bitswap/options.go
@@ -51,6 +51,10 @@ func SetSendDontHaves(send bool) Option {
 	return Option{server.SetSendDontHaves(send)}
 }
 
+func WithNotifyNewBlocks(notify bool) Option {
+	return Option{server.WithNotifyNewBlocks(notify)}
+}
+
 func WithPeerBlockRequestFilter(pbrf server.PeerBlockRequestFilter) Option {
 	return Option{server.WithPeerBlockRequestFilter(pbrf)}
 }

--- a/bitswap/options.go
+++ b/bitswap/options.go
@@ -51,20 +51,16 @@ func SetSendDontHaves(send bool) Option {
 	return Option{server.SetSendDontHaves(send)}
 }
 
-func WithNotifyNewBlocks(notify bool) Option {
-	return Option{server.WithNotifyNewBlocks(notify)}
-}
-
-func WithNoPeerLedger() Option {
-	return Option{server.WithNoPeerLedger()}
-}
-
 func WithPeerBlockRequestFilter(pbrf server.PeerBlockRequestFilter) Option {
 	return Option{server.WithPeerBlockRequestFilter(pbrf)}
 }
 
 func WithScoreLedger(scoreLedger server.ScoreLedger) Option {
 	return Option{server.WithScoreLedger(scoreLedger)}
+}
+
+func WithPeerLedger(peerLedger server.PeerLedger) Option {
+	return Option{server.WithPeerLedger(peerLedger)}
 }
 
 func WithTargetMessageSize(tms int) Option {

--- a/bitswap/server/forward.go
+++ b/bitswap/server/forward.go
@@ -11,4 +11,6 @@ type (
 	TaskInfo               = decision.TaskInfo
 	ScoreLedger            = decision.ScoreLedger
 	ScorePeerFunc          = decision.ScorePeerFunc
+	PeerLedger             = decision.PeerLedger
+	PeerEntry              = decision.PeerEntry
 )

--- a/bitswap/server/internal/decision/peer_ledger.go
+++ b/bitswap/server/internal/decision/peer_ledger.go
@@ -8,20 +8,20 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
-type peerLedger struct {
-	// thoses two maps are inversions of each other
+type DefaultPeerLedger struct {
+	// these two maps are inversions of each other
 	peers map[peer.ID]map[cid.Cid]entry
 	cids  map[cid.Cid]map[peer.ID]entry
 }
 
-func newPeerLedger() *peerLedger {
-	return &peerLedger{
+func NewDefaultPeerLedger() *DefaultPeerLedger {
+	return &DefaultPeerLedger{
 		peers: make(map[peer.ID]map[cid.Cid]entry),
 		cids:  make(map[cid.Cid]map[peer.ID]entry),
 	}
 }
 
-func (l *peerLedger) Wants(p peer.ID, e wl.Entry) {
+func (l *DefaultPeerLedger) Wants(p peer.ID, e wl.Entry) {
 	cids, ok := l.peers[p]
 	if !ok {
 		cids = make(map[cid.Cid]entry)
@@ -37,8 +37,7 @@ func (l *peerLedger) Wants(p peer.ID, e wl.Entry) {
 	m[p] = entry{e.Priority, e.WantType}
 }
 
-// CancelWant returns true if the cid was present in the wantlist.
-func (l *peerLedger) CancelWant(p peer.ID, k cid.Cid) bool {
+func (l *DefaultPeerLedger) CancelWant(p peer.ID, k cid.Cid) bool {
 	wants, ok := l.peers[p]
 	if !ok {
 		return false
@@ -52,8 +51,7 @@ func (l *peerLedger) CancelWant(p peer.ID, k cid.Cid) bool {
 	return true
 }
 
-// CancelWantWithType will not cancel WantBlock if we sent a HAVE message.
-func (l *peerLedger) CancelWantWithType(p peer.ID, k cid.Cid, typ pb.Message_Wantlist_WantType) {
+func (l *DefaultPeerLedger) CancelWantWithType(p peer.ID, k cid.Cid, typ pb.Message_Wantlist_WantType) {
 	wants, ok := l.peers[p]
 	if !ok {
 		return
@@ -74,7 +72,7 @@ func (l *peerLedger) CancelWantWithType(p peer.ID, k cid.Cid, typ pb.Message_Wan
 	l.removePeerFromCid(p, k)
 }
 
-func (l *peerLedger) removePeerFromCid(p peer.ID, k cid.Cid) {
+func (l *DefaultPeerLedger) removePeerFromCid(p peer.ID, k cid.Cid) {
 	m, ok := l.cids[k]
 	if !ok {
 		return
@@ -85,29 +83,28 @@ func (l *peerLedger) removePeerFromCid(p peer.ID, k cid.Cid) {
 	}
 }
 
-type entryForPeer struct {
-	Peer peer.ID
-	entry
-}
-
 type entry struct {
 	Priority int32
 	WantType pb.Message_Wantlist_WantType
 }
 
-func (l *peerLedger) Peers(k cid.Cid) []entryForPeer {
+func (l *DefaultPeerLedger) Peers(k cid.Cid) []PeerEntry {
 	m, ok := l.cids[k]
 	if !ok {
 		return nil
 	}
-	peers := make([]entryForPeer, 0, len(m))
+	peers := make([]PeerEntry, 0, len(m))
 	for p, e := range m {
-		peers = append(peers, entryForPeer{p, e})
+		peers = append(peers, PeerEntry{
+			Peer:     p,
+			Priority: e.Priority,
+			WantType: e.WantType,
+		})
 	}
 	return peers
 }
 
-func (l *peerLedger) CollectPeerIDs() []peer.ID {
+func (l *DefaultPeerLedger) CollectPeerIDs() []peer.ID {
 	peers := make([]peer.ID, 0, len(l.peers))
 	for p := range l.peers {
 		peers = append(peers, p)
@@ -115,11 +112,11 @@ func (l *peerLedger) CollectPeerIDs() []peer.ID {
 	return peers
 }
 
-func (l *peerLedger) WantlistSizeForPeer(p peer.ID) int {
+func (l *DefaultPeerLedger) WantlistSizeForPeer(p peer.ID) int {
 	return len(l.peers[p])
 }
 
-func (l *peerLedger) WantlistForPeer(p peer.ID) []wl.Entry {
+func (l *DefaultPeerLedger) WantlistForPeer(p peer.ID) []wl.Entry {
 	cids, ok := l.peers[p]
 	if !ok {
 		return nil
@@ -139,7 +136,7 @@ func (l *peerLedger) WantlistForPeer(p peer.ID) []wl.Entry {
 // ClearPeerWantlist does not take an effort to fully erase it from memory.
 // This is intended when the peer is still connected and the map capacity could
 // be reused. If the memory should be freed use PeerDisconnected instead.
-func (l *peerLedger) ClearPeerWantlist(p peer.ID) {
+func (l *DefaultPeerLedger) ClearPeerWantlist(p peer.ID) {
 	cids, ok := l.peers[p]
 	if !ok {
 		return
@@ -150,7 +147,7 @@ func (l *peerLedger) ClearPeerWantlist(p peer.ID) {
 	}
 }
 
-func (l *peerLedger) PeerDisconnected(p peer.ID) {
+func (l *DefaultPeerLedger) PeerDisconnected(p peer.ID) {
 	l.ClearPeerWantlist(p)
 	delete(l.peers, p)
 }

--- a/bitswap/server/server.go
+++ b/bitswap/server/server.go
@@ -161,6 +161,14 @@ func WithScoreLedger(scoreLedger decision.ScoreLedger) Option {
 	}
 }
 
+// WithNotifyNewBlocks configures the engine with [decision.WithNotifyNewBlocks].
+func WithNotifyNewBlocks(notify bool) Option {
+	o := decision.WithNotifyNewBlocks(notify)
+	return func(bs *Server) {
+		bs.engineOptions = append(bs.engineOptions, o)
+	}
+}
+
 // LedgerForPeer returns aggregated data about blocks swapped and communication
 // with a given peer.
 func (bs *Server) LedgerForPeer(p peer.ID) *decision.Receipt {

--- a/bitswap/server/server.go
+++ b/bitswap/server/server.go
@@ -161,17 +161,9 @@ func WithScoreLedger(scoreLedger decision.ScoreLedger) Option {
 	}
 }
 
-// WithNotifyNewBlocks configures the engine with [decision.WithNotifyNewBlocks].
-func WithNotifyNewBlocks(notify bool) Option {
-	o := decision.WithNotifyNewBlocks(notify)
-	return func(bs *Server) {
-		bs.engineOptions = append(bs.engineOptions, o)
-	}
-}
-
-// WithNoPeerLedger configures the engine with [decision.WithNoPeerLedger].
-func WithNoPeerLedger() Option {
-	o := decision.WithNoPeerLedger()
+// WithPeerLedger configures the engine with a custom [decision.PeerLedger].
+func WithPeerLedger(peerLedger decision.PeerLedger) Option {
+	o := decision.WithPeerLedger(peerLedger)
 	return func(bs *Server) {
 		bs.engineOptions = append(bs.engineOptions, o)
 	}

--- a/bitswap/server/server.go
+++ b/bitswap/server/server.go
@@ -169,6 +169,14 @@ func WithNotifyNewBlocks(notify bool) Option {
 	}
 }
 
+// WithNoPeerLedger configures the engine with [decision.WithNoPeerLedger].
+func WithNoPeerLedger() Option {
+	o := decision.WithNoPeerLedger()
+	return func(bs *Server) {
+		bs.engineOptions = append(bs.engineOptions, o)
+	}
+}
+
 // LedgerForPeer returns aggregated data about blocks swapped and communication
 // with a given peer.
 func (bs *Server) LedgerForPeer(p peer.ID) *decision.Receipt {


### PR DESCRIPTION
Introduces `WithPeerLedger`, which allows to override the default peer ledger with anything else you want.