### PR TITLE
chore: fix invalid url in docs

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -54,7 +54,7 @@ Default: `"grpc"`
 
 ### `Zipkin Exporter`
 
-See [Zipkin Exporter](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#zipkin-exporter).
+See [Zipkin Exporter](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#zipkin-exporter).
 
 ### `File Exporter`
 
@@ -66,7 +66,7 @@ Default: `"$PWD/traces.json"`
 
 ### `OTEL_PROPAGATORS`
 
-See [General SDK Configuration](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration).
+See [General SDK Configuration](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration).
 
 ## Using Jaeger UI
 

--- a/examples/gateway/common/tracing.go
+++ b/examples/gateway/common/tracing.go
@@ -28,7 +28,7 @@ func SetupTracing(ctx context.Context, serviceName string) (*trace.TracerProvide
 	// using autoprop.NewTextMapPropagator, we ensure the value of the environmental
 	// variable OTEL_PROPAGATORS is respected, if set. By default, Trace Context
 	// and Baggage are used. More details on:
-	// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md
+	// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md
 	otel.SetTextMapPropagator(autoprop.NewTextMapPropagator())
 
 	return tp, nil

--- a/tracing/exporters.go
+++ b/tracing/exporters.go
@@ -20,7 +20,7 @@ import (
 // most of this code.
 //
 // Specs:
-// - https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#exporter-selection
+// - https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#exporter-selection
 // - https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md
 func NewSpanExporters(ctx context.Context) ([]trace.SpanExporter, error) {
 	var exporters []trace.SpanExporter


### PR DESCRIPTION
<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->

The previous link has expired and has been replaced with the latest address.
