### PR TITLE
chore: no lifecycle context to shutdown ProviderQueryManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ The following emojis are used to highlight certain changes:
 - `gateway`: `NewCacheBlockStore` and `NewCarBackend` will use `prometheus.DefaultRegisterer` when a custom one is not specified via `WithPrometheusRegistry` [#722](https://github.com/ipfs/boxo/pull/722)
 - `filestore`: added opt-in `WithMMapReader` option to `FileManager` to enable memory-mapped file reads [#665](https://github.com/ipfs/boxo/pull/665)
 - `bitswap/routing` `ProviderQueryManager` does not require calling `Startup` separate from `New`. [#741](https://github.com/ipfs/boxo/pull/741)
+- `bitswap/routing` ProviderQueryManager does not use liftcycle context.
 
 ### Changed
 

--- a/bitswap/client/client.go
+++ b/bitswap/client/client.go
@@ -182,7 +182,7 @@ func New(parent context.Context, network bsnet.BitSwapNetwork, providerFinder Pr
 
 	if bs.providerFinder != nil && bs.defaultProviderQueryManager {
 		// network can do dialing.
-		pqm, err := rpqm.New(ctx, network, bs.providerFinder,
+		pqm, err := rpqm.New(network, bs.providerFinder,
 			rpqm.WithMaxInProcessRequests(16),
 			rpqm.WithMaxProviders(10),
 			rpqm.WithMaxTimeout(10*time.Second))
@@ -512,6 +512,9 @@ func (bs *Client) Close() error {
 		close(bs.closing)
 		bs.sm.Shutdown()
 		bs.cancel()
+		if bs.pqm != nil {
+			bs.pqm.Close()
+		}
 		bs.notif.Shutdown()
 	})
 	return nil


### PR DESCRIPTION
Call `Close` instead of cancelling long-lived context.

