### PR TITLE
fix(routing/http/server): adjust bucket sizes for http metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The following emojis are used to highlight certain changes:
 ### Changed
 
 - No longer using `github.com/jbenet/goprocess` to avoid requiring in dependents.
+- `routing/http/server`: changed default Prometheus buckets for response size and duration to match real world data.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,12 @@ The following emojis are used to highlight certain changes:
 
 ### Added
 
-- `routing/http/server`: added Prometheus instrumentation to http delegated routing endpoints.
-- `routing/http/server`: added configurable routing timeout (`DefaultRoutingTimeout` being 30s) to prevent indefinite hangs during content/peer routing. Set custom duration via `WithRoutingTimeout`.
+- `routing/http/server`: added built-in Prometheus instrumentation to http delegated `/routing/v1/` endpoints, with custom buckets for response size and duration to match real world data observed at [the `delegated-ipfs.dev` instance](https://docs.ipfs.tech/concepts/public-utilities/#delegated-routing). [#718](https://github.com/ipfs/boxo/pull/718) [#724](https://github.com/ipfs/boxo/pull/724)
+- `routing/http/server`: added configurable routing timeout (`DefaultRoutingTimeout` being 30s) to prevent indefinite hangs during content/peer routing. Set custom duration via `WithRoutingTimeout`. [#720](https://github.com/ipfs/boxo/pull/720)
 
 ### Changed
 
-- No longer using `github.com/jbenet/goprocess` to avoid requiring in dependents.
-- `routing/http/server`: changed default Prometheus buckets for response size and duration to match real world data.
+- No longer using `github.com/jbenet/goprocess` to avoid requiring in dependents. [#710](https://github.com/ipfs/boxo/pull/710)
 
 ### Removed
 

--- a/routing/http/server/server.go
+++ b/routing/http/server/server.go
@@ -158,9 +158,9 @@ func Handler(svc ContentRouter, opts ...Option) http.Handler {
 	// Create middleware with prometheus recorder
 	mdlw := middleware.New(middleware.Config{
 		Recorder: metrics.NewRecorder(metrics.Config{
-			Registry: server.promRegistry,
-			Prefix:   "delegated_routing_server",
-
+			Registry:        server.promRegistry,
+			Prefix:          "delegated_routing_server",
+			SizeBuckets:     prometheus.ExponentialBuckets(100, 4, 8), // [100 400 1600 6400 25600 102400 409600 1.6384e+06]
 			DurationBuckets: []float64{0.1, 0.5, 1, 2, 5, 8, 10, 20, 30},
 		}),
 	})


### PR DESCRIPTION
This PR addresses feedback from https://github.com/ipfs/someguy/pull/87#pullrequestreview-2444074615 and introduced more realistic size buckets for the response size histogram.


### Reference numbers

- https://delegated-ipfs.dev/routing/v1/providers/bafkreibm6jg3ux5qumhcn2b3flc3tyu6dmlb4xa7u5bf44yegnrjhc4yeq 179331 bytes
- Current metrics (not segmented per route)
![Screenshot 2024-11-19 at 10 11 44 AM](https://github.com/user-attachments/assets/62baa739-f8fb-452a-85ea-132a3bc9b557)
