### PR TITLE
chore: minor examples cleanup

### DIFF
--- a/examples/bitswap-transfer/README.md
+++ b/examples/bitswap-transfer/README.md
@@ -1,4 +1,4 @@
-# Transfering UnixFS file with Bitswap
+# Transferring UnixFS file with Bitswap
 
 This is an example that quickly shows how to use IPFS tooling to move around a file.
 

--- a/examples/routing/delegated-routing-client/main_test.go
+++ b/examples/routing/delegated-routing-client/main_test.go
@@ -32,7 +32,7 @@ func TestFindProviders(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	out := &bytes.Buffer{}
-	err := run(out, ts.URL, cidStr, "", "", 1)
+	err := run(out, ts.URL, cidStr, "", "", time.Second)
 	assert.Contains(t, out.String(), "12D3KooWM8sovaEGU1bmiWGWAzvs47DEcXKZZTuJnpQyVTkRs2Vn\n\tProtocols: [transport-bitswap]\n\tAddresses: [/ip4/111.222.222.111/tcp/5734]\n")
 	assert.Contains(t, out.String(), "12D3KooWB6RAWgcmHAP7TGEGK7utV2ZuqSzX1DNjRa97TtJ7139n\n\tProtocols: []\n\tAddresses: [/ip4/127.0.0.1/tcp/5734]\n")
 	assert.NoError(t, err)
@@ -50,7 +50,7 @@ func TestFindPeers(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	out := &bytes.Buffer{}
-	err := run(out, ts.URL, "", pidStr, "", 1)
+	err := run(out, ts.URL, "", pidStr, "", time.Second)
 	assert.Contains(t, out.String(), "12D3KooWM8sovaEGU1bmiWGWAzvs47DEcXKZZTuJnpQyVTkRs2Vn\n\tProtocols: [transport-bitswap]\n\tAddresses: [/ip4/111.222.222.111/tcp/5734]\n")
 	assert.NoError(t, err)
 }
@@ -67,7 +67,7 @@ func TestGetIPNS(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	out := &bytes.Buffer{}
-	err := run(out, ts.URL, "", "", name.String(), 1)
+	err := run(out, ts.URL, "", "", name.String(), time.Second)
 	assert.Contains(t, out.String(), fmt.Sprintf("/ipns/%s\n\tSignature: VALID\n\tValue: /ipfs/bafkreifjjcie6lypi6ny7amxnfftagclbuxndqonfipmb64f2km2devei4\n", name.String()))
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
- Pass time.Duration instead of passing int that gets converted to time.Duration.
- Remove unneeded else clauses
- spelling
