### PR TITLE
fix(bitswap): autostart network on new client/server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ The following emojis are used to highlight certain changes:
 - `gateway`: `NewCacheBlockStore` and `NewCarBackend` will use `prometheus.DefaultRegisterer` when a custom one is not specified via `WithPrometheusRegistry` [#722](https://github.com/ipfs/boxo/pull/722)
 - `filestore`: added opt-in `WithMMapReader` option to `FileManager` to enable memory-mapped file reads [#665](https://github.com/ipfs/boxo/pull/665)
 - `bitswap/routing` `ProviderQueryManager` does not require calling `Startup` separate from `New`. [#741](https://github.com/ipfs/boxo/pull/741)
+- `bitswap/client`, `bitswap/server`: Added `NewWithAutoStart` constructors that automatically call `network.Start()`, providing a more intuitive API when using standalone client or server. 
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ The following emojis are used to highlight certain changes:
 - `gateway`: `NewCacheBlockStore` and `NewCarBackend` will use `prometheus.DefaultRegisterer` when a custom one is not specified via `WithPrometheusRegistry` [#722](https://github.com/ipfs/boxo/pull/722)
 - `filestore`: added opt-in `WithMMapReader` option to `FileManager` to enable memory-mapped file reads [#665](https://github.com/ipfs/boxo/pull/665)
 - `bitswap/routing` `ProviderQueryManager` does not require calling `Startup` separate from `New`. [#741](https://github.com/ipfs/boxo/pull/741)
-- `bitswap/client`, `bitswap/server`: Added `NewWithAutoStart` constructors that automatically call `network.Start()`, providing a more intuitive API when using standalone client or server. 
+- `bitswap/client`, `bitswap/server`: Added `NewWithAutoStart` constructors that automatically call `network.Start()`, providing a more intuitive API when using standalone client or server. [#743](https://github.com/ipfs/boxo/pull/743) 
 
 ### Changed
 

--- a/bitswap/client/client.go
+++ b/bitswap/client/client.go
@@ -8,6 +8,15 @@ import (
 	"sync"
 	"time"
 
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+	delay "github.com/ipfs/go-ipfs-delay"
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/ipfs/go-metrics-interface"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
 	bsbpm "github.com/ipfs/boxo/bitswap/client/internal/blockpresencemanager"
 	bsgetter "github.com/ipfs/boxo/bitswap/client/internal/getter"
 	bsmq "github.com/ipfs/boxo/bitswap/client/internal/messagequeue"
@@ -26,14 +35,6 @@ import (
 	blockstore "github.com/ipfs/boxo/blockstore"
 	exchange "github.com/ipfs/boxo/exchange"
 	rpqm "github.com/ipfs/boxo/routing/providerquerymanager"
-	blocks "github.com/ipfs/go-block-format"
-	"github.com/ipfs/go-cid"
-	delay "github.com/ipfs/go-ipfs-delay"
-	logging "github.com/ipfs/go-log/v2"
-	"github.com/ipfs/go-metrics-interface"
-	"github.com/libp2p/go-libp2p/core/peer"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 )
 
 var log = logging.Logger("bitswap/client")
@@ -127,6 +128,15 @@ type BlockReceivedNotifier interface {
 // https://pkg.go.dev/github.com/libp2p/go-libp2p@v0.37.0/core/routing#ContentRouting
 type ProviderFinder interface {
 	FindProvidersAsync(context.Context, cid.Cid, int) <-chan peer.AddrInfo
+}
+
+// NewWithAutoStart creates a new BitSwap client and automatically starts it on the network.
+// This is the recommended way to create a standalone BitSwap client.
+func NewWithAutoStart(parent context.Context, network bsnet.BitSwapNetwork, providerFinder ProviderFinder, bstore blockstore.Blockstore, options ...Option) *Client {
+	client := New(parent, network, providerFinder, bstore, options...)
+	network.Start(client)
+
+	return client
 }
 
 // New initializes a Bitswap client that runs until client.Close is called.

--- a/bitswap/client/client.go
+++ b/bitswap/client/client.go
@@ -142,6 +142,9 @@ func NewWithAutoStart(parent context.Context, network bsnet.BitSwapNetwork, prov
 // New initializes a Bitswap client that runs until client.Close is called.
 // The Content providerFinder paramteter can be nil to disable content-routing
 // lookups for content (rely only on bitswap for discovery).
+//
+// IMPORTANT: You must call network.Start(client) before using this client, or it will silently fail to receive responses.
+// Consider using NewWithAutoStart instead.
 func New(parent context.Context, network bsnet.BitSwapNetwork, providerFinder ProviderFinder, bstore blockstore.Blockstore, options ...Option) *Client {
 	// important to use provided parent context (since it may include important
 	// loggable data). It's probably not a good idea to allow bitswap to be

--- a/bitswap/client/client.go
+++ b/bitswap/client/client.go
@@ -8,15 +8,6 @@ import (
 	"sync"
 	"time"
 
-	blocks "github.com/ipfs/go-block-format"
-	"github.com/ipfs/go-cid"
-	delay "github.com/ipfs/go-ipfs-delay"
-	logging "github.com/ipfs/go-log/v2"
-	"github.com/ipfs/go-metrics-interface"
-	"github.com/libp2p/go-libp2p/core/peer"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
-
 	bsbpm "github.com/ipfs/boxo/bitswap/client/internal/blockpresencemanager"
 	bsgetter "github.com/ipfs/boxo/bitswap/client/internal/getter"
 	bsmq "github.com/ipfs/boxo/bitswap/client/internal/messagequeue"
@@ -35,6 +26,14 @@ import (
 	blockstore "github.com/ipfs/boxo/blockstore"
 	exchange "github.com/ipfs/boxo/exchange"
 	rpqm "github.com/ipfs/boxo/routing/providerquerymanager"
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+	delay "github.com/ipfs/go-ipfs-delay"
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/ipfs/go-metrics-interface"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 var log = logging.Logger("bitswap/client")

--- a/bitswap/server/server.go
+++ b/bitswap/server/server.go
@@ -72,6 +72,9 @@ func NewWithAutoStart(parent context.Context, network bsnet.BitSwapNetwork, bsto
 	return server
 }
 
+// New creates a new BitSwap server without starting it on the network.
+// IMPORTANT: You must call network.Start(server) before using this server,
+// or it will silently fail to receive requests. Consider using NewWithAutoStart instead.
 func New(ctx context.Context, network bsnet.BitSwapNetwork, bstore blockstore.Blockstore, options ...Option) *Server {
 	ctx, cancel := context.WithCancel(ctx)
 

--- a/bitswap/server/server.go
+++ b/bitswap/server/server.go
@@ -8,13 +8,6 @@ import (
 	"sync"
 	"time"
 
-	blocks "github.com/ipfs/go-block-format"
-	"github.com/ipfs/go-cid"
-	logging "github.com/ipfs/go-log/v2"
-	"github.com/ipfs/go-metrics-interface"
-	"github.com/libp2p/go-libp2p/core/peer"
-	"go.uber.org/zap"
-
 	"github.com/ipfs/boxo/bitswap/internal/defaults"
 	"github.com/ipfs/boxo/bitswap/message"
 	pb "github.com/ipfs/boxo/bitswap/message/pb"
@@ -23,6 +16,12 @@ import (
 	"github.com/ipfs/boxo/bitswap/server/internal/decision"
 	"github.com/ipfs/boxo/bitswap/tracer"
 	blockstore "github.com/ipfs/boxo/blockstore"
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/ipfs/go-metrics-interface"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"go.uber.org/zap"
 )
 
 var (

--- a/bitswap/server/server.go
+++ b/bitswap/server/server.go
@@ -8,6 +8,13 @@ import (
 	"sync"
 	"time"
 
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/ipfs/go-metrics-interface"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"go.uber.org/zap"
+
 	"github.com/ipfs/boxo/bitswap/internal/defaults"
 	"github.com/ipfs/boxo/bitswap/message"
 	pb "github.com/ipfs/boxo/bitswap/message/pb"
@@ -16,12 +23,6 @@ import (
 	"github.com/ipfs/boxo/bitswap/server/internal/decision"
 	"github.com/ipfs/boxo/bitswap/tracer"
 	blockstore "github.com/ipfs/boxo/blockstore"
-	blocks "github.com/ipfs/go-block-format"
-	"github.com/ipfs/go-cid"
-	logging "github.com/ipfs/go-log/v2"
-	"github.com/ipfs/go-metrics-interface"
-	"github.com/libp2p/go-libp2p/core/peer"
-	"go.uber.org/zap"
 )
 
 var (
@@ -60,6 +61,15 @@ type Server struct {
 
 	// Extra options to pass to the decision manager
 	engineOptions []decision.Option
+}
+
+// NewWithAutoStart creates a new BitSwap server and automatically starts it on the network.
+// This is the recommended way to create a standalone BitSwap server.
+func NewWithAutoStart(parent context.Context, network bsnet.BitSwapNetwork, bstore blockstore.Blockstore, options ...Option) *Server {
+	server := New(parent, network, bstore, options...)
+	network.Start(server)
+
+	return server
 }
 
 func New(ctx context.Context, network bsnet.BitSwapNetwork, bstore blockstore.Blockstore, options ...Option) *Server {


### PR DESCRIPTION
**Add NewWithAutoStart constructors for bitswap client and server**

Fixes [#68](https://github.com/ipfs/boxo/issues/68)

This PR adds `NewWithAutoStart` constructors to both client and server packages that automatically call `network.Start()`. This provides a more intuitive API when using standalone client or server, avoiding the common footgun where users need to manually call `network.Start()`.

The existing `New()` constructors are preserved for backwards compatibility and now include documentation about the `Start()` requirement.