### PR TITLE
fix(gateway): ipld.ErrNotFound should result in a 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
-- `boxo/gateway` now returns 404 Status Not Found instead of 500 when the requested data cannot be found, without a fallback on bitswap or similar restriction.
+- `boxo/gateway` now correctly returns 404 Status Not Found instead of 500 when the requested content cannot be found due to offline exchange, gateway running in no-fetch (non-recursive) mode, or a similar restriction that only serves a specific set of CIDs.
 - `bitswap/client` fix memory leak in BlockPresenceManager due to unlimited map growth.
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
+- `boxo/gateway` now returns 404 Status Not Found instead of 500 when the requested data cannot be found, without a fallback on bitswap or similar restriction.
+
 ### Security
 
 ## [v0.21.0]

--- a/gateway/errors.go
+++ b/gateway/errors.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ipfs/boxo/path"
 	"github.com/ipfs/boxo/path/resolver"
 	"github.com/ipfs/go-cid"
+	ipld "github.com/ipfs/go-ipld-format"
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipld/go-ipld-prime/schema"
 )
@@ -223,6 +224,10 @@ func webError(w http.ResponseWriter, r *http.Request, c *Config, err error, defa
 // the wrong type, etc.), rather than issues with just finding and retrieving the data.
 func isErrNotFound(err error) bool {
 	if errors.Is(err, &resolver.ErrNoLink{}) || errors.Is(err, schema.ErrNoSuchField{}) {
+		return true
+	}
+
+	if ipld.IsNotFound(err) {
 		return true
 	}
 

--- a/gateway/errors.go
+++ b/gateway/errors.go
@@ -186,10 +186,10 @@ func webError(w http.ResponseWriter, r *http.Request, c *Config, err error, defa
 	switch {
 	case errors.Is(err, &cid.ErrInvalidCid{}):
 		code = http.StatusBadRequest
-	case isErrNotFound(err):
-		code = http.StatusNotFound
 	case isErrContentBlocked(err):
 		code = http.StatusGone
+	case isErrNotFound(err):
+		code = http.StatusNotFound
 	case errors.Is(err, context.DeadlineExceeded):
 		code = http.StatusGatewayTimeout
 	}

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -924,7 +924,7 @@ func TestErrorBubblingFromBackend(t *testing.T) {
 		})
 	}
 
-	testError("500 Not Found from IPLD", &ipld.ErrNotFound{}, http.StatusInternalServerError)
+	testError("404 Not Found from IPLD", &ipld.ErrNotFound{}, http.StatusNotFound)
 	testError("404 Not Found from path resolver", &resolver.ErrNoLink{}, http.StatusNotFound)
 	testError("502 Bad Gateway", ErrBadGateway, http.StatusBadGateway)
 	testError("504 Gateway Timeout", ErrGatewayTimeout, http.StatusGatewayTimeout)


### PR DESCRIPTION
Fix https://github.com/ipfs/boxo/issues/593

In case of blockstore restriction like with --offline or similar restriction, returning a 500 is inapropriate.

It's also going back to a previous gateway behavior (at least in kubo v0.22, possibly later).

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
