### PR TITLE
refactor(bitswap): unify logger names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The following emojis are used to highlight certain changes:
 ### Changed
 
 - `bitswap/server` minor memory use and performance improvements
+- `bitswap` unify logger names to use uniform format bitswap/path/pkgname
 
 ### Removed
 

--- a/bitswap/client/client.go
+++ b/bitswap/client/client.go
@@ -38,7 +38,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-var log = logging.Logger("bitswap-client")
+var log = logging.Logger("bitswap/client")
 
 // Option defines the functional option type that can be used to configure
 // bitswap instances

--- a/bitswap/client/internal/getter/getter.go
+++ b/bitswap/client/internal/getter/getter.go
@@ -13,7 +13,7 @@ import (
 	ipld "github.com/ipfs/go-ipld-format"
 )
 
-var log = logging.Logger("bitswap")
+var log = logging.Logger("bitswap/client/getter")
 
 // GetBlocksFunc is any function that can take an array of CIDs and return a
 // channel of incoming blocks.

--- a/bitswap/client/internal/messagequeue/messagequeue.go
+++ b/bitswap/client/internal/messagequeue/messagequeue.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	log   = logging.Logger("bitswap")
+	log   = logging.Logger("bitswap/client/msgq")
 	sflog = log.Desugar()
 )
 

--- a/bitswap/client/internal/peermanager/peermanager.go
+++ b/bitswap/client/internal/peermanager/peermanager.go
@@ -11,7 +11,7 @@ import (
 	peer "github.com/libp2p/go-libp2p/core/peer"
 )
 
-var log = logging.Logger("bs:peermgr")
+var log = logging.Logger("bitswap/client/peermgr")
 
 // PeerQueue provides a queue of messages to be sent for a single peer.
 type PeerQueue interface {

--- a/bitswap/client/internal/providerquerymanager/providerquerymanager.go
+++ b/bitswap/client/internal/providerquerymanager/providerquerymanager.go
@@ -13,7 +13,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-var log = logging.Logger("bitswap")
+var log = logging.Logger("bitswap/client/provqrymgr")
 
 const (
 	maxProviders         = 10

--- a/bitswap/client/internal/session/session.go
+++ b/bitswap/client/internal/session/session.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	log   = logging.Logger("bs:sess")
+	log   = logging.Logger("bitswap/session")
 	sflog = log.Desugar()
 )
 

--- a/bitswap/client/internal/sessionpeermanager/sessionpeermanager.go
+++ b/bitswap/client/internal/sessionpeermanager/sessionpeermanager.go
@@ -9,7 +9,7 @@ import (
 	peer "github.com/libp2p/go-libp2p/core/peer"
 )
 
-var log = logging.Logger("bs:sprmgr")
+var log = logging.Logger("bitswap/client/sesspeermgr")
 
 const (
 	// Connection Manager tag value for session peers. Indicates to connection

--- a/bitswap/network/ipfs_impl.go
+++ b/bitswap/network/ipfs_impl.go
@@ -26,7 +26,7 @@ import (
 	"github.com/multiformats/go-multistream"
 )
 
-var log = logging.Logger("bitswap_network")
+var log = logging.Logger("bitswap/network")
 
 var connectTimeout = time.Second * 5
 

--- a/bitswap/server/internal/decision/engine.go
+++ b/bitswap/server/internal/decision/engine.go
@@ -60,7 +60,7 @@ import (
 // whatever it sees fit to produce desired outcomes (get wanted keys
 // quickly, maintain good relationships with peers, etc).
 
-var log = logging.Logger("engine")
+var log = logging.Logger("bitswap/server/decision")
 
 const (
 	// outboxChanBuffer must be 0 to prevent stale messages from being sent

--- a/bitswap/server/server.go
+++ b/bitswap/server/server.go
@@ -29,7 +29,7 @@ import (
 var provideKeysBufferSize = 2048
 
 var (
-	log   = logging.Logger("bitswap-server")
+	log   = logging.Logger("bitswap/server")
 	sflog = log.Desugar()
 )
 


### PR DESCRIPTION
Use uniform pattern for logger naming: bitswap/pkgname

Slash delimiters are used to separate path segments used in logger names. This follows the convention used most commonly in other parts of boxo.
