### PR TITLE
Bitswap: move providing -> Exchange-layer, providerQueryManager -> routing

### DIFF
--- a/bitswap/client/internal/messagequeue/messagequeue.go
+++ b/bitswap/client/internal/messagequeue/messagequeue.go
@@ -51,7 +51,7 @@ const (
 // MessageNetwork is any network that can connect peers and generate a message
 // sender.
 type MessageNetwork interface {
-	ConnectTo(context.Context, peer.ID) error
+	Connect(context.Context, peer.AddrInfo) error
 	NewMessageSender(context.Context, peer.ID, *bsnet.MessageSenderOpts) (bsnet.MessageSender, error)
 	Latency(peer.ID) time.Duration
 	Ping(context.Context, peer.ID) ping.Result

--- a/bitswap/client/internal/messagequeue/messagequeue_test.go
+++ b/bitswap/client/internal/messagequeue/messagequeue_test.go
@@ -27,7 +27,7 @@ type fakeMessageNetwork struct {
 	messageSender      bsnet.MessageSender
 }
 
-func (fmn *fakeMessageNetwork) ConnectTo(context.Context, peer.ID) error {
+func (fmn *fakeMessageNetwork) Connect(context.Context, peer.AddrInfo) error {
 	return fmn.connectError
 }
 

--- a/bitswap/client/internal/session/session.go
+++ b/bitswap/client/internal/session/session.go
@@ -75,7 +75,7 @@ type SessionPeerManager interface {
 // ProviderFinder is used to find providers for a given key
 type ProviderFinder interface {
 	// FindProvidersAsync searches for peers that provide the given CID
-	FindProvidersAsync(ctx context.Context, k cid.Cid) <-chan peer.ID
+	FindProvidersAsync(ctx context.Context, k cid.Cid, max int) <-chan peer.AddrInfo
 }
 
 // opType is the kind of operation that is being processed by the event loop
@@ -403,14 +403,18 @@ func (s *Session) handlePeriodicSearch(ctx context.Context) {
 // findMorePeers attempts to find more peers for a session by searching for
 // providers for the given Cid
 func (s *Session) findMorePeers(ctx context.Context, c cid.Cid) {
+	// noop when provider finder is disabled
+	if s.providerFinder == nil {
+		return
+	}
 	go func(k cid.Cid) {
 		ctx, span := internal.StartSpan(ctx, "Session.FindMorePeers")
 		defer span.End()
-		for p := range s.providerFinder.FindProvidersAsync(ctx, k) {
+		for p := range s.providerFinder.FindProvidersAsync(ctx, k, 0) {
 			// When a provider indicates that it has a cid, it's equivalent to
 			// the providing peer sending a HAVE
 			span.AddEvent("FoundPeer")
-			s.sws.Update(p, nil, []cid.Cid{c}, nil)
+			s.sws.Update(p.ID, nil, []cid.Cid{c}, nil)
 		}
 	}(c)
 }

--- a/bitswap/client/internal/session/session_test.go
+++ b/bitswap/client/internal/session/session_test.go
@@ -116,7 +116,7 @@ func newFakeProviderFinder() *fakeProviderFinder {
 	}
 }
 
-func (fpf *fakeProviderFinder) FindProvidersAsync(ctx context.Context, k cid.Cid) <-chan peer.ID {
+func (fpf *fakeProviderFinder) FindProvidersAsync(ctx context.Context, k cid.Cid, max int) <-chan peer.AddrInfo {
 	go func() {
 		select {
 		case fpf.findMorePeersRequested <- k:
@@ -124,7 +124,7 @@ func (fpf *fakeProviderFinder) FindProvidersAsync(ctx context.Context, k cid.Cid
 		}
 	}()
 
-	return make(chan peer.ID)
+	return make(chan peer.AddrInfo)
 }
 
 type wantReq struct {

--- a/bitswap/internal/defaults/defaults.go
+++ b/bitswap/internal/defaults/defaults.go
@@ -20,11 +20,6 @@ const (
 	BitswapMaxOutstandingBytesPerPeer = 1 << 20
 	// the number of bytes we attempt to make each outgoing bitswap message
 	BitswapEngineTargetMessageSize = 16 * 1024
-	// HasBlockBufferSize is the buffer size of the channel for new blocks
-	// that need to be provided. They should get pulled over by the
-	// provideCollector even before they are actually provided.
-	// TODO: Does this need to be this large givent that?
-	HasBlockBufferSize = 256
 
 	// Maximum size of the wantlist we are willing to keep in memory.
 	MaxQueuedWantlistEntiresPerPeer = 1024

--- a/bitswap/network/interface.go
+++ b/bitswap/network/interface.go
@@ -40,7 +40,7 @@ type BitSwapNetwork interface {
 	// Stop stops the network service.
 	Stop()
 
-	ConnectTo(context.Context, peer.ID) error
+	Connect(context.Context, peer.AddrInfo) error
 	DisconnectFrom(context.Context, peer.ID) error
 
 	NewMessageSender(context.Context, peer.ID, *MessageSenderOpts) (MessageSender, error)
@@ -48,8 +48,6 @@ type BitSwapNetwork interface {
 	ConnectionManager() connmgr.ConnManager
 
 	Stats() Stats
-
-	Routing
 
 	Pinger
 }
@@ -88,7 +86,7 @@ type Receiver interface {
 // network.
 type Routing interface {
 	// FindProvidersAsync returns a channel of providers for the given key.
-	FindProvidersAsync(context.Context, cid.Cid, int) <-chan peer.ID
+	FindProvidersAsync(context.Context, cid.Cid, int) <-chan peer.AddrInfo
 
 	// Provide provides the key to the network.
 	Provide(context.Context, cid.Cid) error

--- a/bitswap/network/ipfs_impl.go
+++ b/bitswap/network/ipfs_impl.go
@@ -11,15 +11,12 @@ import (
 	bsmsg "github.com/ipfs/boxo/bitswap/message"
 	"github.com/ipfs/boxo/bitswap/network/internal"
 
-	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p/core/connmgr"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/libp2p/go-libp2p/core/protocol"
-	"github.com/libp2p/go-libp2p/core/routing"
 	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
 	"github.com/libp2p/go-msgio"
 	ma "github.com/multiformats/go-multiaddr"
@@ -36,12 +33,11 @@ var (
 )
 
 // NewFromIpfsHost returns a BitSwapNetwork supported by underlying IPFS host.
-func NewFromIpfsHost(host host.Host, r routing.ContentRouting, opts ...NetOpt) BitSwapNetwork {
+func NewFromIpfsHost(host host.Host, opts ...NetOpt) BitSwapNetwork {
 	s := processSettings(opts...)
 
 	bitswapNetwork := impl{
-		host:    host,
-		routing: r,
+		host: host,
 
 		protocolBitswapNoVers:  s.ProtocolPrefix + ProtocolBitswapNoVers,
 		protocolBitswapOneZero: s.ProtocolPrefix + ProtocolBitswapOneZero,
@@ -73,7 +69,6 @@ type impl struct {
 	stats Stats
 
 	host          host.Host
-	routing       routing.ContentRouting
 	connectEvtMgr *connectEventManager
 
 	protocolBitswapNoVers  protocol.ID
@@ -104,7 +99,7 @@ func (s *streamMessageSender) Connect(ctx context.Context) (network.Stream, erro
 	tctx, cancel := context.WithTimeout(ctx, s.opts.SendTimeout)
 	defer cancel()
 
-	if err := s.bsnet.ConnectTo(tctx, s.to); err != nil {
+	if err := s.bsnet.Connect(ctx, peer.AddrInfo{ID: s.to}); err != nil {
 		return nil, err
 	}
 
@@ -363,38 +358,15 @@ func (bsnet *impl) Stop() {
 	bsnet.host.Network().StopNotify((*netNotifiee)(bsnet))
 }
 
-func (bsnet *impl) ConnectTo(ctx context.Context, p peer.ID) error {
-	return bsnet.host.Connect(ctx, peer.AddrInfo{ID: p})
+func (bsnet *impl) Connect(ctx context.Context, p peer.AddrInfo) error {
+	if p.ID == bsnet.host.ID() {
+		return nil
+	}
+	return bsnet.host.Connect(ctx, p)
 }
 
 func (bsnet *impl) DisconnectFrom(ctx context.Context, p peer.ID) error {
 	return bsnet.host.Network().ClosePeer(p)
-}
-
-// FindProvidersAsync returns a channel of providers for the given key.
-func (bsnet *impl) FindProvidersAsync(ctx context.Context, k cid.Cid, max int) <-chan peer.ID {
-	out := make(chan peer.ID, max)
-	go func() {
-		defer close(out)
-		providers := bsnet.routing.FindProvidersAsync(ctx, k, max)
-		for info := range providers {
-			if info.ID == bsnet.host.ID() {
-				continue // ignore self as provider
-			}
-			bsnet.host.Peerstore().AddAddrs(info.ID, info.Addrs, peerstore.TempAddrTTL)
-			select {
-			case <-ctx.Done():
-				return
-			case out <- info.ID:
-			}
-		}
-	}()
-	return out
-}
-
-// Provide provides the key to the network
-func (bsnet *impl) Provide(ctx context.Context, k cid.Cid) error {
-	return bsnet.routing.Provide(ctx, k, true)
 }
 
 // handleNewStream receives a new stream from the network.

--- a/bitswap/options.go
+++ b/bitswap/options.go
@@ -43,10 +43,6 @@ func TaskWorkerCount(count int) Option {
 	return Option{server.TaskWorkerCount(count)}
 }
 
-func ProvideEnabled(enabled bool) Option {
-	return Option{server.ProvideEnabled(enabled)}
-}
-
 func SetSendDontHaves(send bool) Option {
 	return Option{server.SetSendDontHaves(send)}
 }
@@ -105,4 +101,12 @@ func WithTracer(tap tracer.Tracer) Option {
 			bs.tracer = tap
 		}),
 	}
+}
+
+func WithClientOption(opt client.Option) Option {
+	return Option{opt}
+}
+
+func WithServerOption(opt server.Option) Option {
+	return Option{opt}
 }

--- a/bitswap/testnet/network_test.go
+++ b/bitswap/testnet/network_test.go
@@ -8,7 +8,6 @@ import (
 	bsmsg "github.com/ipfs/boxo/bitswap/message"
 	bsnet "github.com/ipfs/boxo/bitswap/network"
 
-	mockrouting "github.com/ipfs/boxo/routing/mock"
 	blocks "github.com/ipfs/go-block-format"
 	delay "github.com/ipfs/go-ipfs-delay"
 
@@ -17,7 +16,7 @@ import (
 )
 
 func TestSendMessageAsyncButWaitForResponse(t *testing.T) {
-	net := VirtualNetwork(mockrouting.NewServer(), delay.Fixed(0))
+	net := VirtualNetwork(delay.Fixed(0))
 	responderPeer := tnet.RandIdentityOrFatal(t)
 	waiter := net.Adapter(tnet.RandIdentityOrFatal(t))
 	responder := net.Adapter(responderPeer)

--- a/bitswap/testnet/peernet.go
+++ b/bitswap/testnet/peernet.go
@@ -5,9 +5,6 @@ import (
 
 	bsnet "github.com/ipfs/boxo/bitswap/network"
 
-	mockrouting "github.com/ipfs/boxo/routing/mock"
-	ds "github.com/ipfs/go-datastore"
-
 	tnet "github.com/libp2p/go-libp2p-testing/net"
 	"github.com/libp2p/go-libp2p/core/peer"
 	mockpeernet "github.com/libp2p/go-libp2p/p2p/net/mock"
@@ -15,12 +12,11 @@ import (
 
 type peernet struct {
 	mockpeernet.Mocknet
-	routingserver mockrouting.Server
 }
 
 // StreamNet is a testnet that uses libp2p's MockNet
-func StreamNet(ctx context.Context, net mockpeernet.Mocknet, rs mockrouting.Server) (Network, error) {
-	return &peernet{net, rs}, nil
+func StreamNet(ctx context.Context, net mockpeernet.Mocknet) (Network, error) {
+	return &peernet{net}, nil
 }
 
 func (pn *peernet) Adapter(p tnet.Identity, opts ...bsnet.NetOpt) bsnet.BitSwapNetwork {
@@ -28,8 +24,8 @@ func (pn *peernet) Adapter(p tnet.Identity, opts ...bsnet.NetOpt) bsnet.BitSwapN
 	if err != nil {
 		panic(err.Error())
 	}
-	routing := pn.routingserver.ClientWithDatastore(context.TODO(), p, ds.NewMapDatastore())
-	return bsnet.NewFromIpfsHost(client, routing, opts...)
+
+	return bsnet.NewFromIpfsHost(client, opts...)
 }
 
 func (pn *peernet) HasPeer(p peer.ID) bool {

--- a/bitswap/testnet/virtual.go
+++ b/bitswap/testnet/virtual.go
@@ -11,27 +11,23 @@ import (
 	bsmsg "github.com/ipfs/boxo/bitswap/message"
 	bsnet "github.com/ipfs/boxo/bitswap/network"
 
-	mockrouting "github.com/ipfs/boxo/routing/mock"
-	cid "github.com/ipfs/go-cid"
 	delay "github.com/ipfs/go-ipfs-delay"
 
 	tnet "github.com/libp2p/go-libp2p-testing/net"
 	"github.com/libp2p/go-libp2p/core/connmgr"
 	"github.com/libp2p/go-libp2p/core/peer"
 	protocol "github.com/libp2p/go-libp2p/core/protocol"
-	"github.com/libp2p/go-libp2p/core/routing"
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
 )
 
 // VirtualNetwork generates a new testnet instance - a fake network that
 // is used to simulate sending messages.
-func VirtualNetwork(rs mockrouting.Server, d delay.D) Network {
+func VirtualNetwork(d delay.D) Network {
 	return &network{
 		latencies:          make(map[peer.ID]map[peer.ID]time.Duration),
 		clients:            make(map[peer.ID]*receiverQueue),
 		delay:              d,
-		routingserver:      rs,
 		isRateLimited:      false,
 		rateLimitGenerator: nil,
 		conns:              make(map[string]struct{}),
@@ -45,13 +41,12 @@ type RateLimitGenerator interface {
 
 // RateLimitedVirtualNetwork generates a testnet instance where nodes are rate
 // limited in the upload/download speed.
-func RateLimitedVirtualNetwork(rs mockrouting.Server, d delay.D, rateLimitGenerator RateLimitGenerator) Network {
+func RateLimitedVirtualNetwork(d delay.D, rateLimitGenerator RateLimitGenerator) Network {
 	return &network{
 		latencies:          make(map[peer.ID]map[peer.ID]time.Duration),
 		rateLimiters:       make(map[peer.ID]map[peer.ID]*mocknet.RateLimiter),
 		clients:            make(map[peer.ID]*receiverQueue),
 		delay:              d,
-		routingserver:      rs,
 		isRateLimited:      true,
 		rateLimitGenerator: rateLimitGenerator,
 		conns:              make(map[string]struct{}),
@@ -63,7 +58,6 @@ type network struct {
 	latencies          map[peer.ID]map[peer.ID]time.Duration
 	rateLimiters       map[peer.ID]map[peer.ID]*mocknet.RateLimiter
 	clients            map[peer.ID]*receiverQueue
-	routingserver      mockrouting.Server
 	delay              delay.D
 	isRateLimited      bool
 	rateLimitGenerator RateLimitGenerator
@@ -105,7 +99,6 @@ func (n *network) Adapter(p tnet.Identity, opts ...bsnet.NetOpt) bsnet.BitSwapNe
 	client := &networkClient{
 		local:              p.ID(),
 		network:            n,
-		routing:            n.routingserver.Client(p),
 		supportedProtocols: s.SupportedProtocols,
 	}
 	n.clients[p.ID()] = &receiverQueue{receiver: client}
@@ -192,7 +185,6 @@ type networkClient struct {
 	local              peer.ID
 	receivers          []bsnet.Receiver
 	network            *network
-	routing            routing.Routing
 	supportedProtocols []protocol.ID
 }
 
@@ -253,27 +245,6 @@ func (nc *networkClient) Stats() bsnet.Stats {
 	}
 }
 
-// FindProvidersAsync returns a channel of providers for the given key.
-func (nc *networkClient) FindProvidersAsync(ctx context.Context, k cid.Cid, max int) <-chan peer.ID {
-	// NB: this function duplicates the AddrInfo -> ID transformation in the
-	// bitswap network adapter. Not to worry. This network client will be
-	// deprecated once the ipfsnet.Mock is added. The code below is only
-	// temporary.
-
-	out := make(chan peer.ID)
-	go func() {
-		defer close(out)
-		providers := nc.routing.FindProvidersAsync(ctx, k, max)
-		for info := range providers {
-			select {
-			case <-ctx.Done():
-			case out <- info.ID:
-			}
-		}
-	}()
-	return out
-}
-
 func (nc *networkClient) ConnectionManager() connmgr.ConnManager {
 	return &connmgr.NullConnMgr{}
 }
@@ -322,11 +293,6 @@ func (nc *networkClient) NewMessageSender(ctx context.Context, p peer.ID, opts *
 	}, nil
 }
 
-// Provide provides the key to the network.
-func (nc *networkClient) Provide(ctx context.Context, k cid.Cid) error {
-	return nc.routing.Provide(ctx, k, true)
-}
-
 func (nc *networkClient) Start(r ...bsnet.Receiver) {
 	nc.receivers = r
 }
@@ -334,15 +300,15 @@ func (nc *networkClient) Start(r ...bsnet.Receiver) {
 func (nc *networkClient) Stop() {
 }
 
-func (nc *networkClient) ConnectTo(_ context.Context, p peer.ID) error {
+func (nc *networkClient) Connect(_ context.Context, p peer.AddrInfo) error {
 	nc.network.mu.Lock()
-	otherClient, ok := nc.network.clients[p]
+	otherClient, ok := nc.network.clients[p.ID]
 	if !ok {
 		nc.network.mu.Unlock()
 		return errors.New("no such peer in network")
 	}
 
-	tag := tagForPeers(nc.local, p)
+	tag := tagForPeers(nc.local, p.ID)
 	if _, ok := nc.network.conns[tag]; ok {
 		nc.network.mu.Unlock()
 		// log.Warning("ALREADY CONNECTED TO PEER (is this a reconnect? test lib needs fixing)")
@@ -352,7 +318,7 @@ func (nc *networkClient) ConnectTo(_ context.Context, p peer.ID) error {
 	nc.network.mu.Unlock()
 
 	otherClient.receiver.PeerConnected(nc.local)
-	nc.PeerConnected(p)
+	nc.PeerConnected(p.ID)
 	return nil
 }
 

--- a/blockservice/test/mock.go
+++ b/blockservice/test/mock.go
@@ -10,14 +10,15 @@ import (
 
 // Mocks returns |n| connected mock Blockservices
 func Mocks(n int, opts ...blockservice.Option) []blockservice.BlockService {
-	net := tn.VirtualNetwork(mockrouting.NewServer(), delay.Fixed(0))
-	sg := testinstance.NewTestInstanceGenerator(net, nil, nil)
-
+	net := tn.VirtualNetwork(delay.Fixed(0))
+	routing := mockrouting.NewServer()
+	sg := testinstance.NewTestInstanceGenerator(net, routing, nil, nil)
 	instances := sg.Instances(n)
 
 	var servs []blockservice.BlockService
 	for _, i := range instances {
-		servs = append(servs, blockservice.New(i.Blockstore(), i.Exchange, opts...))
+		servs = append(servs, blockservice.New(i.Blockstore,
+			i.Exchange, opts...))
 	}
 	return servs
 }

--- a/examples/bitswap-transfer/main.go
+++ b/examples/bitswap-transfer/main.go
@@ -32,7 +32,6 @@ import (
 	unixfile "github.com/ipfs/boxo/ipld/unixfs/file"
 	"github.com/ipfs/boxo/ipld/unixfs/importer/balanced"
 	uih "github.com/ipfs/boxo/ipld/unixfs/importer/helpers"
-	routinghelpers "github.com/libp2p/go-libp2p-routing-helpers"
 
 	bsclient "github.com/ipfs/boxo/bitswap/client"
 	bsnet "github.com/ipfs/boxo/bitswap/network"
@@ -178,15 +177,15 @@ func startDataServer(ctx context.Context, h host.Host) (cid.Cid, *bsserver.Serve
 
 	// Start listening on the Bitswap protocol
 	// For this example we're not leveraging any content routing (DHT, IPNI, delegated routing requests, etc.) as we know the peer we are fetching from
-	n := bsnet.NewFromIpfsHost(h, routinghelpers.Null{})
+	n := bsnet.NewFromIpfsHost(h)
 	bswap := bsserver.New(ctx, n, bs)
 	n.Start(bswap)
 	return nd.Cid(), bswap, nil
 }
 
 func runClient(ctx context.Context, h host.Host, c cid.Cid, targetPeer string) ([]byte, error) {
-	n := bsnet.NewFromIpfsHost(h, routinghelpers.Null{})
-	bswap := bsclient.New(ctx, n, blockstore.NewBlockstore(datastore.NewNullDatastore()))
+	n := bsnet.NewFromIpfsHost(h)
+	bswap := bsclient.New(ctx, n, nil, blockstore.NewBlockstore(datastore.NewNullDatastore()))
 	n.Start(bswap)
 	defer bswap.Close()
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/ipld/go-car/v2 v2.14.2
 	github.com/ipld/go-ipld-prime v0.21.0
 	github.com/libp2p/go-libp2p v0.37.0
-	github.com/libp2p/go-libp2p-routing-helpers v0.7.4
 	github.com/multiformats/go-multiaddr v0.13.0
 	github.com/multiformats/go-multicodec v0.9.0
 	github.com/prometheus/client_golang v1.20.5
@@ -95,6 +94,7 @@ require (
 	github.com/libp2p/go-libp2p-kad-dht v0.27.0 // indirect
 	github.com/libp2p/go-libp2p-kbucket v0.6.4 // indirect
 	github.com/libp2p/go-libp2p-record v0.2.0 // indirect
+	github.com/libp2p/go-libp2p-routing-helpers v0.7.4 // indirect
 	github.com/libp2p/go-msgio v0.3.0 // indirect
 	github.com/libp2p/go-nat v0.2.0 // indirect
 	github.com/libp2p/go-netroute v0.2.1 // indirect

--- a/exchange/providing/providing.go
+++ b/exchange/providing/providing.go
@@ -1,0 +1,46 @@
+// Package providing implements an exchange wrapper which
+// does content providing for new blocks.
+package providing
+
+import (
+	"context"
+
+	"github.com/ipfs/boxo/exchange"
+	"github.com/ipfs/boxo/provider"
+	blocks "github.com/ipfs/go-block-format"
+)
+
+// Exchange is an exchange wrapper that calls Provide for blocks received
+// over NotifyNewBlocks.
+type Exchange struct {
+	exchange.Interface
+	provider provider.Provider
+}
+
+// New creates a new providing Exchange with the given exchange and provider.
+// This is a light wrapper. We recommend that the provider supports the
+// handling of many concurrent provides etc. as it is called directly for
+// every new block.
+func New(base exchange.Interface, provider provider.Provider) *Exchange {
+	return &Exchange{
+		Interface: base,
+		provider:  provider,
+	}
+}
+
+// NotifyNewBlocks calls NotifyNewBlocks on the underlying provider and
+// provider.Provide for every block after that.
+func (ex *Exchange) NotifyNewBlocks(ctx context.Context, blocks ...blocks.Block) error {
+	// Notify blocks on the underlying exchange.
+	err := ex.Interface.NotifyNewBlocks(ctx, blocks...)
+	if err != nil {
+		return err
+	}
+
+	for _, b := range blocks {
+		if err := ex.provider.Provide(ctx, b.Cid(), true); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/exchange/providing/providing_test.go
+++ b/exchange/providing/providing_test.go
@@ -1,0 +1,74 @@
+package providing
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	testinstance "github.com/ipfs/boxo/bitswap/testinstance"
+	tn "github.com/ipfs/boxo/bitswap/testnet"
+	"github.com/ipfs/boxo/blockservice"
+	"github.com/ipfs/boxo/provider"
+	mockrouting "github.com/ipfs/boxo/routing/mock"
+	delay "github.com/ipfs/go-ipfs-delay"
+	"github.com/ipfs/go-test/random"
+)
+
+func TestExchange(t *testing.T) {
+	ctx := context.Background()
+	net := tn.VirtualNetwork(delay.Fixed(0))
+	routing := mockrouting.NewServer()
+	sg := testinstance.NewTestInstanceGenerator(net, routing, nil, nil)
+	i := sg.Next()
+	provFinder := routing.Client(i.Identity)
+	prov, err := provider.New(i.Datastore,
+		provider.Online(provFinder),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	provExchange := New(i.Exchange, prov)
+	// write-through so that we notify when re-adding block
+	bs := blockservice.New(i.Blockstore, provExchange,
+		blockservice.WriteThrough())
+	block := random.BlocksOfSize(1, 10)[0]
+	// put it on the blockstore of the first instance
+	err = i.Blockstore.Put(ctx, block)
+	if err != nil {
+		t.Fatal()
+	}
+
+	// Trigger reproviding, otherwise it's not really provided.
+	err = prov.Reprovide(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	providersChan := provFinder.FindProvidersAsync(ctx, block.Cid(), 1)
+	_, ok := <-providersChan
+	if ok {
+		t.Fatal("there should be no providers yet for block")
+	}
+
+	// Now add it via BlockService. It should trigger NotifyNewBlocks
+	// on the exchange and thus they should get announced.
+	err = bs.AddBlock(ctx, block)
+	if err != nil {
+		t.Fatal()
+	}
+	// Trigger reproviding, otherwise it's not really provided.
+	err = prov.Reprovide(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	providersChan = provFinder.FindProvidersAsync(ctx, block.Cid(), 1)
+	_, ok = <-providersChan
+	if !ok {
+		t.Fatal("there should be one provider for the block")
+	}
+}

--- a/fetcher/helpers/block_visitor_test.go
+++ b/fetcher/helpers/block_visitor_test.go
@@ -44,8 +44,9 @@ func TestFetchGraphToBlocks(t *testing.T) {
 		})
 	}))
 
-	net := tn.VirtualNetwork(mockrouting.NewServer(), delay.Fixed(0*time.Millisecond))
-	ig := testinstance.NewTestInstanceGenerator(net, nil, nil)
+	routing := mockrouting.NewServer()
+	net := tn.VirtualNetwork(delay.Fixed(0 * time.Millisecond))
+	ig := testinstance.NewTestInstanceGenerator(net, routing, nil, nil)
 	defer ig.Close()
 
 	peers := ig.Instances(2)
@@ -53,7 +54,7 @@ func TestFetchGraphToBlocks(t *testing.T) {
 	defer hasBlock.Exchange.Close()
 
 	blocks := []blocks.Block{block1, block2, block3, block4}
-	err := hasBlock.Blockstore().PutMany(bg, blocks)
+	err := hasBlock.Blockstore.PutMany(bg, blocks)
 	require.NoError(t, err)
 	err = hasBlock.Exchange.NotifyNewBlocks(bg, blocks...)
 	require.NoError(t, err)
@@ -61,7 +62,7 @@ func TestFetchGraphToBlocks(t *testing.T) {
 	wantsBlock := peers[1]
 	defer wantsBlock.Exchange.Close()
 
-	wantsGetter := blockservice.New(wantsBlock.Blockstore(), wantsBlock.Exchange)
+	wantsGetter := blockservice.New(wantsBlock.Blockstore, wantsBlock.Exchange)
 	fetcherConfig := bsfetcher.NewFetcherConfig(wantsGetter)
 	session := fetcherConfig.NewSession(context.Background())
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -94,15 +95,16 @@ func TestFetchGraphToUniqueBlocks(t *testing.T) {
 		})
 	}))
 
-	net := tn.VirtualNetwork(mockrouting.NewServer(), delay.Fixed(0*time.Millisecond))
-	ig := testinstance.NewTestInstanceGenerator(net, nil, nil)
+	routing := mockrouting.NewServer()
+	net := tn.VirtualNetwork(delay.Fixed(0 * time.Millisecond))
+	ig := testinstance.NewTestInstanceGenerator(net, routing, nil, nil)
 	defer ig.Close()
 
 	peers := ig.Instances(2)
 	hasBlock := peers[0]
 	defer hasBlock.Exchange.Close()
 
-	err := hasBlock.Blockstore().PutMany(bg, []blocks.Block{block1, block2, block3})
+	err := hasBlock.Blockstore.PutMany(bg, []blocks.Block{block1, block2, block3})
 	require.NoError(t, err)
 
 	err = hasBlock.Exchange.NotifyNewBlocks(bg, block1, block2, block3)
@@ -111,7 +113,7 @@ func TestFetchGraphToUniqueBlocks(t *testing.T) {
 	wantsBlock := peers[1]
 	defer wantsBlock.Exchange.Close()
 
-	wantsGetter := blockservice.New(wantsBlock.Blockstore(), wantsBlock.Exchange)
+	wantsGetter := blockservice.New(wantsBlock.Blockstore, wantsBlock.Exchange)
 	fetcherConfig := bsfetcher.NewFetcherConfig(wantsGetter)
 	session := fetcherConfig.NewSession(context.Background())
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/fetcher/impl/blockservice/fetcher_test.go
+++ b/fetcher/impl/blockservice/fetcher_test.go
@@ -38,15 +38,16 @@ func TestFetchIPLDPrimeNode(t *testing.T) {
 		})
 	}))
 
-	net := tn.VirtualNetwork(mockrouting.NewServer(), delay.Fixed(0*time.Millisecond))
-	ig := testinstance.NewTestInstanceGenerator(net, nil, nil)
+	routing := mockrouting.NewServer()
+	net := tn.VirtualNetwork(delay.Fixed(0 * time.Millisecond))
+	ig := testinstance.NewTestInstanceGenerator(net, routing, nil, nil)
 	defer ig.Close()
 
 	peers := ig.Instances(2)
 	hasBlock := peers[0]
 	defer hasBlock.Exchange.Close()
 
-	err := hasBlock.Blockstore().Put(bg, block)
+	err := hasBlock.Blockstore.Put(bg, block)
 	require.NoError(t, err)
 
 	err = hasBlock.Exchange.NotifyNewBlocks(bg, block)
@@ -55,7 +56,7 @@ func TestFetchIPLDPrimeNode(t *testing.T) {
 	wantsBlock := peers[1]
 	defer wantsBlock.Exchange.Close()
 
-	wantsGetter := blockservice.New(wantsBlock.Blockstore(), wantsBlock.Exchange)
+	wantsGetter := blockservice.New(wantsBlock.Blockstore, wantsBlock.Exchange)
 	fetcherConfig := bsfetcher.NewFetcherConfig(wantsGetter)
 	session := fetcherConfig.NewSession(context.Background())
 
@@ -87,8 +88,9 @@ func TestFetchIPLDGraph(t *testing.T) {
 		})
 	}))
 
-	net := tn.VirtualNetwork(mockrouting.NewServer(), delay.Fixed(0*time.Millisecond))
-	ig := testinstance.NewTestInstanceGenerator(net, nil, nil)
+	routing := mockrouting.NewServer()
+	net := tn.VirtualNetwork(delay.Fixed(0 * time.Millisecond))
+	ig := testinstance.NewTestInstanceGenerator(net, routing, nil, nil)
 	defer ig.Close()
 
 	peers := ig.Instances(2)
@@ -96,7 +98,7 @@ func TestFetchIPLDGraph(t *testing.T) {
 	defer hasBlock.Exchange.Close()
 
 	blocks := []blocks.Block{block1, block2, block3, block4}
-	err := hasBlock.Blockstore().PutMany(bg, blocks)
+	err := hasBlock.Blockstore.PutMany(bg, blocks)
 	require.NoError(t, err)
 	err = hasBlock.Exchange.NotifyNewBlocks(bg, blocks...)
 	require.NoError(t, err)
@@ -104,7 +106,7 @@ func TestFetchIPLDGraph(t *testing.T) {
 	wantsBlock := peers[1]
 	defer wantsBlock.Exchange.Close()
 
-	wantsGetter := blockservice.New(wantsBlock.Blockstore(), wantsBlock.Exchange)
+	wantsGetter := blockservice.New(wantsBlock.Blockstore, wantsBlock.Exchange)
 	fetcherConfig := bsfetcher.NewFetcherConfig(wantsGetter)
 	session := fetcherConfig.NewSession(context.Background())
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -143,8 +145,9 @@ func TestFetchIPLDPath(t *testing.T) {
 		})
 	}))
 
-	net := tn.VirtualNetwork(mockrouting.NewServer(), delay.Fixed(0*time.Millisecond))
-	ig := testinstance.NewTestInstanceGenerator(net, nil, nil)
+	routing := mockrouting.NewServer()
+	net := tn.VirtualNetwork(delay.Fixed(0 * time.Millisecond))
+	ig := testinstance.NewTestInstanceGenerator(net, routing, nil, nil)
 	defer ig.Close()
 
 	peers := ig.Instances(2)
@@ -152,7 +155,7 @@ func TestFetchIPLDPath(t *testing.T) {
 	defer hasBlock.Exchange.Close()
 
 	blocks := []blocks.Block{block1, block2, block3, block4, block5}
-	err := hasBlock.Blockstore().PutMany(bg, blocks)
+	err := hasBlock.Blockstore.PutMany(bg, blocks)
 	require.NoError(t, err)
 	err = hasBlock.Exchange.NotifyNewBlocks(bg, blocks...)
 	require.NoError(t, err)
@@ -160,7 +163,7 @@ func TestFetchIPLDPath(t *testing.T) {
 	wantsBlock := peers[1]
 	defer wantsBlock.Exchange.Close()
 
-	wantsGetter := blockservice.New(wantsBlock.Blockstore(), wantsBlock.Exchange)
+	wantsGetter := blockservice.New(wantsBlock.Blockstore, wantsBlock.Exchange)
 	fetcherConfig := bsfetcher.NewFetcherConfig(wantsGetter)
 	session := fetcherConfig.NewSession(context.Background())
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -206,9 +209,9 @@ func TestHelpers(t *testing.T) {
 			na.AssembleEntry("nonlink").AssignString("zoo")
 		})
 	}))
-
-	net := tn.VirtualNetwork(mockrouting.NewServer(), delay.Fixed(0*time.Millisecond))
-	ig := testinstance.NewTestInstanceGenerator(net, nil, nil)
+	routing := mockrouting.NewServer()
+	net := tn.VirtualNetwork(delay.Fixed(0 * time.Millisecond))
+	ig := testinstance.NewTestInstanceGenerator(net, routing, nil, nil)
 	defer ig.Close()
 
 	peers := ig.Instances(2)
@@ -216,7 +219,7 @@ func TestHelpers(t *testing.T) {
 	defer hasBlock.Exchange.Close()
 
 	blocks := []blocks.Block{block1, block2, block3, block4}
-	err := hasBlock.Blockstore().PutMany(bg, blocks)
+	err := hasBlock.Blockstore.PutMany(bg, blocks)
 	require.NoError(t, err)
 	err = hasBlock.Exchange.NotifyNewBlocks(bg, blocks...)
 	require.NoError(t, err)
@@ -224,7 +227,7 @@ func TestHelpers(t *testing.T) {
 	wantsBlock := peers[1]
 	defer wantsBlock.Exchange.Close()
 
-	wantsGetter := blockservice.New(wantsBlock.Blockstore(), wantsBlock.Exchange)
+	wantsGetter := blockservice.New(wantsBlock.Blockstore, wantsBlock.Exchange)
 
 	t.Run("Block retrieves node", func(t *testing.T) {
 		fetcherConfig := bsfetcher.NewFetcherConfig(wantsGetter)
@@ -321,8 +324,9 @@ func TestNodeReification(t *testing.T) {
 		na.AssembleEntry("link4").AssignLink(link4)
 	}))
 
-	net := tn.VirtualNetwork(mockrouting.NewServer(), delay.Fixed(0*time.Millisecond))
-	ig := testinstance.NewTestInstanceGenerator(net, nil, nil)
+	routing := mockrouting.NewServer()
+	net := tn.VirtualNetwork(delay.Fixed(0 * time.Millisecond))
+	ig := testinstance.NewTestInstanceGenerator(net, routing, nil, nil)
 	defer ig.Close()
 
 	peers := ig.Instances(2)
@@ -330,7 +334,7 @@ func TestNodeReification(t *testing.T) {
 	defer hasBlock.Exchange.Close()
 
 	blocks := []blocks.Block{block2, block3, block4}
-	err := hasBlock.Blockstore().PutMany(bg, blocks)
+	err := hasBlock.Blockstore.PutMany(bg, blocks)
 	require.NoError(t, err)
 	err = hasBlock.Exchange.NotifyNewBlocks(bg, blocks...)
 	require.NoError(t, err)
@@ -338,7 +342,7 @@ func TestNodeReification(t *testing.T) {
 	wantsBlock := peers[1]
 	defer wantsBlock.Exchange.Close()
 
-	wantsGetter := blockservice.New(wantsBlock.Blockstore(), wantsBlock.Exchange)
+	wantsGetter := blockservice.New(wantsBlock.Blockstore, wantsBlock.Exchange)
 	fetcherConfig := bsfetcher.NewFetcherConfig(wantsGetter)
 	nodeReifier := func(lnkCtx ipld.LinkContext, nd ipld.Node, ls *ipld.LinkSystem) (ipld.Node, error) {
 		return &selfLoader{Node: nd, ctx: lnkCtx.Ctx, ls: ls}, nil

--- a/provider/noop.go
+++ b/provider/noop.go
@@ -19,7 +19,7 @@ func (op *noopProvider) Close() error {
 	return nil
 }
 
-func (op *noopProvider) Provide(cid.Cid) error {
+func (op *noopProvider) Provide(context.Context, cid.Cid, bool) error {
 	return nil
 }
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -18,7 +18,7 @@ var logR = logging.Logger("reprovider.simple")
 // Provider announces blocks to the network
 type Provider interface {
 	// Provide takes a cid and makes an attempt to announce it to the network
-	Provide(cid.Cid) error
+	Provide(context.Context, cid.Cid, bool) error
 }
 
 // Reprovider reannounces blocks to the network

--- a/provider/reprovider.go
+++ b/provider/reprovider.go
@@ -455,7 +455,7 @@ func (s *reprovider) Close() error {
 	return err
 }
 
-func (s *reprovider) Provide(cid cid.Cid) error {
+func (s *reprovider) Provide(ctx context.Context, cid cid.Cid, announce bool) error {
 	return s.q.Enqueue(cid)
 }
 

--- a/provider/reprovider_test.go
+++ b/provider/reprovider_test.go
@@ -198,7 +198,7 @@ func TestOfflineRecordsThenOnlineRepublish(t *testing.T) {
 	sys, err := New(ds)
 	assert.NoError(t, err)
 
-	err = sys.Provide(c)
+	err = sys.Provide(context.Background(), c, true)
 	assert.NoError(t, err)
 
 	err = sys.Close()

--- a/routing/mock/centralized_client.go
+++ b/routing/mock/centralized_client.go
@@ -47,11 +47,12 @@ func (c *client) FindPeer(ctx context.Context, pid peer.ID) (peer.AddrInfo, erro
 }
 
 func (c *client) FindProvidersAsync(ctx context.Context, k cid.Cid, max int) <-chan peer.AddrInfo {
+	log.Debugf("FindProvidersAsync: %s %d", k, max)
 	out := make(chan peer.AddrInfo)
 	go func() {
 		defer close(out)
 		for i, p := range c.server.Providers(k) {
-			if max <= i {
+			if max > 0 && max <= i {
 				return
 			}
 			select {

--- a/routing/mock/centralized_server.go
+++ b/routing/mock/centralized_server.go
@@ -39,7 +39,7 @@ func (rs *s) Announce(p peer.AddrInfo, c cid.Cid) error {
 	rs.lock.Lock()
 	defer rs.lock.Unlock()
 
-	k := c.KeyString()
+	k := c.Hash().String()
 
 	_, ok := rs.providers[k]
 	if !ok {
@@ -54,16 +54,16 @@ func (rs *s) Announce(p peer.AddrInfo, c cid.Cid) error {
 
 func (rs *s) Providers(c cid.Cid) []peer.AddrInfo {
 	rs.delayConf.Query.Wait() // before locking
-
 	rs.lock.RLock()
 	defer rs.lock.RUnlock()
-	k := c.KeyString()
+	k := c.Hash().String()
 
 	var ret []peer.AddrInfo
 	records, ok := rs.providers[k]
 	if !ok {
 		return ret
 	}
+
 	for _, r := range records {
 		if time.Since(r.Created) > rs.delayConf.ValueVisibility.Get() {
 			ret = append(ret, r.Peer)
@@ -74,7 +74,6 @@ func (rs *s) Providers(c cid.Cid) []peer.AddrInfo {
 		j := rand.Intn(i + 1)
 		ret[i], ret[j] = ret[j], ret[i]
 	}
-
 	return ret
 }
 

--- a/routing/providerquerymanager/providerquerymanager_test.go
+++ b/routing/providerquerymanager/providerquerymanager_test.go
@@ -13,27 +13,30 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
-type fakeProviderNetwork struct {
+type fakeProviderDialer struct {
+	connectError error
+	connectDelay time.Duration
+}
+
+type fakeProviderDiscovery struct {
 	peersFound       []peer.ID
-	connectError     error
 	delay            time.Duration
-	connectDelay     time.Duration
 	queriesMadeMutex sync.RWMutex
 	queriesMade      int
 	liveQueries      int
 }
 
-func (fpn *fakeProviderNetwork) ConnectTo(context.Context, peer.ID) error {
-	time.Sleep(fpn.connectDelay)
-	return fpn.connectError
+func (fpd *fakeProviderDialer) Connect(context.Context, peer.AddrInfo) error {
+	time.Sleep(fpd.connectDelay)
+	return fpd.connectError
 }
 
-func (fpn *fakeProviderNetwork) FindProvidersAsync(ctx context.Context, k cid.Cid, max int) <-chan peer.ID {
+func (fpn *fakeProviderDiscovery) FindProvidersAsync(ctx context.Context, k cid.Cid, max int) <-chan peer.AddrInfo {
 	fpn.queriesMadeMutex.Lock()
 	fpn.queriesMade++
 	fpn.liveQueries++
 	fpn.queriesMadeMutex.Unlock()
-	incomingPeers := make(chan peer.ID)
+	incomingPeers := make(chan peer.AddrInfo)
 	go func() {
 		defer close(incomingPeers)
 		for _, p := range fpn.peersFound {
@@ -44,7 +47,7 @@ func (fpn *fakeProviderNetwork) FindProvidersAsync(ctx context.Context, k cid.Ci
 			default:
 			}
 			select {
-			case incomingPeers <- p:
+			case incomingPeers <- peer.AddrInfo{ID: p}:
 			case <-ctx.Done():
 				return
 			}
@@ -57,28 +60,36 @@ func (fpn *fakeProviderNetwork) FindProvidersAsync(ctx context.Context, k cid.Ci
 	return incomingPeers
 }
 
+func mustNotErr[T any](out T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return out
+}
+
 func TestNormalSimultaneousFetch(t *testing.T) {
 	peers := random.Peers(10)
-	fpn := &fakeProviderNetwork{
+	fpd := &fakeProviderDialer{}
+	fpn := &fakeProviderDiscovery{
 		peersFound: peers,
 		delay:      1 * time.Millisecond,
 	}
 	ctx := context.Background()
-	providerQueryManager := New(ctx, fpn)
+	providerQueryManager := mustNotErr(New(ctx, fpd, fpn))
 	providerQueryManager.Startup()
 	keys := random.Cids(2)
 
 	sessionCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	firstRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, keys[0])
-	secondRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, keys[1])
+	firstRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, keys[0], 0)
+	secondRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, keys[1], 0)
 
-	var firstPeersReceived []peer.ID
+	var firstPeersReceived []peer.AddrInfo
 	for p := range firstRequestChan {
 		firstPeersReceived = append(firstPeersReceived, p)
 	}
 
-	var secondPeersReceived []peer.ID
+	var secondPeersReceived []peer.AddrInfo
 	for p := range secondRequestChan {
 		secondPeersReceived = append(secondPeersReceived, p)
 	}
@@ -96,26 +107,27 @@ func TestNormalSimultaneousFetch(t *testing.T) {
 
 func TestDedupingProviderRequests(t *testing.T) {
 	peers := random.Peers(10)
-	fpn := &fakeProviderNetwork{
+	fpd := &fakeProviderDialer{}
+	fpn := &fakeProviderDiscovery{
 		peersFound: peers,
 		delay:      1 * time.Millisecond,
 	}
 	ctx := context.Background()
-	providerQueryManager := New(ctx, fpn)
+	providerQueryManager := mustNotErr(New(ctx, fpd, fpn))
 	providerQueryManager.Startup()
 	key := random.Cids(1)[0]
 
 	sessionCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	firstRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key)
-	secondRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key)
+	firstRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key, 0)
+	secondRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key, 0)
 
-	var firstPeersReceived []peer.ID
+	var firstPeersReceived []peer.AddrInfo
 	for p := range firstRequestChan {
 		firstPeersReceived = append(firstPeersReceived, p)
 	}
 
-	var secondPeersReceived []peer.ID
+	var secondPeersReceived []peer.AddrInfo
 	for p := range secondRequestChan {
 		secondPeersReceived = append(secondPeersReceived, p)
 	}
@@ -136,12 +148,13 @@ func TestDedupingProviderRequests(t *testing.T) {
 
 func TestCancelOneRequestDoesNotTerminateAnother(t *testing.T) {
 	peers := random.Peers(10)
-	fpn := &fakeProviderNetwork{
+	fpd := &fakeProviderDialer{}
+	fpn := &fakeProviderDiscovery{
 		peersFound: peers,
 		delay:      1 * time.Millisecond,
 	}
 	ctx := context.Background()
-	providerQueryManager := New(ctx, fpn)
+	providerQueryManager := mustNotErr(New(ctx, fpd, fpn))
 	providerQueryManager.Startup()
 
 	key := random.Cids(1)[0]
@@ -149,17 +162,17 @@ func TestCancelOneRequestDoesNotTerminateAnother(t *testing.T) {
 	// first session will cancel before done
 	firstSessionCtx, firstCancel := context.WithTimeout(ctx, 3*time.Millisecond)
 	defer firstCancel()
-	firstRequestChan := providerQueryManager.FindProvidersAsync(firstSessionCtx, key)
+	firstRequestChan := providerQueryManager.FindProvidersAsync(firstSessionCtx, key, 0)
 	secondSessionCtx, secondCancel := context.WithTimeout(ctx, 5*time.Second)
 	defer secondCancel()
-	secondRequestChan := providerQueryManager.FindProvidersAsync(secondSessionCtx, key)
+	secondRequestChan := providerQueryManager.FindProvidersAsync(secondSessionCtx, key, 0)
 
-	var firstPeersReceived []peer.ID
+	var firstPeersReceived []peer.AddrInfo
 	for p := range firstRequestChan {
 		firstPeersReceived = append(firstPeersReceived, p)
 	}
 
-	var secondPeersReceived []peer.ID
+	var secondPeersReceived []peer.AddrInfo
 	for p := range secondRequestChan {
 		secondPeersReceived = append(secondPeersReceived, p)
 	}
@@ -180,29 +193,30 @@ func TestCancelOneRequestDoesNotTerminateAnother(t *testing.T) {
 
 func TestCancelManagerExitsGracefully(t *testing.T) {
 	peers := random.Peers(10)
-	fpn := &fakeProviderNetwork{
+	fpd := &fakeProviderDialer{}
+	fpn := &fakeProviderDiscovery{
 		peersFound: peers,
 		delay:      1 * time.Millisecond,
 	}
 	ctx := context.Background()
 	managerCtx, managerCancel := context.WithTimeout(ctx, 5*time.Millisecond)
 	defer managerCancel()
-	providerQueryManager := New(managerCtx, fpn)
+	providerQueryManager := mustNotErr(New(managerCtx, fpd, fpn))
 	providerQueryManager.Startup()
 
 	key := random.Cids(1)[0]
 
 	sessionCtx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
 	defer cancel()
-	firstRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key)
-	secondRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key)
+	firstRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key, 0)
+	secondRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key, 0)
 
-	var firstPeersReceived []peer.ID
+	var firstPeersReceived []peer.AddrInfo
 	for p := range firstRequestChan {
 		firstPeersReceived = append(firstPeersReceived, p)
 	}
 
-	var secondPeersReceived []peer.ID
+	var secondPeersReceived []peer.AddrInfo
 	for p := range secondRequestChan {
 		secondPeersReceived = append(secondPeersReceived, p)
 	}
@@ -215,28 +229,30 @@ func TestCancelManagerExitsGracefully(t *testing.T) {
 
 func TestPeersWithConnectionErrorsNotAddedToPeerList(t *testing.T) {
 	peers := random.Peers(10)
-	fpn := &fakeProviderNetwork{
-		peersFound:   peers,
+	fpd := &fakeProviderDialer{
 		connectError: errors.New("not able to connect"),
-		delay:        1 * time.Millisecond,
+	}
+	fpn := &fakeProviderDiscovery{
+		peersFound: peers,
+		delay:      1 * time.Millisecond,
 	}
 	ctx := context.Background()
-	providerQueryManager := New(ctx, fpn)
+	providerQueryManager := mustNotErr(New(ctx, fpd, fpn))
 	providerQueryManager.Startup()
 
 	key := random.Cids(1)[0]
 
 	sessionCtx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
 	defer cancel()
-	firstRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key)
-	secondRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key)
+	firstRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key, 0)
+	secondRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key, 0)
 
-	var firstPeersReceived []peer.ID
+	var firstPeersReceived []peer.AddrInfo
 	for p := range firstRequestChan {
 		firstPeersReceived = append(firstPeersReceived, p)
 	}
 
-	var secondPeersReceived []peer.ID
+	var secondPeersReceived []peer.AddrInfo
 	for p := range secondRequestChan {
 		secondPeersReceived = append(secondPeersReceived, p)
 	}
@@ -248,38 +264,39 @@ func TestPeersWithConnectionErrorsNotAddedToPeerList(t *testing.T) {
 
 func TestRateLimitingRequests(t *testing.T) {
 	peers := random.Peers(10)
-	fpn := &fakeProviderNetwork{
+	fpd := &fakeProviderDialer{}
+	fpn := &fakeProviderDiscovery{
 		peersFound: peers,
 		delay:      5 * time.Millisecond,
 	}
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	providerQueryManager := New(ctx, fpn)
+	providerQueryManager := mustNotErr(New(ctx, fpd, fpn))
 	providerQueryManager.Startup()
 
-	keys := random.Cids(maxInProcessRequests + 1)
+	keys := random.Cids(providerQueryManager.maxInProcessRequests + 1)
 	sessionCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	var requestChannels []<-chan peer.ID
-	for i := 0; i < maxInProcessRequests+1; i++ {
-		requestChannels = append(requestChannels, providerQueryManager.FindProvidersAsync(sessionCtx, keys[i]))
+	var requestChannels []<-chan peer.AddrInfo
+	for i := 0; i < providerQueryManager.maxInProcessRequests+1; i++ {
+		requestChannels = append(requestChannels, providerQueryManager.FindProvidersAsync(sessionCtx, keys[i], 0))
 	}
 	time.Sleep(20 * time.Millisecond)
 	fpn.queriesMadeMutex.Lock()
-	if fpn.liveQueries != maxInProcessRequests {
+	if fpn.liveQueries != providerQueryManager.maxInProcessRequests {
 		t.Logf("Queries made: %d\n", fpn.liveQueries)
 		t.Fatal("Did not limit parallel requests to rate limit")
 	}
 	fpn.queriesMadeMutex.Unlock()
-	for i := 0; i < maxInProcessRequests+1; i++ {
+	for i := 0; i < providerQueryManager.maxInProcessRequests+1; i++ {
 		for range requestChannels[i] {
 		}
 	}
 
 	fpn.queriesMadeMutex.Lock()
 	defer fpn.queriesMadeMutex.Unlock()
-	if fpn.queriesMade != maxInProcessRequests+1 {
+	if fpn.queriesMade != providerQueryManager.maxInProcessRequests+1 {
 		t.Logf("Queries made: %d\n", fpn.queriesMade)
 		t.Fatal("Did not make all separate requests")
 	}
@@ -287,20 +304,21 @@ func TestRateLimitingRequests(t *testing.T) {
 
 func TestFindProviderTimeout(t *testing.T) {
 	peers := random.Peers(10)
-	fpn := &fakeProviderNetwork{
+	fpd := &fakeProviderDialer{}
+	fpn := &fakeProviderDiscovery{
 		peersFound: peers,
 		delay:      10 * time.Millisecond,
 	}
 	ctx := context.Background()
-	providerQueryManager := New(ctx, fpn)
+	providerQueryManager := mustNotErr(New(ctx, fpd, fpn))
 	providerQueryManager.Startup()
-	providerQueryManager.SetFindProviderTimeout(2 * time.Millisecond)
+	providerQueryManager.setFindProviderTimeout(2 * time.Millisecond)
 	keys := random.Cids(1)
 
 	sessionCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	firstRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, keys[0])
-	var firstPeersReceived []peer.ID
+	firstRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, keys[0], 0)
+	var firstPeersReceived []peer.AddrInfo
 	for p := range firstRequestChan {
 		firstPeersReceived = append(firstPeersReceived, p)
 	}
@@ -311,19 +329,20 @@ func TestFindProviderTimeout(t *testing.T) {
 
 func TestFindProviderPreCanceled(t *testing.T) {
 	peers := random.Peers(10)
-	fpn := &fakeProviderNetwork{
+	fpd := &fakeProviderDialer{}
+	fpn := &fakeProviderDiscovery{
 		peersFound: peers,
 		delay:      1 * time.Millisecond,
 	}
 	ctx := context.Background()
-	providerQueryManager := New(ctx, fpn)
+	providerQueryManager := mustNotErr(New(ctx, fpd, fpn))
 	providerQueryManager.Startup()
-	providerQueryManager.SetFindProviderTimeout(100 * time.Millisecond)
+	providerQueryManager.setFindProviderTimeout(100 * time.Millisecond)
 	keys := random.Cids(1)
 
 	sessionCtx, cancel := context.WithCancel(ctx)
 	cancel()
-	firstRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, keys[0])
+	firstRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, keys[0], 0)
 	if firstRequestChan == nil {
 		t.Fatal("expected non-nil channel")
 	}
@@ -336,18 +355,19 @@ func TestFindProviderPreCanceled(t *testing.T) {
 
 func TestCancelFindProvidersAfterCompletion(t *testing.T) {
 	peers := random.Peers(2)
-	fpn := &fakeProviderNetwork{
+	fpd := &fakeProviderDialer{}
+	fpn := &fakeProviderDiscovery{
 		peersFound: peers,
 		delay:      1 * time.Millisecond,
 	}
 	ctx := context.Background()
-	providerQueryManager := New(ctx, fpn)
+	providerQueryManager := mustNotErr(New(ctx, fpd, fpn))
 	providerQueryManager.Startup()
-	providerQueryManager.SetFindProviderTimeout(100 * time.Millisecond)
+	providerQueryManager.setFindProviderTimeout(100 * time.Millisecond)
 	keys := random.Cids(1)
 
 	sessionCtx, cancel := context.WithCancel(ctx)
-	firstRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, keys[0])
+	firstRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, keys[0], 0)
 	<-firstRequestChan                // wait for everything to start.
 	time.Sleep(10 * time.Millisecond) // wait for the incoming providres to stop.
 	cancel()                          // cancel the context.
@@ -363,5 +383,29 @@ func TestCancelFindProvidersAfterCompletion(t *testing.T) {
 		case <-timer.C:
 			t.Fatal("should have finished receiving responses within timeout")
 		}
+	}
+}
+
+func TestLimitedProviders(t *testing.T) {
+	max := 5
+	peers := random.Peers(10)
+	fpd := &fakeProviderDialer{}
+	fpn := &fakeProviderDiscovery{
+		peersFound: peers,
+		delay:      1 * time.Millisecond,
+	}
+	ctx := context.Background()
+	providerQueryManager := mustNotErr(New(ctx, fpd, fpn, WithMaxProviders(max)))
+	providerQueryManager.Startup()
+	providerQueryManager.setFindProviderTimeout(100 * time.Millisecond)
+	keys := random.Cids(1)
+
+	providersChan := providerQueryManager.FindProvidersAsync(ctx, keys[0], 0)
+	total := 0
+	for range providersChan {
+		total++
+	}
+	if total != max {
+		t.Fatal("returned more providers than requested")
 	}
 }


### PR DESCRIPTION
fixes #640

This is an attempt at splitting the ProviderQueryManager out of Bitswap so that we can configure it more in consumers.