### PR TITLE
Remove peer's count of first responses when peer becomes unavailable

### DIFF
--- a/bitswap/client/internal/session/peerresponsetracker.go
+++ b/bitswap/client/internal/session/peerresponsetracker.go
@@ -61,3 +61,7 @@ func (prt *peerResponseTracker) getPeerCount(p peer.ID) int {
 	// will be chosen
 	return prt.firstResponder[p] + 1
 }
+
+func (prt *peerResponseTracker) remove(p peer.ID) {
+	delete(prt.firstResponder, p)
+}

--- a/bitswap/client/internal/session/sessionwantsender.go
+++ b/bitswap/client/internal/session/sessionwantsender.go
@@ -321,14 +321,15 @@ func (sws *sessionWantSender) processAvailability(availability map[peer.ID]bool)
 			if wasAvailable {
 				stateChange = true
 				newlyUnavailable = append(newlyUnavailable, p)
+				// Remove count of first responses from peer.
+				sws.peerRspTrkr.remove(p)
 			}
 		}
 
 		// If the state has changed
 		if stateChange {
 			sws.updateWantsPeerAvailability(p, isNowAvailable)
-			// Reset the count of consecutive DONT_HAVEs received from the
-			// peer
+			// Reset count of consecutive DONT_HAVEs received from the peer.
 			delete(sws.peerConsecutiveDontHaves, p)
 		}
 	}


### PR DESCRIPTION
The peer response tracker counts the times each peer is first to response to block requests. When a peer becomes unavailabile, its count of first responses should be removed. This way we are not tracking the first response count for peers that are no longer available.
