### PR TITLE
feat(routing/http/server): add routing timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The following emojis are used to highlight certain changes:
 ### Added
 
 - `routing/http/server`: added Prometheus instrumentation to http delegated routing endpoints.
+- `routing/http/server`: added a routing timeout with default value of 30 seconds to delegated routing server to avoid indefinite hanging on content/peer routing requests.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The following emojis are used to highlight certain changes:
 ### Added
 
 - `routing/http/server`: added Prometheus instrumentation to http delegated routing endpoints.
-- `routing/http/server`: added a routing timeout with default value of 30 seconds to delegated routing server to avoid indefinite hanging on content/peer routing requests.
+- `routing/http/server`: added configurable routing timeout (`DefaultRoutingTimeout` being 30s) to prevent indefinite hangs during content/peer routing. Set custom duration via `WithRoutingTimeout`.
 
 ### Changed
 


### PR DESCRIPTION
## Why

See https://github.com/ipfs/someguy/issues/88. 

TL;DR: Without any routing timeout, routing requests will run indefinitely if the record limit isn't reached. 

