### PR TITLE
Add debug logging for deduplicated queries

### DIFF
--- a/routing/providerquerymanager/providerquerymanager.go
+++ b/routing/providerquerymanager/providerquerymanager.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap/zapcore"
 )
 
 var log = logging.Logger("routing/provqrymgr")
@@ -487,7 +488,9 @@ func (npqm *newProvideQueryMessage) handle(pqm *ProviderQueryManager) {
 		}
 	} else {
 		trace.SpanFromContext(npqm.ctx).AddEvent("JoinQuery", trace.WithAttributes(attribute.Stringer("cid", npqm.k)))
-		log.Debugf("Joined existing query for cid %s which now has %d queries in progress", npqm.k, len(requestStatus.listeners)+1)
+		if log.Level().Enabled(zapcore.DebugLevel) {
+			log.Debugf("Joined existing query for cid %s which now has %d queries in progress", npqm.k, len(requestStatus.listeners)+1)
+		}
 	}
 	inProgressChan := make(chan peer.AddrInfo)
 	requestStatus.listeners[inProgressChan] = struct{}{}

--- a/routing/providerquerymanager/providerquerymanager.go
+++ b/routing/providerquerymanager/providerquerymanager.go
@@ -186,6 +186,10 @@ func (pqm *ProviderQueryManager) FindProvidersAsync(sessionCtx context.Context, 
 		close(ch)
 		span.End()
 		return ch
+	case <-sessionCtx.Done():
+		ch := make(chan peer.AddrInfo)
+		close(ch)
+		return ch
 	}
 
 	// DO NOT select on sessionCtx. We only want to abort here if we're


### PR DESCRIPTION
Also, added comment about why request context is not used in `inProgressRequestStatus`.

Would deduplicated requests be worth tracking with a prometheus gauge?