### PR TITLE
fix(bitswap): use unique logger name for MessageQueue

### DIFF
--- a/bitswap/client/internal/messagequeue/messagequeue.go
+++ b/bitswap/client/internal/messagequeue/messagequeue.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	log   = logging.Logger("bitswap")
+	log   = logging.Logger("bs:msgqueue")
 	sflog = log.Desugar()
 )
 


### PR DESCRIPTION
`bitwap` is already taken by the root pkg and there is no way to access the MessageQueue logger