### PR TITLE
fix(gateway): Cache-Control header for UnixFS directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The following emojis are used to highlight certain changes:
 
 - `bitswap/server` minor memory use and performance improvements
 - `bitswap` unify logger names to use uniform format bitswap/path/pkgname
+- `gateway` now always returns meaningful cache-control headers for generated HTML listings of UnixFS directories
 
 ### Removed
 

--- a/gateway/handler_unixfs_dir.go
+++ b/gateway/handler_unixfs_dir.go
@@ -136,9 +136,14 @@ func (i *handler) serveDirectory(ctx context.Context, w http.ResponseWriter, r *
 	dirEtag := getDirListingEtag(resolvedPath.RootCid())
 	w.Header().Set("Etag", dirEtag)
 
-	// Add TTL if known.
+	// Set Cache-Control
 	if rq.ttl > 0 {
-		w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", int(rq.ttl.Seconds())))
+		// Use known TTL from IPNS Record or DNSLink TXT Record
+		w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d, stale-while-revalidate=2678400", int(rq.ttl.Seconds())))
+	} else {
+		// Cache for 1 week, serve stale cache for up to a month
+		// (style of generated HTML may change, should not be cached forever)
+		w.Header().Set("Cache-Control", "public, max-age=604800, stale-while-revalidate=2678400")
 	}
 
 	if r.Method == http.MethodHead {


### PR DESCRIPTION
Cache-Control headers are currently not being returned when viewing the directory index page of a UnixFS directory. This is because `rq.ttl` returns `0`.

For example, the following request path is missing a `Cache-Control` header: `/ipfs/<cid>/`

According to the Path Gateway Specification:

> Cache-Control: public, max-age=29030400, immutable must be returned for every immutable resource under /ipfs/ namespace.

https://specs.ipfs.tech/http-gateways/path-gateway/#cache-control-response-header

This PR sets the appropriate header.