### PR TITLE
Typo Fix in `scoreledger.go`

### DIFF
--- a/bitswap/server/internal/decision/scoreledger.go
+++ b/bitswap/server/internal/decision/scoreledger.go
@@ -109,7 +109,7 @@ type DefaultScoreLedger struct {
 	scorePeer ScorePeerFunc
 	// is closed on Close
 	closing chan struct{}
-	// protects the fields immediatly below
+	// protects the fields immediately below
 	lock sync.RWMutex
 	// ledgerMap lists score ledgers by their partner key.
 	ledgerMap map[peer.ID]*scoreledger


### PR DESCRIPTION
### Typo Fix in `scoreledger.go`

#### Description:
This pull request fixes a typo in the `scoreledger.go` file, changing "immediatly" to the correct spelling "immediately" in the comment.

#### Changes:
- Fixed typo in comment at line 109 of `scoreledger.go`.

#### File Changed:
- `bitswap/server/internal/decision/scoreledger.go`

#### Diff:
```diff
@@ -109,7 +109,7 @@ type DefaultScoreLedger struct {
    scorePeer ScorePeerFunc
    // is closed on Close
    closing chan struct{}
    // protects the fields immediatly below
    // protects the fields immediately below
    lock sync.RWMutex
    // ledgerMap lists score ledgers by their partner key.
    ledgerMap map[peer.ID]*scoreledger

-->
