### PR TITLE
feat: option to not read size of blocks for want-have requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The following emojis are used to highlight certain changes:
 ### Added
 
 * `boxo/bitswap/server`:
-  * A new `WithReplaceHasWithBlockMaxSize(n)` option can be used with `bitswap.New`. It sets the maximum size of a block in bytes up to which we will replace a want-have with a want-block. Setting a size of 0 disables this want-have replacement and means that block sizes are not read for want-have requests.
+  * A new `WithWantHaveReplaceSize(n)` option can be used with `bitswap.New`. It sets the maximum size of a block in bytes up to which the bitswap server will replace a WantHave with a WantBlock response. Setting this to 0 disables this WantHave replacement and means that block sizes are not read when processing WantHave requests.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The following emojis are used to highlight certain changes:
 
 ### Added
 
+* `boxo/bitswap/server`:
+  * A new `WithReplaceHasWithBlockMaxSize(n)` option can be used with `bitswap.New`. It sets the maximum size of a block in bytes up to which we will replace a want-have with a want-block. Setting a size of 0 disables this want-have replacement and means that block sizes are not read for want-have requests.
+
 ### Changed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The following emojis are used to highlight certain changes:
 ### Added
 
 * `boxo/bitswap/server`:
-  * A new `WithWantHaveReplaceSize(n)` option can be used with `bitswap.New`. It sets the maximum size of a block in bytes up to which the bitswap server will replace a WantHave with a WantBlock response. Setting this to 0 disables this WantHave replacement and means that block sizes are not read when processing WantHave requests.
+  * A new [`WithWantHaveReplaceSize(n)`](https://pkg.go.dev/github.com/ipfs/boxo/bitswap/server/#WithWantHaveReplaceSize) option can be used with `bitswap.New` to fine-tune cost-vs-performance. It sets the maximum size of a block in bytes up to which the bitswap server will replace a WantHave with a WantBlock response. Setting this to 0 disables this WantHave replacement and means that block sizes are not read when processing WantHave requests. [#672](https://github.com/ipfs/boxo/pull/672)
 
 ### Changed
 

--- a/bitswap/internal/defaults/defaults.go
+++ b/bitswap/internal/defaults/defaults.go
@@ -37,4 +37,7 @@ const (
 	// RebroadcastDelay is the default delay to trigger broadcast of
 	// random CIDs in the wantlist.
 	RebroadcastDelay = time.Minute
+
+	// DefaultWantHaveReplaceSize controls the implicit behavior of WithWantHaveReplaceSize.
+	DefaultWantHaveReplaceSize = 1024
 )

--- a/bitswap/options.go
+++ b/bitswap/options.go
@@ -71,12 +71,12 @@ func WithTaskComparator(comparator server.TaskComparator) Option {
 	return Option{server.WithTaskComparator(comparator)}
 }
 
-// WithReplaceHasWithBlockMaxSize sets the maximum size of a block in bytes up
-// to which we will replace a want-have with a want-block. Setting a size of 0
-// disables this want-have replacement and means that block sizes are not read
-// for want-have requests.
-func WithReplaceHasWithBlockMaxSize(maxSize int) Option {
-	return Option{server.WithReplaceHasWithBlockMaxSize(maxSize)}
+// WithWantHaveReplaceSize sets the maximum size of a block in bytes up to
+// which the bitswap server will replace a WantHave with a WantBlock response.
+// Setting this to 0 disables this WantHave replacement and means that block
+// sizes are not read when processing WantHave requests.
+func WithWantHaveReplaceSize(size int) Option {
+	return Option{server.WithWantHaveReplaceSize(size)}
 }
 
 func ProviderSearchDelay(newProvSearchDelay time.Duration) Option {

--- a/bitswap/options.go
+++ b/bitswap/options.go
@@ -71,6 +71,14 @@ func WithTaskComparator(comparator server.TaskComparator) Option {
 	return Option{server.WithTaskComparator(comparator)}
 }
 
+// WithReplaceHasWithBlockMaxSize sets the maximum size of a block in bytes up
+// to which we will replace a want-have with a want-block. Setting a size of 0
+// disables this want-have replacement and means that block sizes are not read
+// for want-have requests.
+func WithReplaceHasWithBlockMaxSize(maxSize int) Option {
+	return Option{server.WithReplaceHasWithBlockMaxSize(maxSize)}
+}
+
 func ProviderSearchDelay(newProvSearchDelay time.Duration) Option {
 	return Option{client.ProviderSearchDelay(newProvSearchDelay)}
 }

--- a/bitswap/options.go
+++ b/bitswap/options.go
@@ -73,8 +73,7 @@ func WithTaskComparator(comparator server.TaskComparator) Option {
 
 // WithWantHaveReplaceSize sets the maximum size of a block in bytes up to
 // which the bitswap server will replace a WantHave with a WantBlock response.
-// Setting this to 0 disables this WantHave replacement and means that block
-// sizes are not read when processing WantHave requests.
+// See [server.WithWantHaveReplaceSize] for details.
 func WithWantHaveReplaceSize(size int) Option {
 	return Option{server.WithWantHaveReplaceSize(size)}
 }

--- a/bitswap/server/internal/decision/blockstoremanager.go
+++ b/bitswap/server/internal/decision/blockstoremanager.go
@@ -132,7 +132,7 @@ func (bsm *blockstoreManager) hasBlocks(ctx context.Context, ks []cid.Cid) (map[
 		has, err := bsm.bs.Has(ctx, c)
 		if err != nil {
 			// Note: this isn't a fatal error. We shouldn't abort the request
-			log.Errorf("blockstore.GetSize(%s) error: %s", c, err)
+			log.Errorf("blockstore.Has(%c) error: %s", c, err)
 			return
 		}
 		if has {

--- a/bitswap/server/internal/decision/blockstoremanager_test.go
+++ b/bitswap/server/internal/decision/blockstoremanager_test.go
@@ -98,29 +98,22 @@ func TestBlockstoreManager(t *testing.T) {
 		cids = append(cids, b.Cid())
 	}
 
-	sizes, err := bsm.getBlockSizes(ctx, cids)
+	hasBlocks, err := bsm.hasBlocks(ctx, cids)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(sizes) != len(blks)-1 {
+	if len(hasBlocks) != len(blks)-1 {
 		t.Fatal("Wrong response length")
 	}
-
 	for _, c := range cids {
-		expSize := len(exp[c].RawData())
-		size, ok := sizes[c]
-
-		// Only the last key should be missing
+		_, ok := hasBlocks[c]
 		if c.Equals(cids[len(cids)-1]) {
 			if ok {
 				t.Fatal("Non-existent block should not be in sizes map")
 			}
 		} else {
 			if !ok {
-				t.Fatal("Block should be in sizes map")
-			}
-			if size != expSize {
-				t.Fatal("Block has wrong size")
+				t.Fatal("Block should be in hasBlocks")
 			}
 		}
 	}

--- a/bitswap/server/internal/decision/engine.go
+++ b/bitswap/server/internal/decision/engine.go
@@ -714,7 +714,6 @@ func (e *Engine) MessageReceived(ctx context.Context, p peer.ID, m bsmsg.BitSwap
 			}
 			for blkCid := range hasBlocks {
 				blockSizes[blkCid] = 0
-				fmt.Println("   block cid:", blkCid)
 			}
 		}
 	}

--- a/bitswap/server/internal/decision/engine.go
+++ b/bitswap/server/internal/decision/engine.go
@@ -435,6 +435,12 @@ func NewEngine(
 
 	e.peerRequestQueue = peertaskqueue.New(peerTaskQueueOpts...)
 
+	if e.replaceHasWithBlockMaxSize == 0 {
+		log.Info("Replace WantHave with WantBlock is disabled")
+	} else {
+		log.Infow("Replace WantHave with WantBlock is enabled", "maxSize", e.replaceHasWithBlockMaxSize)
+	}
+
 	return e
 }
 

--- a/bitswap/server/internal/decision/engine.go
+++ b/bitswap/server/internal/decision/engine.go
@@ -702,11 +702,14 @@ func (e *Engine) MessageReceived(ctx context.Context, p peer.ID, m bsmsg.BitSwap
 			log.Info("aborting message processing", err)
 			return false
 		}
-		if blockSizes == nil {
-			blockSizes = make(map[cid.Cid]int, len(hasBlocks))
-		}
-		for blkCid := range hasBlocks {
-			blockSizes[blkCid] = 0
+		if len(hasBlocks) != 0 {
+			if blockSizes == nil {
+				blockSizes = make(map[cid.Cid]int, len(hasBlocks))
+			}
+			for blkCid := range hasBlocks {
+				blockSizes[blkCid] = 0
+				fmt.Println("   block cid:", blkCid)
+			}
 		}
 	}
 

--- a/bitswap/server/internal/decision/engine.go
+++ b/bitswap/server/internal/decision/engine.go
@@ -77,10 +77,6 @@ const (
 	// queuedTagWeight is the default weight for peers that have work queued
 	// on their behalf.
 	queuedTagWeight = 10
-
-	// defaultWantHave ReplaceSize is the default maximum size of the block in
-	// bytes up to which we will replace a WantHave with a WantBlock response.
-	defaultWantHaveReplaceSize = 1024
 )
 
 // Envelope contains a message for a Peer.
@@ -394,7 +390,7 @@ func NewEngine(
 		outbox:                          make(chan (<-chan *Envelope), outboxChanBuffer),
 		workSignal:                      make(chan struct{}, 1),
 		ticker:                          time.NewTicker(time.Millisecond * 100),
-		wantHaveReplaceSize:             defaultWantHaveReplaceSize,
+		wantHaveReplaceSize:             defaults.DefaultWantHaveReplaceSize,
 		taskWorkerCount:                 defaults.BitswapEngineTaskWorkerCount,
 		sendDontHaves:                   true,
 		self:                            self,

--- a/bitswap/server/internal/decision/engine_test.go
+++ b/bitswap/server/internal/decision/engine_test.go
@@ -188,10 +188,10 @@ func newEngineForTesting(
 	bs blockstore.Blockstore,
 	peerTagger PeerTagger,
 	self peer.ID,
-	maxReplaceSize int,
+	wantHaveReplaceSize int,
 	opts ...Option,
 ) *Engine {
-	opts = append(opts, WithReplaceHasWithBlockMaxSize(maxReplaceSize))
+	opts = append(opts, WithWantHaveReplaceSize(wantHaveReplaceSize))
 	return NewEngine(ctx, bs, peerTagger, self, opts...)
 }
 

--- a/bitswap/server/internal/decision/engine_test.go
+++ b/bitswap/server/internal/decision/engine_test.go
@@ -191,14 +191,8 @@ func newEngineForTesting(
 	maxReplaceSize int,
 	opts ...Option,
 ) *Engine {
-	return newEngine(
-		ctx,
-		bs,
-		peerTagger,
-		self,
-		maxReplaceSize,
-		opts...,
-	)
+	opts = append(opts, WithReplaceHasWithBlockMaxSize(maxReplaceSize))
+	return NewEngine(ctx, bs, peerTagger, self, opts...)
 }
 
 func TestOutboxClosedWhenEngineClosed(t *testing.T) {

--- a/bitswap/server/server.go
+++ b/bitswap/server/server.go
@@ -251,6 +251,19 @@ func HasBlockBufferSize(count int) Option {
 	}
 }
 
+// WithReplaceHasWithBlockMaxSize sets the maximum size of a block in bytes up
+// to which we will replace a want-have with a want-block. Setting a size of 0
+// disables this want-have replacement and means that block sizes are not read
+// for want-have requests.
+func WithReplaceHasWithBlockMaxSize(maxSize int) Option {
+	if maxSize < 0 {
+		maxSize = 0
+	}
+	return func(bs *Server) {
+		bs.engineOptions = append(bs.engineOptions, decision.WithReplaceHasWithBlockMaxSize(maxSize))
+	}
+}
+
 // WantlistForPeer returns the currently understood list of blocks requested by a
 // given peer.
 func (bs *Server) WantlistForPeer(p peer.ID) []cid.Cid {

--- a/bitswap/server/server.go
+++ b/bitswap/server/server.go
@@ -252,9 +252,27 @@ func HasBlockBufferSize(count int) Option {
 }
 
 // WithWantHaveReplaceSize sets the maximum size of a block in bytes up to
-// which to replace a WantHave with a WantBlock. Setting to 0 disables this
-// WantHave replacement and means that block sizes are not read when processing
-// WantHave requests.
+// which the bitswap server will replace a WantHave with a WantBlock response.
+//
+// Behavior:
+//   - If size > 0: The server may send full blocks instead of just confirming possession
+//     for blocks up to the specified size.
+//   - If size = 0: WantHave replacement is disabled entirely. This allows the server to
+//     skip reading block sizes during WantHave request processing, which can be more
+//     efficient if the data storage bills "possession" checks and "reads" differently.
+//
+// Performance considerations:
+//   - Enabling replacement (size > 0) may reduce network round-trips but requires
+//     checking block sizes for each WantHave request to decide if replacement should occur.
+//   - Disabling replacement (size = 0) optimizes server performance by avoiding
+//     block size checks, potentially reducing infrastructure costs if possession checks
+//     are less expensive than full reads.
+//
+// The default implicit behavior is unspecified and may change in future releases.
+//
+// Use this option to set explicit behavior to balance between network
+// efficiency, server performance, and potential storage cost optimizations
+// based on your specific use case and storage backend.
 func WithWantHaveReplaceSize(size int) Option {
 	if size < 0 {
 		size = 0

--- a/bitswap/server/server.go
+++ b/bitswap/server/server.go
@@ -251,16 +251,16 @@ func HasBlockBufferSize(count int) Option {
 	}
 }
 
-// WithReplaceHasWithBlockMaxSize sets the maximum size of a block in bytes up
-// to which we will replace a want-have with a want-block. Setting a size of 0
-// disables this want-have replacement and means that block sizes are not read
-// for want-have requests.
-func WithReplaceHasWithBlockMaxSize(maxSize int) Option {
-	if maxSize < 0 {
-		maxSize = 0
+// WithWantHaveReplaceSize sets the maximum size of a block in bytes up to
+// which to replace a WantHave with a WantBlock. Setting to 0 disables this
+// WantHave replacement and means that block sizes are not read when processing
+// WantHave requests.
+func WithWantHaveReplaceSize(size int) Option {
+	if size < 0 {
+		size = 0
 	}
 	return func(bs *Server) {
-		bs.engineOptions = append(bs.engineOptions, decision.WithReplaceHasWithBlockMaxSize(maxSize))
+		bs.engineOptions = append(bs.engineOptions, decision.WithWantHaveReplaceSize(size))
 	}
 }
 

--- a/bitswap/server/server.go
+++ b/bitswap/server/server.go
@@ -268,7 +268,8 @@ func HasBlockBufferSize(count int) Option {
 //     block size checks, potentially reducing infrastructure costs if possession checks
 //     are less expensive than full reads.
 //
-// The default implicit behavior is unspecified and may change in future releases.
+// It defaults to [defaults.DefaultWantHaveReplaceSize]
+// and the value may change in future releases.
 //
 // Use this option to set explicit behavior to balance between network
 // efficiency, server performance, and potential storage cost optimizations


### PR DESCRIPTION
When the replace-have-with-want-blocks is disabled, the block sizes for blocks corresponding to have-want requests are not read and instead the blockstore is checked only to see if the block is present.

The replace-have-with-want-blocks feature can be disabled using the new `WithReplaceHasWithBlockMaxSize(n)` option which can be used with `bitswap.New`. It sets the maximum size of a block in bytes up to which we will replace a want-have with a want-block. Setting a size of 0 disables want-have replacement and means that block sizes are not read for want-have requests.

Aims to fix #657
