### PR TITLE
Provider query manager improvements

### DIFF
--- a/bitswap/client/client.go
+++ b/bitswap/client/client.go
@@ -76,6 +76,7 @@ func New(parent context.Context, network bsnet.BitSwapNetwork, bstore blockstore
 	bpm := bsbpm.New()
 	pm := bspm.New(ctx, peerQueueFactory, network.Self())
 	pqm := bspqm.New(ctx, network,
+		bspqm.WithFindProviderTimeout(opts.findProviderTimeout),
 		bspqm.WithMaxConcurrentFinds(opts.maxConcurrentFinds),
 		bspqm.WithMaxProvidersPerFind(opts.maxProvidersPerFind))
 

--- a/bitswap/client/client.go
+++ b/bitswap/client/client.go
@@ -76,8 +76,8 @@ func New(parent context.Context, network bsnet.BitSwapNetwork, bstore blockstore
 	bpm := bsbpm.New()
 	pm := bspm.New(ctx, peerQueueFactory, network.Self())
 	pqm := bspqm.New(ctx, network,
-		bspqm.WithMaxConcurrentFinds(opts.pqmMaxConcurrentFinds),
-		bspqm.WithMaxProvidersPerFind(opts.pqmMaxProvidersPerFind))
+		bspqm.WithMaxConcurrentFinds(opts.maxConcurrentFinds),
+		bspqm.WithMaxProvidersPerFind(opts.maxProvidersPerFind))
 
 	sessionFactory := func(
 		sessctx context.Context,

--- a/bitswap/client/client.go
+++ b/bitswap/client/client.go
@@ -76,8 +76,8 @@ func New(parent context.Context, network bsnet.BitSwapNetwork, bstore blockstore
 	bpm := bsbpm.New()
 	pm := bspm.New(ctx, peerQueueFactory, network.Self())
 	pqm := bspqm.New(ctx, network,
-		bspqm.WithMaxProvidersPerFind(opts.pqmMaxProvidersPerFind),
-		bspqm.WithMaxInProcessRequests(opts.pqmMaxInProcessRequests))
+		bspqm.WithMaxConcurrentFinds(opts.pqmMaxConcurrentFinds),
+		bspqm.WithMaxProvidersPerFind(opts.pqmMaxProvidersPerFind))
 
 	sessionFactory := func(
 		sessctx context.Context,

--- a/bitswap/client/internal/providerquerymanager/options.go
+++ b/bitswap/client/internal/providerquerymanager/options.go
@@ -1,0 +1,42 @@
+package providerquerymanager
+
+const (
+	defaultMaxProvidersPerFind  = 10
+	defaultMaxInProcessRequests = 6
+)
+
+type config struct {
+	maxProvidersPerFind  int
+	maxInProcessRequests int
+}
+
+type Option func(*config)
+
+func getOpts(opts []Option) config {
+	cfg := config{
+		maxProvidersPerFind:  defaultMaxProvidersPerFind,
+		maxInProcessRequests: defaultMaxInProcessRequests,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
+}
+
+func WithMaxProvidersPerFind(n int) Option {
+	return func(c *config) {
+		if n == 0 {
+			n = defaultMaxProvidersPerFind
+		}
+		c.maxProvidersPerFind = n
+	}
+}
+
+func WithMaxInProcessRequests(n int) Option {
+	return func(c *config) {
+		if n == 0 {
+			n = defaultMaxInProcessRequests
+		}
+		c.maxInProcessRequests = n
+	}
+}

--- a/bitswap/client/internal/providerquerymanager/options.go
+++ b/bitswap/client/internal/providerquerymanager/options.go
@@ -1,26 +1,35 @@
 package providerquerymanager
 
 const (
-	defaultMaxProvidersPerFind  = 10
-	defaultMaxInProcessRequests = 6
+	defaultMaxConcurrentFinds  = 16
+	defaultMaxProvidersPerFind = 10
 )
 
 type config struct {
-	maxProvidersPerFind  int
-	maxInProcessRequests int
+	maxConcurrentFinds  int
+	maxProvidersPerFind int
 }
 
 type Option func(*config)
 
 func getOpts(opts []Option) config {
 	cfg := config{
-		maxProvidersPerFind:  defaultMaxProvidersPerFind,
-		maxInProcessRequests: defaultMaxInProcessRequests,
+		maxConcurrentFinds:  defaultMaxConcurrentFinds,
+		maxProvidersPerFind: defaultMaxProvidersPerFind,
 	}
 	for _, opt := range opts {
 		opt(&cfg)
 	}
 	return cfg
+}
+
+func WithMaxConcurrentFinds(n int) Option {
+	return func(c *config) {
+		if n == 0 {
+			n = defaultMaxConcurrentFinds
+		}
+		c.maxConcurrentFinds = n
+	}
 }
 
 func WithMaxProvidersPerFind(n int) Option {
@@ -29,14 +38,5 @@ func WithMaxProvidersPerFind(n int) Option {
 			n = defaultMaxProvidersPerFind
 		}
 		c.maxProvidersPerFind = n
-	}
-}
-
-func WithMaxInProcessRequests(n int) Option {
-	return func(c *config) {
-		if n == 0 {
-			n = defaultMaxInProcessRequests
-		}
-		c.maxInProcessRequests = n
 	}
 }

--- a/bitswap/client/internal/providerquerymanager/options.go
+++ b/bitswap/client/internal/providerquerymanager/options.go
@@ -1,11 +1,17 @@
 package providerquerymanager
 
+import (
+	"time"
+)
+
 const (
+	defaultFindProviderTimeout = 10 * time.Second
 	defaultMaxConcurrentFinds  = 16
 	defaultMaxProvidersPerFind = 10
 )
 
 type config struct {
+	findProviderTimeout time.Duration
 	maxConcurrentFinds  int
 	maxProvidersPerFind int
 }
@@ -14,6 +20,7 @@ type Option func(*config)
 
 func getOpts(opts []Option) config {
 	cfg := config{
+		findProviderTimeout: defaultFindProviderTimeout,
 		maxConcurrentFinds:  defaultMaxConcurrentFinds,
 		maxProvidersPerFind: defaultMaxProvidersPerFind,
 	}
@@ -23,19 +30,41 @@ func getOpts(opts []Option) config {
 	return cfg
 }
 
+// WitrFindProviderTimeout configures the maximum amount of time to spend on a
+// single find providers attempt. This value can be changed at runtime using
+// SetFindProviderTimeout. Use 0 to configure the default.
+func WithFindProviderTimeout(to time.Duration) Option {
+	return func(c *config) {
+		if to == 0 {
+			to = defaultFindProviderTimeout
+		}
+		c.findProviderTimeout = to
+	}
+}
+
+// WithMaxConcurrentFinds configures the maxmum number of workers that run
+// FindProvidersAsync at the same time. Use 0 to configure the default value.
 func WithMaxConcurrentFinds(n int) Option {
 	return func(c *config) {
 		if n == 0 {
 			n = defaultMaxConcurrentFinds
+		} else if n < 0 {
+			panic("bitswap: WithMaxConcurrentFinds given negative value")
 		}
 		c.maxConcurrentFinds = n
 	}
 }
 
+// WithMaxProvidersPerFind configures the maximum number of providers that are
+// returned from a single fiond providers attempt. Use 0 to configure the
+// default value or use a negative value to find all providers within the
+// timeout configured by WithFindProviderTimeout.
 func WithMaxProvidersPerFind(n int) Option {
 	return func(c *config) {
 		if n == 0 {
 			n = defaultMaxProvidersPerFind
+		} else if n < 0 {
+			n = 0 // 0 means find all
 		}
 		c.maxProvidersPerFind = n
 	}

--- a/bitswap/client/internal/providerquerymanager/providerquerymanager.go
+++ b/bitswap/client/internal/providerquerymanager/providerquerymanager.go
@@ -99,7 +99,7 @@ func New(ctx context.Context, network ProviderQueryNetwork, options ...Option) *
 		providerQueryMessages: make(chan providerQueryMessage),
 		opts:                  getOpts(options),
 	}
-	pqm.SetFindProviderTimeout(defaultTimeout)
+	pqm.SetFindProviderTimeout(pqm.opts.findProviderTimeout)
 	return pqm
 }
 
@@ -113,9 +113,14 @@ type inProgressRequest struct {
 	incoming       chan peer.ID
 }
 
-// SetFindProviderTimeout changes the timeout for finding providers
-func (pqm *ProviderQueryManager) SetFindProviderTimeout(findProviderTimeout time.Duration) {
-	pqm.findProviderTimeout.Store(int64(findProviderTimeout))
+// SetFindProviderTimeout changes the timeout for finding providers. Setting a
+// value of 0 resets to the value configures when this ProviderQueryManager was
+// created.
+func (pqm *ProviderQueryManager) SetFindProviderTimeout(timeout time.Duration) {
+	if timeout == 0 {
+		timeout = pqm.opts.findProviderTimeout
+	}
+	pqm.findProviderTimeout.Store(int64(timeout))
 }
 
 // FindProvidersAsync finds providers for the given block.

--- a/bitswap/client/internal/providerquerymanager/providerquerymanager.go
+++ b/bitswap/client/internal/providerquerymanager/providerquerymanager.go
@@ -6,7 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/gammazero/channelqueue"
+	"github.com/gammazero/chanqueue"
 	"github.com/gammazero/deque"
 	"github.com/ipfs/boxo/bitswap/client/internal"
 	"github.com/ipfs/go-cid"
@@ -76,7 +76,7 @@ type ProviderQueryManager struct {
 	ctx                        context.Context
 	network                    ProviderQueryNetwork
 	providerQueryMessages      chan providerQueryMessage
-	providerRequestsProcessing *channelqueue.ChannelQueue[*findProviderRequest]
+	providerRequestsProcessing *chanqueue.ChanQueue[*findProviderRequest]
 
 	findProviderTimeout atomic.Int64
 
@@ -304,10 +304,10 @@ func (pqm *ProviderQueryManager) run() {
 	defer pqm.cleanupInProcessRequests()
 
 	var wg sync.WaitGroup
-	pqm.providerRequestsProcessing = channelqueue.New[*findProviderRequest](-1)
+	pqm.providerRequestsProcessing = chanqueue.New[*findProviderRequest]()
 	defer func() {
 		pqm.providerRequestsProcessing.Close()
-		// Afers workers done, close and drain channelqueue.
+		// Afers workers done, close and drain ChanQueue.
 		go func() {
 			wg.Wait()
 			for range pqm.providerRequestsProcessing.Out() {

--- a/bitswap/client/internal/providerquerymanager/providerquerymanager.go
+++ b/bitswap/client/internal/providerquerymanager/providerquerymanager.go
@@ -166,7 +166,8 @@ func (pqm *ProviderQueryManager) receiveProviders(sessionCtx context.Context, k 
 	// reading from the returned channel -- so that the broadcast never blocks
 	// based on: https://medium.com/capital-one-tech/building-an-unbounded-channel-in-go-789e175cd2cd
 	returnedProviders := make(chan peer.ID)
-	receivedProviders := deque.New[peer.ID]()
+	var receivedProviders deque.Deque[peer.ID]
+	receivedProviders.Grow(len(receivedInProgressRequest.providersSoFar))
 	for _, pid := range receivedInProgressRequest.providersSoFar {
 		receivedProviders.PushBack(pid)
 	}
@@ -292,7 +293,7 @@ func (pqm *ProviderQueryManager) providerRequestBufferWorker() {
 	// buffer for incoming provider queries and dispatches to the find
 	// provider workers as they become available
 	// based on: https://medium.com/capital-one-tech/building-an-unbounded-channel-in-go-789e175cd2cd
-	providerQueryRequestBuffer := deque.New[*findProviderRequest]()
+	var providerQueryRequestBuffer deque.Deque[*findProviderRequest]
 	nextProviderQuery := func() *findProviderRequest {
 		if providerQueryRequestBuffer.Len() == 0 {
 			return nil

--- a/bitswap/client/internal/providerquerymanager/providerquerymanager.go
+++ b/bitswap/client/internal/providerquerymanager/providerquerymanager.go
@@ -18,10 +18,6 @@ import (
 
 var log = logging.Logger("bitswap/client/provqrymgr")
 
-const (
-	defaultTimeout = 10 * time.Second
-)
-
 type inProgressRequestStatus struct {
 	ctx            context.Context
 	cancelFn       func()

--- a/bitswap/client/internal/providerquerymanager/providerquerymanager.go
+++ b/bitswap/client/internal/providerquerymanager/providerquerymanager.go
@@ -96,7 +96,7 @@ func New(ctx context.Context, network ProviderQueryNetwork) *ProviderQueryManage
 	pqm := &ProviderQueryManager{
 		ctx:                          ctx,
 		network:                      network,
-		providerQueryMessages:        make(chan providerQueryMessage, 16),
+		providerQueryMessages:        make(chan providerQueryMessage),
 		providerRequestsProcessing:   make(chan *findProviderRequest),
 		incomingFindProviderRequests: make(chan *findProviderRequest),
 	}

--- a/bitswap/client/internal/providerquerymanager/providerquerymanager.go
+++ b/bitswap/client/internal/providerquerymanager/providerquerymanager.go
@@ -234,7 +234,7 @@ func (pqm *ProviderQueryManager) cancelProviderRequest(ctx context.Context, k ci
 
 func (pqm *ProviderQueryManager) findProviderWorker() {
 	// findProviderWorker just cycles through incoming provider queries one at
-	// a time. There are maxInProcessRequests of these workers running
+	// a time. There are pqm.opts.maxConcurrentFinds of these workers running
 	// concurrently to let requests go in parallel but keep them rate limited.
 	maxProviders := pqm.opts.maxProvidersPerFind
 	for {
@@ -314,8 +314,8 @@ func (pqm *ProviderQueryManager) run() {
 		}()
 	}()
 
-	wg.Add(pqm.opts.maxInProcessRequests)
-	for i := 0; i < pqm.opts.maxInProcessRequests; i++ {
+	wg.Add(pqm.opts.maxConcurrentFinds)
+	for i := 0; i < pqm.opts.maxConcurrentFinds; i++ {
 		go func() {
 			pqm.findProviderWorker()
 			wg.Done()

--- a/bitswap/client/internal/providerquerymanager/providerquerymanager_test.go
+++ b/bitswap/client/internal/providerquerymanager/providerquerymanager_test.go
@@ -258,6 +258,7 @@ func TestRateLimitingRequests(t *testing.T) {
 	providerQueryManager := New(ctx, fpn)
 	providerQueryManager.Startup()
 
+	maxInProcessRequests := providerQueryManager.opts.maxInProcessRequests
 	keys := random.Cids(maxInProcessRequests + 1)
 	sessionCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()

--- a/bitswap/client/optios.go
+++ b/bitswap/client/optios.go
@@ -17,8 +17,8 @@ type clientConfig struct {
 	tracer                     tracer.Tracer
 
 	// ProviderQueryManager options.
-	pqmMaxConcurrentFinds  int
-	pqmMaxProvidersPerFind int
+	maxConcurrentFinds  int
+	maxProvidersPerFind int
 }
 
 // Option defines the functional option type that can be used to configure
@@ -92,14 +92,14 @@ func WithoutDuplicatedBlockStats() Option {
 	}
 }
 
-func WithPQMMaxConcurrentFinds(n int) Option {
+func WithMaxConcurrentFinds(n int) Option {
 	return func(c *clientConfig) {
-		c.pqmMaxConcurrentFinds = n
+		c.maxConcurrentFinds = n
 	}
 }
 
-func WithPQMMaxProvidersPerFind(n int) Option {
+func WithMaxProvidersPerFind(n int) Option {
 	return func(c *clientConfig) {
-		c.pqmMaxProvidersPerFind = n
+		c.maxProvidersPerFind = n
 	}
 }

--- a/bitswap/client/optios.go
+++ b/bitswap/client/optios.go
@@ -1,0 +1,105 @@
+package client
+
+import (
+	"time"
+
+	"github.com/ipfs/boxo/bitswap/internal/defaults"
+	"github.com/ipfs/boxo/bitswap/tracer"
+	delay "github.com/ipfs/go-ipfs-delay"
+)
+
+type clientConfig struct {
+	blockReceivedNotifier      BlockReceivedNotifier
+	provSearchDelay            time.Duration
+	rebroadcastDelay           delay.D
+	simulateDontHavesOnTimeout bool
+	skipDuplicatedBlocksStats  bool
+	tracer                     tracer.Tracer
+
+	// ProviderQueryManager options.
+	pqmMaxProvidersPerFind  int
+	pqmMaxInProcessRequests int
+}
+
+// Option defines the functional option type that can be used to configure
+// bitswap instances
+type Option func(*clientConfig)
+
+func getOpts(opts []Option) clientConfig {
+	cfg := clientConfig{
+		provSearchDelay:            defaults.ProvSearchDelay,
+		rebroadcastDelay:           delay.Fixed(defaults.RebroadcastDelay),
+		simulateDontHavesOnTimeout: true,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
+}
+
+// ProviderSearchDelay sets the initial dely before triggering a provider
+// search to find more peers and broadcast the want list. It also partially
+// controls re-broadcasts delay when the session idles (does not receive any
+// blocks), but these have back-off logic to increase the interval. See
+// [defaults.ProvSearchDelay] for the default.
+func ProviderSearchDelay(newProvSearchDelay time.Duration) Option {
+	return func(c *clientConfig) {
+		c.provSearchDelay = newProvSearchDelay
+	}
+}
+
+// RebroadcastDelay sets a custom delay for periodic search of a random want.
+// When the value ellapses, a random CID from the wantlist is chosen and the
+// client attempts to find more peers for it and sends them the single want.
+// [defaults.RebroadcastDelay] for the default.
+func RebroadcastDelay(newRebroadcastDelay delay.D) Option {
+	return func(c *clientConfig) {
+		c.rebroadcastDelay = newRebroadcastDelay
+	}
+}
+
+func SetSimulateDontHavesOnTimeout(send bool) Option {
+	return func(c *clientConfig) {
+		c.simulateDontHavesOnTimeout = send
+	}
+}
+
+// Configures the Client to use given tracer.
+// This provides methods to access all messages sent and received by the Client.
+// This interface can be used to implement various statistics (this is original intent).
+func WithTracer(tap tracer.Tracer) Option {
+	return func(c *clientConfig) {
+		c.tracer = tap
+	}
+}
+
+func WithBlockReceivedNotifier(brn BlockReceivedNotifier) Option {
+	return func(c *clientConfig) {
+		c.blockReceivedNotifier = brn
+	}
+}
+
+// WithoutDuplicatedBlockStats disable collecting counts of duplicated blocks
+// received. This counter requires triggering a blockstore.Has() call for
+// every block received by launching goroutines in parallel. In the worst case
+// (no caching/blooms etc), this is an expensive call for the datastore to
+// answer. In a normal case (caching), this has the power of evicting a
+// different block from intermediary caches. In the best case, it doesn't
+// affect performance. Use if this stat is not relevant.
+func WithoutDuplicatedBlockStats() Option {
+	return func(c *clientConfig) {
+		c.skipDuplicatedBlocksStats = true
+	}
+}
+
+func WithPQMMaxProvidersPerFind(n int) Option {
+	return func(c *clientConfig) {
+		c.pqmMaxProvidersPerFind = n
+	}
+}
+
+func WithPQMMaxInProcessRequests(n int) Option {
+	return func(c *clientConfig) {
+		c.pqmMaxInProcessRequests = n
+	}
+}

--- a/bitswap/client/optios.go
+++ b/bitswap/client/optios.go
@@ -17,6 +17,7 @@ type clientConfig struct {
 	tracer                     tracer.Tracer
 
 	// ProviderQueryManager options.
+	findProviderTimeout time.Duration
 	maxConcurrentFinds  int
 	maxProvidersPerFind int
 }
@@ -89,6 +90,12 @@ func WithBlockReceivedNotifier(brn BlockReceivedNotifier) Option {
 func WithoutDuplicatedBlockStats() Option {
 	return func(c *clientConfig) {
 		c.skipDuplicatedBlocksStats = true
+	}
+}
+
+func WithFindProviderTimeout(to time.Duration) Option {
+	return func(c *clientConfig) {
+		c.findProviderTimeout = to
 	}
 }
 

--- a/bitswap/client/optios.go
+++ b/bitswap/client/optios.go
@@ -17,8 +17,8 @@ type clientConfig struct {
 	tracer                     tracer.Tracer
 
 	// ProviderQueryManager options.
-	pqmMaxProvidersPerFind  int
-	pqmMaxInProcessRequests int
+	pqmMaxConcurrentFinds  int
+	pqmMaxProvidersPerFind int
 }
 
 // Option defines the functional option type that can be used to configure
@@ -92,14 +92,14 @@ func WithoutDuplicatedBlockStats() Option {
 	}
 }
 
-func WithPQMMaxProvidersPerFind(n int) Option {
+func WithPQMMaxConcurrentFinds(n int) Option {
 	return func(c *clientConfig) {
-		c.pqmMaxProvidersPerFind = n
+		c.pqmMaxConcurrentFinds = n
 	}
 }
 
-func WithPQMMaxInProcessRequests(n int) Option {
+func WithPQMMaxProvidersPerFind(n int) Option {
 	return func(c *clientConfig) {
-		c.pqmMaxInProcessRequests = n
+		c.pqmMaxProvidersPerFind = n
 	}
 }

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/flynn/noise v1.1.0 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.6 // indirect
+	github.com/gammazero/deque v0.2.1 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/flynn/noise v1.1.0 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.6 // indirect
+	github.com/gammazero/channelqueue v0.2.2 // indirect
 	github.com/gammazero/deque v1.0.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/flynn/noise v1.1.0 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.6 // indirect
-	github.com/gammazero/deque v0.2.1 // indirect
+	github.com/gammazero/deque v1.0.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -77,6 +77,8 @@ github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7z
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gabriel-vasile/mimetype v1.4.6 h1:3+PzJTKLkvgjeTbts6msPJt4DixhT4YtFNf1gtGe3zc=
 github.com/gabriel-vasile/mimetype v1.4.6/go.mod h1:JX1qVKqZd40hUPpAfiNTe0Sne7hdfKSbOqqmkq8GCXc=
+github.com/gammazero/channelqueue v0.2.2 h1:ufNzIbeDBxNfHj0m5uwUfOwvTmHF/O40hu2ZNnvF+/8=
+github.com/gammazero/channelqueue v0.2.2/go.mod h1:824o5HHE+yO1xokh36BIuSv8YWwXW0364ku91eRMFS4=
 github.com/gammazero/deque v1.0.0 h1:LTmimT8H7bXkkCy6gZX7zNLtkbz4NdS2z8LZuor3j34=
 github.com/gammazero/deque v1.0.0/go.mod h1:iflpYvtGfM3U8S8j+sZEKIak3SAKYpA5/SQewgfXDKo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -77,8 +77,8 @@ github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7z
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gabriel-vasile/mimetype v1.4.6 h1:3+PzJTKLkvgjeTbts6msPJt4DixhT4YtFNf1gtGe3zc=
 github.com/gabriel-vasile/mimetype v1.4.6/go.mod h1:JX1qVKqZd40hUPpAfiNTe0Sne7hdfKSbOqqmkq8GCXc=
-github.com/gammazero/deque v0.2.1 h1:qSdsbG6pgp6nL7A0+K/B7s12mcCY/5l5SIUpMOl+dC0=
-github.com/gammazero/deque v0.2.1/go.mod h1:LFroj8x4cMYCukHJDbxFCkT+r9AndaJnFMuZDV34tuU=
+github.com/gammazero/deque v1.0.0 h1:LTmimT8H7bXkkCy6gZX7zNLtkbz4NdS2z8LZuor3j34=
+github.com/gammazero/deque v1.0.0/go.mod h1:iflpYvtGfM3U8S8j+sZEKIak3SAKYpA5/SQewgfXDKo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -77,6 +77,8 @@ github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7z
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gabriel-vasile/mimetype v1.4.6 h1:3+PzJTKLkvgjeTbts6msPJt4DixhT4YtFNf1gtGe3zc=
 github.com/gabriel-vasile/mimetype v1.4.6/go.mod h1:JX1qVKqZd40hUPpAfiNTe0Sne7hdfKSbOqqmkq8GCXc=
+github.com/gammazero/deque v0.2.1 h1:qSdsbG6pgp6nL7A0+K/B7s12mcCY/5l5SIUpMOl+dC0=
+github.com/gammazero/deque v0.2.1/go.mod h1:LFroj8x4cMYCukHJDbxFCkT+r9AndaJnFMuZDV34tuU=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cskr/pubsub v1.0.2
 	github.com/dustin/go-humanize v1.0.1
 	github.com/gabriel-vasile/mimetype v1.4.6
-	github.com/gammazero/deque v0.2.1
+	github.com/gammazero/deque v1.0.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cskr/pubsub v1.0.2
 	github.com/dustin/go-humanize v1.0.1
 	github.com/gabriel-vasile/mimetype v1.4.6
-	github.com/gammazero/channelqueue v0.2.2
+	github.com/gammazero/chanqueue v1.0.0
 	github.com/gammazero/deque v1.0.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/cskr/pubsub v1.0.2
 	github.com/dustin/go-humanize v1.0.1
 	github.com/gabriel-vasile/mimetype v1.4.6
+	github.com/gammazero/channelqueue v0.2.2
 	github.com/gammazero/deque v1.0.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/cskr/pubsub v1.0.2
 	github.com/dustin/go-humanize v1.0.1
 	github.com/gabriel-vasile/mimetype v1.4.6
+	github.com/gammazero/deque v0.2.1
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7z
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gabriel-vasile/mimetype v1.4.6 h1:3+PzJTKLkvgjeTbts6msPJt4DixhT4YtFNf1gtGe3zc=
 github.com/gabriel-vasile/mimetype v1.4.6/go.mod h1:JX1qVKqZd40hUPpAfiNTe0Sne7hdfKSbOqqmkq8GCXc=
+github.com/gammazero/channelqueue v0.2.2 h1:ufNzIbeDBxNfHj0m5uwUfOwvTmHF/O40hu2ZNnvF+/8=
+github.com/gammazero/channelqueue v0.2.2/go.mod h1:824o5HHE+yO1xokh36BIuSv8YWwXW0364ku91eRMFS4=
 github.com/gammazero/deque v1.0.0 h1:LTmimT8H7bXkkCy6gZX7zNLtkbz4NdS2z8LZuor3j34=
 github.com/gammazero/deque v1.0.0/go.mod h1:iflpYvtGfM3U8S8j+sZEKIak3SAKYpA5/SQewgfXDKo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7z
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gabriel-vasile/mimetype v1.4.6 h1:3+PzJTKLkvgjeTbts6msPJt4DixhT4YtFNf1gtGe3zc=
 github.com/gabriel-vasile/mimetype v1.4.6/go.mod h1:JX1qVKqZd40hUPpAfiNTe0Sne7hdfKSbOqqmkq8GCXc=
-github.com/gammazero/deque v0.2.1 h1:qSdsbG6pgp6nL7A0+K/B7s12mcCY/5l5SIUpMOl+dC0=
-github.com/gammazero/deque v0.2.1/go.mod h1:LFroj8x4cMYCukHJDbxFCkT+r9AndaJnFMuZDV34tuU=
+github.com/gammazero/deque v1.0.0 h1:LTmimT8H7bXkkCy6gZX7zNLtkbz4NdS2z8LZuor3j34=
+github.com/gammazero/deque v1.0.0/go.mod h1:iflpYvtGfM3U8S8j+sZEKIak3SAKYpA5/SQewgfXDKo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7z
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gabriel-vasile/mimetype v1.4.6 h1:3+PzJTKLkvgjeTbts6msPJt4DixhT4YtFNf1gtGe3zc=
 github.com/gabriel-vasile/mimetype v1.4.6/go.mod h1:JX1qVKqZd40hUPpAfiNTe0Sne7hdfKSbOqqmkq8GCXc=
+github.com/gammazero/deque v0.2.1 h1:qSdsbG6pgp6nL7A0+K/B7s12mcCY/5l5SIUpMOl+dC0=
+github.com/gammazero/deque v0.2.1/go.mod h1:LFroj8x4cMYCukHJDbxFCkT+r9AndaJnFMuZDV34tuU=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7z
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gabriel-vasile/mimetype v1.4.6 h1:3+PzJTKLkvgjeTbts6msPJt4DixhT4YtFNf1gtGe3zc=
 github.com/gabriel-vasile/mimetype v1.4.6/go.mod h1:JX1qVKqZd40hUPpAfiNTe0Sne7hdfKSbOqqmkq8GCXc=
-github.com/gammazero/channelqueue v0.2.2 h1:ufNzIbeDBxNfHj0m5uwUfOwvTmHF/O40hu2ZNnvF+/8=
-github.com/gammazero/channelqueue v0.2.2/go.mod h1:824o5HHE+yO1xokh36BIuSv8YWwXW0364ku91eRMFS4=
+github.com/gammazero/chanqueue v1.0.0 h1:FER/sMailGFA3DDvFooEkipAMU+3c9Bg3bheloPSz6o=
+github.com/gammazero/chanqueue v1.0.0/go.mod h1:fMwpwEiuUgpab0sH4VHiVcEoji1pSi+EIzeG4TPeKPc=
 github.com/gammazero/deque v1.0.0 h1:LTmimT8H7bXkkCy6gZX7zNLtkbz4NdS2z8LZuor3j34=
 github.com/gammazero/deque v1.0.0/go.mod h1:iflpYvtGfM3U8S8j+sZEKIak3SAKYpA5/SQewgfXDKo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=


### PR DESCRIPTION
- Use atomic value to protect variable timeout.
- Remove `inProgressRequestStatuses` map when empty.
- Do not append to slice forever. Use type that reuses items removed from front of list (e.g. [channelqueue](https://pkg.go.dev/github.com/gammazero/channelqueue), [deque](https://pkg.go.dev/github.com/gammazero/deque)
- Add configurable bitswap options:
  - `WithMaxConcurrentFinds`
  - `WithMaxProvidersPerFind`
- Make bitswap options configurable through client.
