### PR TITLE
fix: make timer operations work with golang 1.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
+- Handle timers appropriately for go 1.23 while still being compatible with previous versions.
+
 ### Security
 
 ## [v0.22.0]

--- a/gateway/backend_car_traversal.go
+++ b/gateway/backend_car_traversal.go
@@ -81,7 +81,7 @@ func carToLinearBlockGetter(ctx context.Context, reader io.Reader, timeout time.
 		var ok bool
 		select {
 		case blkRead, ok = <-blkCh:
-			if !t.Stop() {
+			if cap(t.C) == 1 && !t.Stop() {
 				<-t.C
 			}
 			t.Reset(timeout)

--- a/provider/reprovider.go
+++ b/provider/reprovider.go
@@ -231,9 +231,9 @@ func (s *reprovider) run() {
 
 		// setup stopped timers
 		maxCollectionDurationTimer := time.NewTimer(time.Hour)
-		maxCollectionDurationTimer.Stop()
 		pauseDetectTimer := time.NewTimer(time.Hour)
-		pauseDetectTimer.Stop()
+		stopAndEmptyTimer(maxCollectionDurationTimer)
+		stopAndEmptyTimer(pauseDetectTimer)
 
 		// make sure timers are cleaned up
 		defer maxCollectionDurationTimer.Stop()

--- a/provider/reprovider.go
+++ b/provider/reprovider.go
@@ -231,9 +231,9 @@ func (s *reprovider) run() {
 
 		// setup stopped timers
 		maxCollectionDurationTimer := time.NewTimer(time.Hour)
+		maxCollectionDurationTimer.Stop()
 		pauseDetectTimer := time.NewTimer(time.Hour)
-		stopAndEmptyTimer(maxCollectionDurationTimer)
-		stopAndEmptyTimer(pauseDetectTimer)
+		pauseDetectTimer.Stop()
 
 		// make sure timers are cleaned up
 		defer maxCollectionDurationTimer.Stop()
@@ -418,8 +418,9 @@ func (s *reprovider) run() {
 	}()
 }
 
+// TODO: When go 1.23+ is required, replace this with t.Stop().
 func stopAndEmptyTimer(t *time.Timer) {
-	if !t.Stop() {
+	if !t.Stop() && cap(t.C) == 1 {
 		<-t.C
 	}
 }


### PR DESCRIPTION
In golang 1.23 reading a timer's channel after calling timer.Stop will block forever. This is fixed by looking at the timer's channel capacity to determine if the channel may need to be read following a Stop.
