### PR TITLE
bitswap: SessionInterestManager can consider unwanted blocks as interesting

### DIFF
--- a/bitswap/client/internal/sessioninterestmanager/sessioninterestmanager.go
+++ b/bitswap/client/internal/sessioninterestmanager/sessioninterestmanager.go
@@ -131,7 +131,7 @@ func (sim *SessionInterestManager) FilterSessionInterested(ses uint64, ksets ...
 		// For each key in the list
 		for _, c := range ks {
 			// If there is a session that's interested, add the key to the set
-			if _, ok := sim.wants[c][ses]; ok {
+			if wanted, ok := sim.wants[c][ses]; ok && wanted {
 				has = append(has, c)
 			}
 		}

--- a/bitswap/client/internal/sessioninterestmanager/sessioninterestmanager_test.go
+++ b/bitswap/client/internal/sessioninterestmanager/sessioninterestmanager_test.go
@@ -83,6 +83,20 @@ func TestInterestedSessions(t *testing.T) {
 	}
 }
 
+func TestRemoveSessionWants(t *testing.T) {
+	sim := New()
+
+	const ses = 1
+	cids := random.Cids(3)
+	sim.RecordSessionInterest(ses, cids[0:2])
+	sim.RemoveSessionWants(ses, cids)
+	res := sim.FilterSessionInterested(ses, cids)
+
+	if len(res) > 0 {
+		t.Fatal("wants have not been removed")
+	}
+}
+
 func TestRemoveSession(t *testing.T) {
 	sim := New()
 

--- a/bitswap/client/internal/sessioninterestmanager/sessioninterestmanager_test.go
+++ b/bitswap/client/internal/sessioninterestmanager/sessioninterestmanager_test.go
@@ -1,6 +1,7 @@
 package sessioninterestmanager
 
 import (
+	"fmt"
 	"testing"
 
 	cid "github.com/ipfs/go-cid"
@@ -92,7 +93,8 @@ func TestRemoveSessionWants(t *testing.T) {
 	sim.RemoveSessionWants(ses, cids)
 	res := sim.FilterSessionInterested(ses, cids)
 
-	if len(res) > 0 {
+	if len(res[0]) > 0 {
+		fmt.Println(res)
 		t.Fatal("wants have not been removed")
 	}
 }


### PR DESCRIPTION
FilterSessionInterested should only return "wanted" blocks. Currently it returns blocks that have been marked as unwanted (flipped entry in map to false but remained in the map).

I need a second pair of eyes... so in `RemoveSessionWants()` we mark the interest of a session in a block as `false`:

https://github.com/ipfs/boxo/blob/main/bitswap/client/internal/sessioninterestmanager/sessioninterestmanager.go#L81-L86

We however do not remove the entry from the map as done in `RemoveSessionInterested`. But later in `FilterSessionInterested` we only check whether the session entry exists, and not whether it is set to `true`:

https://github.com/ipfs/boxo/blob/main/bitswap/client/internal/sessioninterestmanager/sessioninterestmanager.go#L132-L136

It would seem as if there was some distinction between "session interest", and "session want", but this is not reflected in how things are used. i.e. `Session.ReceiveFrom()` uses `FilterSessionInterest` and `Session.handleReceive()` uses `RemoveSessionWants()`, so I think we might be requesting blocks that we already have because `FilterSessionInterest` is going to still return removed wants. 