### PR TITLE
mfs: clean cache on sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
+* `mfs`: directory cache is now cleared every time the directory node is read, somewhat limiting unbounded growth and time to sync it to the underlying unixfs.
+
 ### Security
 
 ## [v0.25.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
-* `mfs`: directory cache is now cleared every time the directory node is read, somewhat limiting unbounded growth and time to sync it to the underlying unixfs.
+* `mfs`: directory cache is now cleared on Flush(), liberating the memory used by the otherwise ever-growing cache. References to directories and sub-directories should be renewed after flushing.
 
 ### Security
 

--- a/mfs/dir.go
+++ b/mfs/dir.go
@@ -323,7 +323,7 @@ func (d *Directory) Unlink(name string) error {
 }
 
 func (d *Directory) Flush() error {
-	nd, err := d.GetNode()
+	nd, err := d.getNode(true)
 	if err != nil {
 		return err
 	}
@@ -349,7 +349,7 @@ func (d *Directory) AddChild(name string, nd ipld.Node) error {
 	return d.unixfsDir.AddChild(d.ctx, name, nd)
 }
 
-func (d *Directory) syncCache(clean bool) error {
+func (d *Directory) cacheSync(clean bool) error {
 	for name, entry := range d.entriesCache {
 		nd, err := entry.GetNode()
 		if err != nil {
@@ -385,10 +385,14 @@ func (d *Directory) Path() string {
 }
 
 func (d *Directory) GetNode() (ipld.Node, error) {
+	return d.getNode(false)
+}
+
+func (d *Directory) getNode(cacheClean bool) (ipld.Node, error) {
 	d.lock.Lock()
 	defer d.lock.Unlock()
 
-	err := d.syncCache(true)
+	err := d.cacheSync(cacheClean)
 	if err != nil {
 		return nil, err
 	}

--- a/mfs/file.go
+++ b/mfs/file.go
@@ -270,10 +270,9 @@ func (fi *File) setNodeData(data []byte) error {
 	}
 
 	fi.nodeLock.Lock()
-	defer fi.nodeLock.Unlock()
 	fi.node = nd
 	parent := fi.inode.parent
 	name := fi.inode.name
-
+	fi.nodeLock.Unlock()
 	return parent.updateChildEntry(child{name, fi.node})
 }

--- a/mfs/root.go
+++ b/mfs/root.go
@@ -170,16 +170,7 @@ func (kr *Root) Flush() error {
 func (kr *Root) FlushMemFree(ctx context.Context) error {
 	dir := kr.GetDirectory()
 
-	if err := dir.Flush(); err != nil {
-		return err
-	}
-
-	dir.lock.Lock()
-	defer dir.lock.Unlock()
-
-	clear(dir.entriesCache)
-
-	return nil
+	return dir.Flush()
 }
 
 // updateChildEntry implements the `parent` interface, and signals


### PR DESCRIPTION
There have been multiple reports of people complaining that MFS slows down to a crawl and triggers OOM events when adding many items to a folder.

One underlying issue is that the MFS Directory has a cache which can grown unbounded. All items added to a directory are cached here even though they are already written to the underlying Unixfs folder on mfs writes.

The cache serves Child() requests only. The purpose is the a Directory can then give updated information about its children without being "up to date" on its own parent: when a new write happens to a folder, the parent folder needs to be notified about the new unixfs node of their child. With this cache, this notification can be delayed until a Flush() is requested, one of the children triggers a bubbling notification, or the parent folder is traversed.

When the parent folder is traversed, it will write cached entries of its childen to disk, including that of the current folder. In order to write the current folder it has triggered a GetNode() on it, which in turn has written all the cached nodes  in the current folder to disk. This cascades. In principle, leafs do not have children and should not need to be rewritten to unixfs, but without caching the TestConcurrentWrites tests start failing. Caching provides a way for concurrent writes to access a single reference to a unixfs node, somehow making things work.

Apart from cosmetic changes, this commits allows resetting the cache when it has been synced to disk. Other approaches have been tested, like fully removing the cache, or resetting it when it reaches certain size. All were insatisfactory in that MFS breaks in one way or other (i.e. when setting maxCacheSize to 1). Setting size to ~50 allows tests to pass, but just because no tests are testing with 50+1 items.

This change does not break any tests, but after what I've seen, I can assume that concurrent writes during a Flush event probably result in broken expectations, and I wouldn't be surprised if there is a way to concatenate writes, lookups and flushes on references to multiple folders on the tree and trigger errors where things just work now.

The main problem remains: the current setup essentially keeps all mfs in memory. This commit could allevaite the fact that reading the directory object triggers as many unixfs.AddChild() as nodes in the directory. After this, AddChild() would be triggered only on nodes cached since the last time.

I don't find a reliable way of fixing MFS and I have discovered multiple gotchas into what was going to be a quick fix.

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
