### PR TITLE
[bitswap/peermanager] take read-lock for read-only operation

### DIFF
--- a/bitswap/client/internal/peermanager/peermanager.go
+++ b/bitswap/client/internal/peermanager/peermanager.go
@@ -42,7 +42,7 @@ type PeerManager struct {
 	createPeerQueue PeerQueueFactory
 	ctx             context.Context
 
-	psLk         sync.Mutex
+	psLk         sync.RWMutex
 	sessions     map[uint64]Session
 	peerSessions map[peer.ID]map[uint64]struct{}
 
@@ -233,8 +233,8 @@ func (pm *PeerManager) UnregisterSession(ses uint64) {
 // signalAvailability is called when a peer's connectivity changes.
 // It informs interested sessions.
 func (pm *PeerManager) signalAvailability(p peer.ID, isConnected bool) {
-	pm.psLk.Lock()
-	defer pm.psLk.Unlock()
+	pm.psLk.RLock()
+	defer pm.psLk.RUnlock()
 
 	sesIds, ok := pm.peerSessions[p]
 	if !ok {

--- a/bitswap/client/internal/peermanager/peermanager.go
+++ b/bitswap/client/internal/peermanager/peermanager.go
@@ -121,9 +121,9 @@ func (pm *PeerManager) Disconnected(p peer.ID) {
 // ks is the set of blocks, HAVEs and DONT_HAVEs in the message
 // Note that this is just used to calculate latency.
 func (pm *PeerManager) ResponseReceived(p peer.ID, ks []cid.Cid) {
-	pm.pqLk.Lock()
+	pm.pqLk.RLock()
 	pq, ok := pm.peerQueues[p]
-	pm.pqLk.Unlock()
+	pm.pqLk.RUnlock()
 
 	if ok {
 		pq.ResponseReceived(ks)

--- a/bitswap/client/internal/session/sessionwantsender.go
+++ b/bitswap/client/internal/session/sessionwantsender.go
@@ -220,12 +220,7 @@ func (sws *sessionWantSender) addChangeNonBlocking(c change) {
 	case sws.changes <- c:
 	default:
 		// changes channel is full, so add change in a go routine instead
-		go func() {
-			select {
-			case sws.changes <- c:
-			case <-sws.ctx.Done():
-			}
-		}()
+		go sws.addChange(c)
 	}
 }
 


### PR DESCRIPTION
Previously a read-only PeerManager operation was was protected by write-lock. This could have caused for the operation to block unnecessarily waiting for a write-lock.

There was also an instance of this with the PeerManager's session lock.
