### PR TITLE
fix(bitswap/server): pass context to server engine to register metrics

### DIFF
--- a/bitswap/server/internal/decision/engine.go
+++ b/bitswap/server/internal/decision/engine.go
@@ -378,12 +378,13 @@ func wrapTaskComparator(tc TaskComparator) peertask.QueueTaskComparator {
 // maxOutstandingBytesPerPeer hints to the peer task queue not to give a peer
 // more tasks if it has some maximum work already outstanding.
 func NewEngine(
+	ctx context.Context,
 	bs bstore.Blockstore,
 	peerTagger PeerTagger,
 	self peer.ID,
 	opts ...Option,
 ) *Engine {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 
 	e := &Engine{
 		scoreLedger:                     NewDefaultScoreLedger(),

--- a/bitswap/server/internal/decision/engine_test.go
+++ b/bitswap/server/internal/decision/engine_test.go
@@ -188,7 +188,7 @@ func newEngineForTesting(
 	opts ...Option,
 ) *Engine {
 	opts = append(opts, WithWantHaveReplaceSize(wantHaveReplaceSize))
-	return NewEngine(bs, peerTagger, self, opts...)
+	return NewEngine(context.Background(), bs, peerTagger, self, opts...)
 }
 
 func TestOutboxClosedWhenEngineClosed(t *testing.T) {

--- a/bitswap/server/server.go
+++ b/bitswap/server/server.go
@@ -99,6 +99,7 @@ func New(ctx context.Context, network bsnet.BitSwapNetwork, bstore blockstore.Bl
 	}
 
 	s.engine = decision.NewEngine(
+		ctx,
 		bstore,
 		network.ConnectionManager(),
 		network.Self(),


### PR DESCRIPTION
Fixes invalid metrics errors logged by kubo at daemon startup.

Fixes the problem from  https://github.com/ipfs/kubo/pull/10567#pullrequestreview-2443616123