### PR TITLE
fix(bitswap): log unexpected blocks to debug level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,14 +18,12 @@ The following emojis are used to highlight certain changes:
 
 ### Changed
 
-- updated to go-libp2p to [v0.37.0](https://github.com/libp2p/go-libp2p/releases/tag/v0.37.0)
-
 ### Removed
 
 ### Fixed
 
-- Fix panic if current live count is greater than broadcast limit [#702](https://github.com/ipfs/boxo/pull/702)
- 
+- `bitswap/client` no longer logs `"Received provider X for cid Y not requested` to ERROR level, moved to DEBUG [#771](https://github.com/ipfs/boxo/pull/711)
+
 ### Security
 
 ## [v0.24.2]

--- a/bitswap/client/internal/providerquerymanager/providerquerymanager.go
+++ b/bitswap/client/internal/providerquerymanager/providerquerymanager.go
@@ -355,7 +355,7 @@ func (rpm *receivedProviderMessage) debugMessage() {
 func (rpm *receivedProviderMessage) handle(pqm *ProviderQueryManager) {
 	requestStatus, ok := pqm.inProgressRequestStatuses[rpm.k]
 	if !ok {
-		log.Errorf("Received provider (%s) for cid (%s) not requested", rpm.p.String(), rpm.k.String())
+		log.Debugf("Received provider (%s) for cid (%s) not requested", rpm.p.String(), rpm.k.String())
 		return
 	}
 	requestStatus.providersSoFar = append(requestStatus.providersSoFar, rpm.p)


### PR DESCRIPTION
With recent fixes we may be hitting case where we receive "unexpected" block more often (dropping wantlist overflow etc).

This produces unactionable error in logs, for example, kubo staging box:

```
Nov 04 17:14:40 kubo-staging-us-east-02 ipfs[14572]: 2024-11-04T17:14:40.556Z        ERROR        bitswap/client/provqrymgr        providerquerymanager/providerquerymanager.go:358        Received provider (QmQzqxhK82kAmKvARFZSkUVS6fo9sySaiogAnx5EnZ6ZmC) for cid (bafybeieooer53vz7sm33oxxj4xbx4iw2nir74m7hpg43ph4oluabsn6eja) not requested
Nov 04 17:32:57 kubo-staging-us-east-02 ipfs[14572]: 2024-11-04T17:32:57.367Z        ERROR        bitswap/client/provqrymgr        providerquerymanager/providerquerymanager.go:358        Received provider (QmQzqxhK82kAmKvARFZSkUVS6fo9sySaiogAnx5EnZ6ZmC) for cid (bafybeihv3ykvji2jmhvxpnbydcoe5wkips3fvdvav3yxvfbbrqcjbphgxq) not requested
Nov 04 17:33:55 kubo-staging-us-east-02 ipfs[14572]: 2024-11-04T17:33:55.923Z        ERROR        bitswap/client/provqrymgr        providerquerymanager/providerquerymanager.go:358        Received provider (12D3KooWKvFjYQ3R2uXRxpPA77iN7e1CfrGFjEXHB5vBKmim2tjw) for cid (bafkreig3473pmj27yolvzlxy3nwqt47vtvgqaalgr7l734bnzzlsmcr5da) not requested
Nov 04 17:33:55 kubo-staging-us-east-02 ipfs[14572]: 2024-11-04T17:33:55.930Z        ERROR        bitswap/client/provqrymgr        providerquerymanager/providerquerymanager.go:358        Received provider (QmQzqxhK82kAmKvARFZSkUVS6fo9sySaiogAnx5EnZ6ZmC) for cid (bafkreig3473pmj27yolvzlxy3nwqt47vtvgqaalgr7l734bnzzlsmcr5da) not requested
Nov 04 17:35:29 kubo-staging-us-east-02 ipfs[14572]: 2024-11-04T17:35:29.834Z        ERROR        bitswap/client/provqrymgr        providerquerymanager/providerquerymanager.go:358        Received provider (12D3KooWKvFjYQ3R2uXRxpPA77iN7e1CfrGFjEXHB5vBKmim2tjw) for cid (bafkreiaynygymin4wlzbf7hhzjjy6yjnmehzcmqkftkjqnfhdk2w6pkavq) not requested
```

I feel due to nature of this error, it should be a debug level, and not Error.