### PR TITLE
Marco/with after func

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,9 @@ The following emojis are used to highlight certain changes:
 
 * 🛠 `blockstore` and `blockservice`'s `WriteThrough()` option now takes an "enabled" parameter: `WriteThrough(enabled bool)`.
 * Replaced unmaintained mock time implementation uses in tests: [from](github.com/benbjohnson/clock) => [to](github.com/filecoin-project/go-clock)
+* `bitswap/client`: if a libp2p connection has a context, use `context.AfterFunc` to cleanup the connection.
 
 ### Removed
-
 
 
 ### Fixed

--- a/bitswap/network/ipfs_impl.go
+++ b/bitswap/network/ipfs_impl.go
@@ -134,6 +134,11 @@ func (s *streamMessageSender) Connect(ctx context.Context) (network.Stream, erro
 	if err != nil {
 		return nil, err
 	}
+	if withCtx, ok := stream.Conn().(HasContext); ok {
+		context.AfterFunc(withCtx.Context(), func() {
+			s.stream.Store(nil)
+		})
+	}
 
 	s.stream.Store(stream)
 	return stream, nil


### PR DESCRIPTION
refactor: if the conn has a context, use `context.AfterFunc` for cleanup