### PR TITLE
fix(bitswap/client/providerquerymanager): use non-timed out context for tracing

### DIFF
--- a/bitswap/client/internal/providerquerymanager/providerquerymanager.go
+++ b/bitswap/client/internal/providerquerymanager/providerquerymanager.go
@@ -261,7 +261,7 @@ func (pqm *ProviderQueryManager) findProviderWorker() {
 					span.AddEvent("ConnectedToProvider", trace.WithAttributes(attribute.Stringer("peer", p)))
 					select {
 					case pqm.providerQueryMessages <- &receivedProviderMessage{
-						ctx: findProviderCtx,
+						ctx: fpr.ctx,
 						k:   k,
 						p:   p,
 					}:
@@ -274,7 +274,7 @@ func (pqm *ProviderQueryManager) findProviderWorker() {
 			cancel()
 			select {
 			case pqm.providerQueryMessages <- &finishedProviderQueryMessage{
-				ctx: findProviderCtx,
+				ctx: fpr.ctx,
 				k:   k,
 			}:
 			case <-pqm.ctx.Done():


### PR DESCRIPTION
@gammazero going to test this out, but this seems like a relatively simple fix to the issue where we cancel the context which stops the tracing. Instead we pass the uncancelled context from the parent.

Note: I skipped the changelog since it seems like a fairly minor change, but can add if you think it makes sense