### PR TITLE
fix(bitswap): wantlist overflow handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ The following emojis are used to highlight certain changes:
 
 - `routing/http`: the `FindPeer` now returns `routing.ErrNotFound` when no addresses are found
 - `routing/http`: the `FindProvidersAsync` no longer causes a goroutine buildup
-- bitswap wantlist overflow handling now cancels existing entries to make room for newer entries. This fix prevents the wantlist from filling up with CIDs that the server does not have.
+- `bitswap`: wantlist overflow handling now cancels existing entries to make room for newer entries. This fix prevents the wantlist from filling up with CIDs that the server does not have.
 
 ## [v0.20.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ The following emojis are used to highlight certain changes:
 ### Changed
 
 - `boxo/gateway` is now tested against [gateway-conformance v6](https://github.com/ipfs/gateway-conformance/releases/tag/v0.6.0)
-- `bitswap/client` supports additional tracing 
+- `bitswap/client` supports additional tracing
 
 ### Removed
 
@@ -41,6 +41,7 @@ The following emojis are used to highlight certain changes:
 
 - `routing/http`: the `FindPeer` now returns `routing.ErrNotFound` when no addresses are found
 - `routing/http`: the `FindProvidersAsync` no longer causes a goroutine buildup
+- bitswap wantlist overflow handling now cancels existing entries to make room for newer entries. This fix prevents the wantlist from filling up with CIDs that the server does not have.
 
 ## [v0.20.0]
 

--- a/bitswap/client/internal/messagequeue/messagequeue_test.go
+++ b/bitswap/client/internal/messagequeue/messagequeue_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
 )
 
-const collectTimeout = 100 * time.Millisecond
+const collectTimeout = 200 * time.Millisecond
 
 type fakeMessageNetwork struct {
 	connectError       error

--- a/bitswap/server/internal/decision/engine.go
+++ b/bitswap/server/internal/decision/engine.go
@@ -316,8 +316,11 @@ func WithMaxOutstandingBytesPerPeer(count int) Option {
 	}
 }
 
-// WithMaxQueuedWantlistEntriesPerPeer limits how much individual entries each peer is allowed to send.
-// If a peer send us more than this we will truncate newest entries.
+// WithMaxQueuedWantlistEntriesPerPeer limits how many individual entries each
+// peer is allowed to send. If a peer sends more than this, then the lowest
+// priority entries are truncated to this limit. If there is insufficient space
+// to enqueue new entries, then older existing wants with no associated blocks,
+// and lower priority wants, are canceled to make room for the new wants.
 func WithMaxQueuedWantlistEntriesPerPeer(count uint) Option {
 	return func(e *Engine) {
 		e.maxQueuedWantlistEntriesPerPeer = count

--- a/bitswap/server/internal/decision/engine.go
+++ b/bitswap/server/internal/decision/engine.go
@@ -133,6 +133,8 @@ type PeerEntry struct {
 // PeerLedger is an external ledger dealing with peers and their want lists.
 type PeerLedger interface {
 	// Wants informs the ledger that [peer.ID] wants [wl.Entry].
+	// If peer ledger exceed internal limit, then the entry is not added
+	// and false is returned.
 	Wants(p peer.ID, e wl.Entry) bool
 
 	// CancelWant returns true if the [cid.Cid] was removed from the wantlist of [peer.ID].

--- a/bitswap/server/internal/decision/engine.go
+++ b/bitswap/server/internal/decision/engine.go
@@ -741,7 +741,7 @@ func (e *Engine) MessageReceived(ctx context.Context, p peer.ID, m bsmsg.BitSwap
 			if e.peerLedger.CancelWant(p, entCid) {
 				e.peerRequestQueue.Remove(entCid, p)
 			}
-			e.peerLedger.Wants(p, entry.Entry, int(e.maxQueuedWantlistEntriesPerPeer))
+			e.peerLedger.Wants(p, entry.Entry, 0)
 			wants = append(wants, entry)
 		}
 	}
@@ -834,50 +834,6 @@ func (e *Engine) MessageReceived(ctx context.Context, p peer.ID, m bsmsg.BitSwap
 	}
 	return false
 }
-
-/*
-
-		// Ensure sufficient space for new wants.
-		s := e.peerLedger.WantlistSizeForPeer(p)
-		available := int(e.maxQueuedWantlistEntriesPerPeer) - s
-		if len(wants) > available {
-			needSpace := len(wants) - available
-			log.Debugw("wantlist overflow", "local", e.self, "remote", p, "would be", s+len(wants), "canceling", needSpace)
-			// Cancel any wants that are being requested again. This makes room
-			// for new wants and minimizes that existing wants to cancel that
-			// are not in the new request.
-			for _, entry := range wants {
-				if e.peerLedger.CancelWant(p, entry.Cid) {
-					e.peerRequestQueue.Remove(entry.Cid, p)
-					needSpace--
-					if needSpace == 0 {
-						break
-					}
-				}
-			}
-			// Cancel additional wants, that are not being replaced, to make
-			// room for new wants.
-			if needSpace != 0 {
-				wl := e.peerLedger.WantlistForPeer(p)
-				for i := range wl {
-					entCid := wl[i].Cid
-					if e.peerLedger.CancelWant(p, entCid) {
-						e.peerRequestQueue.Remove(entCid, p)
-						needSpace--
-						if needSpace == 0 {
-							break
-						}
-					}
-				}
-			}
-		}
-
-		for _, entry := range wants {
-			e.peerLedger.Wants(p, entry.Entry)
-		}
-	}
-
-*/
 
 // Split the want-havek entries from the cancel and deny entries.
 func (e *Engine) splitWantsCancelsDenials(p peer.ID, m bsmsg.BitSwapMessage) ([]bsmsg.Entry, []bsmsg.Entry, []bsmsg.Entry, error) {

--- a/bitswap/server/internal/decision/engine_test.go
+++ b/bitswap/server/internal/decision/engine_test.go
@@ -1863,7 +1863,7 @@ func TestWantlistOverflow(t *testing.T) {
 	if len(wl) != limit {
 		t.Fatal("wantlist size", len(wl), "does not match limit", limit)
 	}
-	t.Log("Senr message with", limit, "medium-priority wants and", limit-1, "have blocks present")
+	t.Log("Sent message with", limit, "medium-priority wants and", limit-1, "have blocks present")
 
 	m = message.New(false)
 	lowPrioCids := make([]cid.Cid, 5)

--- a/bitswap/server/internal/decision/engine_test.go
+++ b/bitswap/server/internal/decision/engine_test.go
@@ -1733,3 +1733,61 @@ func TestKillConnectionForInlineCid(t *testing.T) {
 		t.Fatal("connection was not killed when receiving inline in cancel")
 	}
 }
+
+func TestWantlistOverflow(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const limit = 32
+	warsaw := newTestEngine(ctx, "warsaw", WithMaxQueuedWantlistEntriesPerPeer(limit))
+	riga := newTestEngine(ctx, "riga")
+
+	m := message.New(false)
+	for i := 0; i < limit+(limit/2); i++ {
+		m.AddEntry(blocks.NewBlock([]byte(fmt.Sprint(i))).Cid(), 0, pb.Message_Wantlist_Block, true)
+	}
+	warsaw.Engine.MessageReceived(ctx, riga.Peer, m)
+
+	if warsaw.Peer == riga.Peer {
+		t.Fatal("Sanity Check: Peers have same Key!")
+	}
+
+	// Check that the wantlist is at the size limit, and limit/2 wants ignored.
+	wl := warsaw.Engine.WantlistForPeer(riga.Peer)
+	if len(wl) != limit {
+		t.Fatal("wantlist does not match limit", len(wl))
+	}
+
+	m = message.New(false)
+	blockCids := make([]cid.Cid, limit/2+4)
+	for i := 0; i < limit/2+4; i++ {
+		c := blocks.NewBlock([]byte(fmt.Sprint(i + limit))).Cid()
+		m.AddEntry(c, 0, pb.Message_Wantlist_Block, true)
+		blockCids[i] = c
+	}
+	warsaw.Engine.MessageReceived(ctx, riga.Peer, m)
+	wl = warsaw.Engine.WantlistForPeer(riga.Peer)
+
+	// Check that wantlist is still at size limit.
+	if len(wl) != limit {
+		t.Fatalf("wantlist size %d does not match limit %d", len(wl), limit)
+	}
+
+	// Check that all new blocks are in wantlist.
+	var missing int
+	for _, c := range blockCids {
+		var found bool
+		for i := range wl {
+			if wl[i].Cid == c {
+				found = true
+				break
+			}
+		}
+		if !found {
+			missing++
+		}
+	}
+	if missing != 0 {
+		t.Fatalf("Missing %d new wants expected in wantlist", missing)
+	}
+}

--- a/bitswap/server/internal/decision/engine_test.go
+++ b/bitswap/server/internal/decision/engine_test.go
@@ -1764,7 +1764,6 @@ func TestWantlistOverflow(t *testing.T) {
 		Engine:     e,
 	}
 
-	//warsaw := newTestEngine(ctx, "warsaw", WithMaxQueuedWantlistEntriesPerPeer(limit))
 	riga := newTestEngine(ctx, "riga")
 	if warsaw.Peer == riga.Peer {
 		t.Fatal("Sanity Check: Peers have same Key!")
@@ -1805,7 +1804,7 @@ func TestWantlistOverflow(t *testing.T) {
 		}
 	}
 
-	// These 7 new wants should overflow and 5 ot them should replace existing
+	// These 7 new wants should overflow and 5 of them should replace existing
 	// wants that do not have blocks.
 	m = message.New(false)
 	blockCids := make([]cid.Cid, 7)

--- a/bitswap/server/internal/decision/peer_ledger.go
+++ b/bitswap/server/internal/decision/peer_ledger.go
@@ -42,13 +42,14 @@ func (l *DefaultPeerLedger) CancelWant(p peer.ID, k cid.Cid) bool {
 	if !ok {
 		return false
 	}
+	_, had := wants[k]
 	delete(wants, k)
 	if len(wants) == 0 {
 		delete(l.peers, p)
 	}
 
 	l.removePeerFromCid(p, k)
-	return true
+	return had
 }
 
 func (l *DefaultPeerLedger) CancelWantWithType(p peer.ID, k cid.Cid, typ pb.Message_Wantlist_WantType) {

--- a/bitswap/server/internal/decision/peer_ledger.go
+++ b/bitswap/server/internal/decision/peer_ledger.go
@@ -23,13 +23,13 @@ func NewDefaultPeerLedger() *DefaultPeerLedger {
 
 // Wants adds an entry to the peer ledger. If adding the entry would make the
 // peer ledger exceed the size limit, then the entry is not added and false is
-// returned.
+// returned. A limit of zero is ignored.
 func (l *DefaultPeerLedger) Wants(p peer.ID, e wl.Entry, limit int) bool {
 	cids, ok := l.peers[p]
 	if !ok {
 		cids = make(map[cid.Cid]entry)
 		l.peers[p] = cids
-	} else if len(cids) == limit {
+	} else if limit != 0 && len(cids) == limit {
 		if _, ok = cids[e.Cid]; !ok {
 			return false // cannot add to peer ledger
 		}


### PR DESCRIPTION
Handle incoming wants that can not be added to the peer ledger without exceeding the peer want limit. These are handled by trying to make room for them by canceling existing wants for which there is no block. If this does not make sufficient room, then any lower priority wants that have blocks are canceled. This fix prevents the wantlist from filling up with CIDs that the server does not have.

Priority is also considered when truncating a wantlist that exceeds the size limit. Considering priority in wantlist truncation and overflow handling ensures that higher priority tasks handled when wantlist size needs to be limited. This will be more important in the future if/when priority is determined by a block's dag path (higher priority when closer to root).

Fixes #527
