### PR TITLE
refactor: reuse timers instead of time.After in loops

### DIFF
--- a/bitswap/network/ipfs_impl.go
+++ b/bitswap/network/ipfs_impl.go
@@ -179,10 +179,13 @@ func (s *streamMessageSender) multiAttempt(ctx context.Context, fn func() error)
 			return err
 		}
 
+		timer := time.NewTimer(s.opts.SendErrorBackoff)
+		defer timer.Stop()
+
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(s.opts.SendErrorBackoff):
+		case <-timer.C:
 			// wait a short time in case disconnect notifications are still propagating
 			log.Infof("send message to %s failed but context was not Done: %s", s.to, err)
 		}

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -304,15 +304,19 @@ func peersConnect(ctx context.Context, ph host.Host, availablePeers []peer.AddrI
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	go func() {
+		timer := time.NewTimer(time.Second)
+		defer timer.Stop()
+
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case <-time.After(1 * time.Second):
+			case <-timer.C:
 				if int(atomic.LoadUint64(&connected)) >= needed {
 					cancel()
 					return
 				}
+				timer.Reset(time.Second)
 			}
 		}
 	}()


### PR DESCRIPTION
Reusing a timer repeatedly results in less GC than time.After in each loop iteration.

Closes #122
