### PR TITLE
feat: add WithMiddleware option to the delegated routing server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The following emojis are used to highlight certain changes:
 
 ### Added
 
+- `routing/http/server`: added `WithMiddleware` option to allow adding http middleware to the delegate routing server for things like metrics, logging, etc.
+
 ### Changed
 
 ### Removed

--- a/routing/http/server/server.go
+++ b/routing/http/server/server.go
@@ -141,7 +141,9 @@ func Handler(svc ContentRouter, opts ...Option) http.Handler {
 	}
 
 	r := mux.NewRouter()
-	r.Use(server.middleware)
+	if server.middleware != nil {
+		r.Use(server.middleware)
+	}
 	r.HandleFunc(findProvidersPath, server.findProviders).Methods(http.MethodGet)
 	r.HandleFunc(providePath, server.provide).Methods(http.MethodPut)
 	r.HandleFunc(findPeersPath, server.findPeers).Methods(http.MethodGet)


### PR DESCRIPTION
Because the router is defined inside the server here, consumers of the server have no clean way to instrument each delegated routing endpoint independently. 

This PR adds a new option that allows passing in middleware similar to the https://github.com/slok/go-http-metrics/blob/master/examples/gorilla/main.go example.