### PR TITLE
refactor: default to prometheus.DefaultRegisterer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ The following emojis are used to highlight certain changes:
 
   - The above is only necessary if content routing is needed. Otherwise:
 
-```
+```go
 	// Create network: no contentRouter anymore
 	bswapnet := network.NewFromIpfsHost(host)
 	// Create Bitswap: a new "discovery" parameter set to nil (disable content discovery)
@@ -64,6 +64,8 @@ The following emojis are used to highlight certain changes:
 
 - `routing/http/server`: added built-in Prometheus instrumentation to http delegated `/routing/v1/` endpoints, with custom buckets for response size and duration to match real world data observed at [the `delegated-ipfs.dev` instance](https://docs.ipfs.tech/concepts/public-utilities/#delegated-routing). [#718](https://github.com/ipfs/boxo/pull/718) [#724](https://github.com/ipfs/boxo/pull/724)
 - `routing/http/server`: added configurable routing timeout (`DefaultRoutingTimeout` being 30s) to prevent indefinite hangs during content/peer routing. Set custom duration via `WithRoutingTimeout`. [#720](https://github.com/ipfs/boxo/pull/720)
+- `routing/http/server`: exposes Prometheus metrics on `prometheus.DefaultRegisterer` and a custom one can be provided via `WithPrometheusRegistry` [#722](https://github.com/ipfs/boxo/pull/722)
+- `gateway`: `NewCacheBlockStore` and `NewCarBackend` will use `prometheus.DefaultRegisterer` when a custom one is not specified via `WithPrometheusRegistry` [#722](https://github.com/ipfs/boxo/pull/722)
 
 ### Changed
 

--- a/gateway/metrics.go
+++ b/gateway/metrics.go
@@ -307,3 +307,14 @@ var tracer = otel.Tracer("boxo/gateway")
 func spanTrace(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
 	return tracer.Start(ctx, "Gateway."+spanName, opts...)
 }
+
+// registerMetric registers metrics in registry or logs an error.
+//
+// Registration may error if metric is alreadyregistered. we are not using
+// MustRegister here to allow people to run tests in parallel without having to
+// write tedious  glue code that creates unique registry for each unit test
+func registerMetric(registry prometheus.Registerer, metric prometheus.Collector) {
+	if err := registry.Register(metric); err != nil {
+		log.Errorf("failed to register %v: %v", metric, err)
+	}
+}


### PR DESCRIPTION
<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->

This PR contains changes on top of https://github.com/ipfs/boxo/pull/718 

It replaces `prometheus.NewRegistry()` calls with `prometheus.DefaultRegisterer` to ensure that by default boxo users who do not specify an explicit registry are not missing some of the metrics.

This convention is what go-libp2p does already, and I feel boxo should follow, to remove confusion why some metrics are present, and some are missing.

## TODO

- [x] merge https://github.com/ipfs/boxo/pull/718 and rebase this on main branch
- [x] sharness tests will fail until fix from https://github.com/ipfs/kubo/pull/10567  lands in Kubo master
- [x] refactor so boxo modules won't panic if `prometheus.DefaultRegisterer` is used and tests are run in parallel
   - [x] log error where possible
   - [x] use unique prefix for metric name where not possible to avoid `registry.MustRegister`