### PR TITLE
Remove dependency on goprocess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The following emojis are used to highlight certain changes:
 
 ### Changed
 
+- No longer using `github.com/jbenet/goprocess` to avoid requiring in dependents.
+
 ### Removed
 
 ### Fixed

--- a/bitswap/bitswap.go
+++ b/bitswap/bitswap.go
@@ -144,10 +144,9 @@ func (bs *Bitswap) Stat() (*Stat, error) {
 
 func (bs *Bitswap) Close() error {
 	bs.net.Stop()
-	return multierr.Combine(
-		bs.Client.Close(),
-		bs.Server.Close(),
-	)
+	bs.Client.Close()
+	bs.Server.Close()
+	return nil
 }
 
 func (bs *Bitswap) WantlistForPeer(p peer.ID) []cid.Cid {

--- a/bitswap/client/client.go
+++ b/bitswap/client/client.go
@@ -31,8 +31,6 @@ import (
 	delay "github.com/ipfs/go-ipfs-delay"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/ipfs/go-metrics-interface"
-	process "github.com/jbenet/goprocess"
-	procctx "github.com/jbenet/goprocess/context"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -117,10 +115,6 @@ func New(parent context.Context, network bsnet.BitSwapNetwork, bstore blockstore
 	// exclusively. We should probably find another way to share logging data
 	ctx, cancelFunc := context.WithCancel(parent)
 
-	px := process.WithTeardown(func() error {
-		return nil
-	})
-
 	// onDontHaveTimeout is called when a want-block is sent to a peer that
 	// has an old version of Bitswap that doesn't support DONT_HAVE messages,
 	// or when no response is received within a timeout.
@@ -165,7 +159,8 @@ func New(parent context.Context, network bsnet.BitSwapNetwork, bstore blockstore
 	bs = &Client{
 		blockstore:                 bstore,
 		network:                    network,
-		process:                    px,
+		cancel:                     cancelFunc,
+		closing:                    make(chan struct{}),
 		pm:                         pm,
 		sm:                         sm,
 		sim:                        sim,
@@ -185,16 +180,6 @@ func New(parent context.Context, network bsnet.BitSwapNetwork, bstore blockstore
 
 	pqm.Startup()
 
-	// bind the context and process.
-	// do it over here to avoid closing before all setup is done.
-	go func() {
-		<-px.Closing() // process closes first
-		sm.Shutdown()
-		cancelFunc()
-		notif.Shutdown()
-	}()
-	procctx.CloseAfterContext(px, ctx) // parent cancelled first
-
 	return bs
 }
 
@@ -212,7 +197,9 @@ type Client struct {
 	// manages channels of outgoing blocks for sessions
 	notif notifications.PubSub
 
-	process process.Process
+	cancel    context.CancelFunc
+	closing   chan struct{}
+	closeOnce sync.Once
 
 	// Counters for various statistics
 	counterLk sync.Mutex
@@ -287,7 +274,7 @@ func (bs *Client) NotifyNewBlocks(ctx context.Context, blks ...blocks.Block) err
 	defer span.End()
 
 	select {
-	case <-bs.process.Closing():
+	case <-bs.closing:
 		return errors.New("bitswap is closed")
 	default:
 	}
@@ -310,10 +297,10 @@ func (bs *Client) NotifyNewBlocks(ctx context.Context, blks ...blocks.Block) err
 	return nil
 }
 
-// receiveBlocksFrom process blocks received from the network
+// receiveBlocksFrom processes blocks received from the network
 func (bs *Client) receiveBlocksFrom(ctx context.Context, from peer.ID, blks []blocks.Block, haves []cid.Cid, dontHaves []cid.Cid) error {
 	select {
-	case <-bs.process.Closing():
+	case <-bs.closing:
 		return errors.New("bitswap is closed")
 	default:
 	}
@@ -465,8 +452,13 @@ func (bs *Client) ReceiveError(err error) {
 }
 
 // Close is called to shutdown the Client
-func (bs *Client) Close() error {
-	return bs.process.Close()
+func (bs *Client) Close() {
+	bs.closeOnce.Do(func() {
+		close(bs.closing)
+		bs.sm.Shutdown()
+		bs.cancel()
+		bs.notif.Shutdown()
+	})
 }
 
 // GetWantlist returns the current local wantlist (both want-blocks and

--- a/bitswap/client/client.go
+++ b/bitswap/client/client.go
@@ -452,13 +452,14 @@ func (bs *Client) ReceiveError(err error) {
 }
 
 // Close is called to shutdown the Client
-func (bs *Client) Close() {
+func (bs *Client) Close() error {
 	bs.closeOnce.Do(func() {
 		close(bs.closing)
 		bs.sm.Shutdown()
 		bs.cancel()
 		bs.notif.Shutdown()
 	})
+	return nil
 }
 
 // GetWantlist returns the current local wantlist (both want-blocks and

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,6 @@ require (
 	github.com/ipld/go-car/v2 v2.14.2
 	github.com/ipld/go-codec-dagpb v1.6.0
 	github.com/ipld/go-ipld-prime v0.21.0
-	github.com/jbenet/goprocess v0.1.4
 	github.com/libp2p/go-buffer-pool v0.1.0
 	github.com/libp2p/go-doh-resolver v0.4.0
 	github.com/libp2p/go-libp2p v0.37.0
@@ -118,6 +117,7 @@ require (
 	github.com/ipfs/go-verifcid v0.0.3 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
+	github.com/jbenet/goprocess v0.1.4 // indirect
 	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.8 // indirect
 	github.com/koron/go-ssdp v0.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -233,7 +233,6 @@ github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20230102063945-1a409dc236
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20230102063945-1a409dc236dd/go.mod h1:wZ8hH8UxeryOs4kJEJaiui/s00hDSbE37OKsL47g+Sw=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=
 github.com/jackpal/go-nat-pmp v1.0.2/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
-github.com/jbenet/go-cienv v0.1.0 h1:Vc/s0QbQtoxX8MwwSLWWh+xNNZvM3Lw7NsTcHrvvhMc=
 github.com/jbenet/go-cienv v0.1.0/go.mod h1:TqNnHUmJgXau0nCzC7kXWeotg3J9W34CUv5Djy1+FlA=
 github.com/jbenet/go-temp-err-catcher v0.1.0 h1:zpb3ZH6wIE8Shj2sKS+khgRvf7T7RABoLk/+KKHggpk=
 github.com/jbenet/go-temp-err-catcher v0.1.0/go.mod h1:0kJRvmDZXNMIiJirNPEYfhpPwbGVtZVWC34vc5WLsDk=

--- a/namesys/republisher/repub.go
+++ b/namesys/republisher/repub.go
@@ -16,8 +16,6 @@ import (
 	"github.com/ipfs/boxo/ipns"
 	ds "github.com/ipfs/go-datastore"
 	logging "github.com/ipfs/go-log/v2"
-	"github.com/jbenet/goprocess"
-	gpctx "github.com/jbenet/goprocess/context"
 	ic "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
@@ -67,8 +65,17 @@ func NewRepublisher(ns namesys.Publisher, ds ds.Datastore, self ic.PrivKey, ks k
 	}
 }
 
-// Run starts the republisher facility. It can be stopped by stopping the provided proc.
-func (rp *Republisher) Run(proc goprocess.Process) {
+// Run starts the republisher facility. It can be stopped by calling the returned function..
+func (rp *Republisher) Run() func() {
+	ctx, cancel := context.WithCancel(context.Background())
+	go rp.run(ctx)
+	return func() {
+		log.Debug("stopping republisher")
+		cancel()
+	}
+}
+
+func (rp *Republisher) run(ctx context.Context) {
 	timer := time.NewTimer(InitialRebroadcastDelay)
 	defer timer.Stop()
 	if rp.Interval < InitialRebroadcastDelay {
@@ -79,21 +86,21 @@ func (rp *Republisher) Run(proc goprocess.Process) {
 		select {
 		case <-timer.C:
 			timer.Reset(rp.Interval)
-			err := rp.republishEntries(proc)
+			err := rp.republishEntries(ctx)
 			if err != nil {
 				log.Info("republisher failed to republish: ", err)
 				if FailureRetryInterval < rp.Interval {
 					timer.Reset(FailureRetryInterval)
 				}
 			}
-		case <-proc.Closing():
+		case <-ctx.Done():
 			return
 		}
 	}
 }
 
-func (rp *Republisher) republishEntries(p goprocess.Process) error {
-	ctx, cancel := context.WithCancel(gpctx.OnClosingContext(p))
+func (rp *Republisher) republishEntries(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	ctx, span := startSpan(ctx, "Republisher.RepublishEntries")
 	defer span.End()

--- a/namesys/republisher/repub_test.go
+++ b/namesys/republisher/repub_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jbenet/goprocess"
 	"github.com/libp2p/go-libp2p"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	ic "github.com/libp2p/go-libp2p/core/crypto"
@@ -125,8 +124,8 @@ func TestRepublish(t *testing.T) {
 	repub.Interval = time.Second
 	repub.RecordLifetime = time.Second * 5
 
-	proc := goprocess.Go(repub.Run)
-	defer proc.Close()
+	stop := repub.Run()
+	defer stop()
 
 	// now wait a couple seconds for it to fire
 	time.Sleep(time.Second * 2)
@@ -182,8 +181,8 @@ func TestLongEOLRepublish(t *testing.T) {
 	repub.Interval = time.Millisecond * 500
 	repub.RecordLifetime = time.Second
 
-	proc := goprocess.Go(repub.Run)
-	defer proc.Close()
+	stop := repub.Run()
+	defer stop()
 
 	// now wait a couple seconds for it to fire a few times
 	time.Sleep(time.Second * 2)


### PR DESCRIPTION
The dependency on goprocess is not needed by boxo, and removing it removes the need to support it in code dependent on boxo.

Closes #709
Closes #130
