### PR TITLE
fix(routing/http/contentrouter):  additional FindPeer checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
+- The HTTP content router now returns routing.ErrNotFound when no addresses are found
+
 ### Security
 
 ## [v0.20.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
-- The HTTP content router now returns routing.ErrNotFound when no addresses are found
+- `routing/http/contentrouter` The `FindPeer` now returns `routing.ErrNotFound` when no addresses are found
 
 ### Security
 

--- a/routing/http/contentrouter/contentrouter.go
+++ b/routing/http/contentrouter/contentrouter.go
@@ -214,6 +214,11 @@ func (c *contentRouter) FindPeer(ctx context.Context, pid peer.ID) (peer.AddrInf
 			addrs = append(addrs, a.Multiaddr)
 		}
 
+		// If there are no addresses there's nothing of value to return
+		if len(addrs) == 0 {
+			continue
+		}
+
 		return peer.AddrInfo{
 			ID:    pid,
 			Addrs: addrs,

--- a/routing/http/contentrouter/contentrouter.go
+++ b/routing/http/contentrouter/contentrouter.go
@@ -200,7 +200,7 @@ func (c *contentRouter) FindPeer(ctx context.Context, pid peer.ID) (peer.AddrInf
 	for iter.Next() {
 		res := iter.Val()
 		if res.Err != nil {
-			logger.Warnw("error iterating provider responses: %s", res.Err)
+			logger.Warnw("error iterating peer responses: %s", res.Err)
 			continue
 		}
 		var addrs []multiaddr.Multiaddr

--- a/routing/http/contentrouter/contentrouter.go
+++ b/routing/http/contentrouter/contentrouter.go
@@ -119,7 +119,7 @@ func readProviderResponses(ctx context.Context, iter iter.ResultIter[types.Recor
 	for iter.Next() {
 		res := iter.Val()
 		if res.Err != nil {
-			logger.Warnw("error iterating provider responses: %s", res.Err)
+			logger.Warnf("error iterating provider responses: %s", res.Err)
 			continue
 		}
 		v := res.Val
@@ -200,12 +200,12 @@ func (c *contentRouter) FindPeer(ctx context.Context, pid peer.ID) (peer.AddrInf
 	for iter.Next() {
 		res := iter.Val()
 		if res.Err != nil {
-			logger.Warnw("error iterating peer responses: %s", res.Err)
+			logger.Warnf("error iterating peer responses: %s", res.Err)
 			continue
 		}
 
 		if *res.Val.ID != pid {
-			logger.Warnw("searched for peerID %s, got response for %s:", pid, *res.Val.ID)
+			logger.Warnf("searched for peerID %s, got response for %s:", pid, *res.Val.ID)
 			continue
 		}
 

--- a/routing/http/contentrouter/contentrouter.go
+++ b/routing/http/contentrouter/contentrouter.go
@@ -203,13 +203,19 @@ func (c *contentRouter) FindPeer(ctx context.Context, pid peer.ID) (peer.AddrInf
 			logger.Warnw("error iterating peer responses: %s", res.Err)
 			continue
 		}
+
+		if *res.Val.ID != pid {
+			logger.Warnw("searched for peerID %s, got response for %s:", pid, *res.Val.ID)
+			continue
+		}
+
 		var addrs []multiaddr.Multiaddr
 		for _, a := range res.Val.Addrs {
 			addrs = append(addrs, a.Multiaddr)
 		}
 
 		return peer.AddrInfo{
-			ID:    *res.Val.ID,
+			ID:    pid,
 			Addrs: addrs,
 		}, nil
 	}

--- a/routing/http/contentrouter/contentrouter.go
+++ b/routing/http/contentrouter/contentrouter.go
@@ -214,7 +214,7 @@ func (c *contentRouter) FindPeer(ctx context.Context, pid peer.ID) (peer.AddrInf
 		}, nil
 	}
 
-	return peer.AddrInfo{}, err
+	return peer.AddrInfo{}, routing.ErrNotFound
 }
 
 func (c *contentRouter) PutValue(ctx context.Context, key string, data []byte, opts ...routing.Option) error {

--- a/routing/http/contentrouter/contentrouter_test.go
+++ b/routing/http/contentrouter/contentrouter_test.go
@@ -199,6 +199,27 @@ func TestFindPeer(t *testing.T) {
 	require.Equal(t, peer.ID, p1)
 }
 
+func TestFindPeerWrongPeer(t *testing.T) {
+	ctx := context.Background()
+	client := &mockClient{}
+	crc := NewContentRoutingClient(client)
+
+	p1 := peer.ID("peer1")
+	p2 := peer.ID("peer2")
+	ais := []*types.PeerRecord{
+		{
+			Schema: types.SchemaPeer,
+			ID:     &p2,
+		},
+	}
+	aisIter := iter.ToResultIter[*types.PeerRecord](iter.FromSlice(ais))
+
+	client.On("FindPeers", ctx, p1).Return(aisIter, nil)
+
+	_, err := crc.FindPeer(ctx, p1)
+	require.ErrorIs(t, err, routing.ErrNotFound)
+}
+
 func TestFindPeerNoPeer(t *testing.T) {
 	ctx := context.Background()
 	client := &mockClient{}

--- a/routing/http/contentrouter/contentrouter_test.go
+++ b/routing/http/contentrouter/contentrouter_test.go
@@ -199,6 +199,20 @@ func TestFindPeer(t *testing.T) {
 	require.Equal(t, peer.ID, p1)
 }
 
+func TestFindPeerNoPeer(t *testing.T) {
+	ctx := context.Background()
+	client := &mockClient{}
+	crc := NewContentRoutingClient(client)
+
+	p1 := peer.ID("peer1")
+	aisIter := iter.ToResultIter[*types.PeerRecord](iter.FromSlice([]*types.PeerRecord{}))
+
+	client.On("FindPeers", ctx, p1).Return(aisIter, nil)
+
+	_, err := crc.FindPeer(ctx, p1)
+	require.ErrorIs(t, err, routing.ErrNotFound)
+}
+
 func makeName(t *testing.T) (crypto.PrivKey, ipns.Name) {
 	sk, _, err := crypto.GenerateEd25519Key(rand.Reader)
 	require.NoError(t, err)


### PR DESCRIPTION
<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->

Noticed a few issues while doing some tracing (e.g. errors not being returned when no data was returned) that caused me to look a little closer here.