### PR TITLE
fix: delegated routing of legacy RSA peerids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The following emojis are used to highlight certain changes:
 ### Fixed
 
 * `routing/http/server` now returns 404 Status Not Found when no records can be found.
+* `routing/http/server` now supports legacy RSA PeerIDs encoded as Base58 Multihash
 
 ### Security
 


### PR DESCRIPTION
This PR continues work from https://github.com/ipfs/boxo/pull/585 which fixed support for ED25519 as BAse58. Here, we add correct support for RSA PeerIDs.

I also added test matrix for all PeerID variants versions to ensure we don't regress.

After this is merged, `/routing/v1/peers` endpoint will accept all variants of PeerIDs we see in the wild.


Namely:

- cidv1-libp2p-key-ed25519-peerid
- base58-ed25519-peerid
- cidv1-libp2p-key-rsa-peerid
- base58-rsa-peerid

@hacdias if this looks good, mind bubbling up to Someguy, and making new release, and deploying to https://delegated-ipfs.dev/?