### PR TITLE
feat(routing/http/client): DefaultProtocolFilter for IPIP-484

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The following emojis are used to highlight certain changes:
 
 ### Changed
 
+- `routing/http/client`: creating delegated routing client with `New` now defaults to querying delegated routing server with `DefaultProtocolFilter`  ([IPIP-484](https://github.com/ipfs/specs/pull/484)) [#689](https://github.com/ipfs/boxo/pull/689)
+
 ### Removed
 
 ### Fixed

--- a/examples/routing/delegated-routing-client/main_test.go
+++ b/examples/routing/delegated-routing-client/main_test.go
@@ -25,7 +25,7 @@ func TestFindProviders(t *testing.T) {
 		if r.URL.Path == "/routing/v1/providers/"+cidStr {
 			w.Header().Set("Content-Type", "application/x-ndjson")
 			w.Write([]byte(`{"Schema":"peer","ID":"12D3KooWM8sovaEGU1bmiWGWAzvs47DEcXKZZTuJnpQyVTkRs2Vn","Addrs":["/ip4/111.222.222.111/tcp/5734"],"Protocols":["transport-bitswap"]}` + "\n"))
-			w.Write([]byte(`{"Schema":"peer","ID":"12D3KooWB6RAWgcmHAP7TGEGK7utV2ZuqSzX1DNjRa97TtJ7139n","Addrs":["/ip4/127.0.0.1/tcp/5734"],"Protocols":["transport-horse"]}` + "\n"))
+			w.Write([]byte(`{"Schema":"peer","ID":"12D3KooWB6RAWgcmHAP7TGEGK7utV2ZuqSzX1DNjRa97TtJ7139n","Addrs":["/ip4/127.0.0.1/tcp/5734"],"Protocols":[]}` + "\n"))
 		}
 	}))
 	t.Cleanup(ts.Close)
@@ -33,7 +33,7 @@ func TestFindProviders(t *testing.T) {
 	out := &bytes.Buffer{}
 	err := run(out, ts.URL, cidStr, "", "", 1)
 	assert.Contains(t, out.String(), "12D3KooWM8sovaEGU1bmiWGWAzvs47DEcXKZZTuJnpQyVTkRs2Vn\n\tProtocols: [transport-bitswap]\n\tAddresses: [/ip4/111.222.222.111/tcp/5734]\n")
-	assert.Contains(t, out.String(), "12D3KooWB6RAWgcmHAP7TGEGK7utV2ZuqSzX1DNjRa97TtJ7139n\n\tProtocols: [transport-horse]\n\tAddresses: [/ip4/127.0.0.1/tcp/5734]\n")
+	assert.Contains(t, out.String(), "12D3KooWB6RAWgcmHAP7TGEGK7utV2ZuqSzX1DNjRa97TtJ7139n\n\tProtocols: []\n\tAddresses: [/ip4/127.0.0.1/tcp/5734]\n")
 	assert.NoError(t, err)
 }
 

--- a/examples/routing/delegated-routing-client/main_test.go
+++ b/examples/routing/delegated-routing-client/main_test.go
@@ -25,6 +25,7 @@ func TestFindProviders(t *testing.T) {
 		if r.URL.Path == "/routing/v1/providers/"+cidStr {
 			w.Header().Set("Content-Type", "application/x-ndjson")
 			w.Write([]byte(`{"Schema":"peer","ID":"12D3KooWM8sovaEGU1bmiWGWAzvs47DEcXKZZTuJnpQyVTkRs2Vn","Addrs":["/ip4/111.222.222.111/tcp/5734"],"Protocols":["transport-bitswap"]}` + "\n"))
+			w.Write([]byte(`{"Schema":"peer","ID":"12D3KooWS6BmwfQEZcRqCHCBbDL2DF5a6F7dZnbPFkwmZCuLEK5f","Addrs":["/ip4/127.0.0.1/tcp/6434"],"Protocols":["horse"]}` + "\n")) // this one will be skipped by DefaultProtocolFilter
 			w.Write([]byte(`{"Schema":"peer","ID":"12D3KooWB6RAWgcmHAP7TGEGK7utV2ZuqSzX1DNjRa97TtJ7139n","Addrs":["/ip4/127.0.0.1/tcp/5734"],"Protocols":[]}` + "\n"))
 		}
 	}))

--- a/routing/http/client/client.go
+++ b/routing/http/client/client.go
@@ -33,6 +33,8 @@ import (
 var (
 	_      contentrouter.Client = &Client{}
 	logger                      = logging.Logger("routing/http/client")
+
+	DefaultProtocolFilter = []string{"unknown", "transport-bitswap"} // IPIP-484
 )
 
 const (
@@ -175,10 +177,11 @@ func WithStreamResultsRequired() Option {
 // The Provider and identity parameters are option. If they are nil, the [client.ProvideBitswap] method will not function.
 func New(baseURL string, opts ...Option) (*Client, error) {
 	client := &Client{
-		baseURL:    baseURL,
-		httpClient: newDefaultHTTPClient(defaultUserAgent),
-		clock:      clock.New(),
-		accepts:    strings.Join([]string{mediaTypeNDJSON, mediaTypeJSON}, ","),
+		baseURL:        baseURL,
+		httpClient:     newDefaultHTTPClient(defaultUserAgent),
+		clock:          clock.New(),
+		accepts:        strings.Join([]string{mediaTypeNDJSON, mediaTypeJSON}, ","),
+		protocolFilter: DefaultProtocolFilter, // can be customized via WithProtocolFilter
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
This PR makes `routing/http/client` initialize with implicit default protocol filter from [IPIP-484](https://github.com/ipfs/specs/pull/484) set to `unknown` + `transport-bitswap`, matching what we explicitly set in Kubo (https://github.com/ipfs/kubo/pull/10534) and Rainbow (https://github.com/ipfs/rainbow/pull/173/). 

## Rationale

 boxo users can change or disable default filter via `WithProtocolFilter` option, but the default should be filter that is optimized for golden path, which currently means bitswap. Processing peers that we know only support unsupported protocols is wasting resources and we should skip them.

Over time, we may add new protocols like http to boxo, and we will also adjust the default list accordingly.


## TODO

- [x] refactor `routing/http/client` to use `DefaultProtocolFilter`
- [x] refactor `examples/routing/delegated-routing-client` to reflect implicit defaults