### PR TITLE
fix(bitswap/session): cleanup live wants on cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ The following emojis are used to highlight certain changes:
 ### Fixed
 
 - `routing/http/client`: optional address and protocol filter parameters from [IPIP-484](https://github.com/ipfs/specs/pull/484) use human-readable `,` instead of `%2C`. [#688](https://github.com/ipfs/boxo/pull/688)
-- `bitswap/client` Cleanup live wants when wants are canceled. This prevents live wants from continuing to get rebroadcasted even after the wants are canceled.
+- `bitswap/client` Cleanup live wants when wants are canceled. This prevents live wants from continuing to get rebroadcasted even after the wants are canceled. [#690](https://github.com/ipfs/boxo/pull/690)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The following emojis are used to highlight certain changes:
 ### Fixed
 
 - `routing/http/client`: optional address and protocol filter parameters from [IPIP-484](https://github.com/ipfs/specs/pull/484) use human-readable `,` instead of `%2C`. [#688](https://github.com/ipfs/boxo/pull/688)
+- `bitswap/client` Cleanup live wants when wants are canceled. This prevents live wants from continuing to get rebroadcasted even after the wants are canceled.
 
 ### Security
 

--- a/bitswap/client/internal/session/sessionwants.go
+++ b/bitswap/client/internal/session/sessionwants.go
@@ -148,6 +148,7 @@ func (sw *sessionWants) PrepareBroadcast() []cid.Cid {
 func (sw *sessionWants) CancelPending(keys []cid.Cid) {
 	for _, k := range keys {
 		sw.toFetch.Remove(k)
+		delete(sw.liveWants, k)
 	}
 }
 


### PR DESCRIPTION
Otherwise, live wants get rebroadcasted forever, even when we canceled those.

