### PR TITLE
Update go-test workflow to use ipdxco

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -15,6 +15,6 @@ concurrency:
 
 jobs:
   go-test:
-    uses: ipfs/uci/.github/workflows/go-test.yml@v1.0
+    uses: ipdxco/unified-github-workflows/.github/workflows/go-test.yml@v1.0
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Make go-test workflow use `ipdxco/unified-github-workflows/.github/workflows/go-test.yml@v1.0` and not `ipfs/uci/.github/workflows/go-test.yml@v1.0`