### PR TITLE
update release procedure

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -63,10 +63,10 @@ Below are links of related/adjacent work that has informed some of the decisions
 - [ ] Verify your [GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification) is configured in local git and GitHub
 - [ ] Ensure Boxo and Kubo are checked out on your system
 - [ ] Create a release branch called `release-vX.Y.Z` and push it
-  * Use `master` as base if `Z == 0`
-  * Use `release` as base if `Z > 0`
+  * Use `main` as base if `Z == 0`
+  * Use `release-X.Y.Z-1` as base if `Z > 0`
 - [ ] Tidy the changelog and push any changelog changes to `release-vX.Y.Z`
-- [ ] Create a draft PR merging `release-vX.Y.Z` into `release`
+- [ ] Create a draft PR merging `release-vX.Y.Z` into `main`
   - [ ] Name it "Release vX.Y.Z"
   - [ ] Reference this release issue
 - [ ] If `Z > 0`, then cherry-pick the necessary commits from `master` into `release-vX.Y.Z` using `git cherry-pick -x <commit>`
@@ -82,14 +82,10 @@ Below are links of related/adjacent work that has informed some of the decisions
 - [ ] Add a "release" label to the Boxo PR
 - [ ] After the release checker creates a draft release, copy-paste the changelog into the draft
 - [ ] Wait for approval from another Boxo maintainer
-- [ ] Merge the PR into `release`, _using "Create a Merge Commit"_, and do not delete the `release-vX.Y.X` branch
+- [ ] Merge the PR into `main`, _using "Create a Merge Commit"_, and do not delete the `release-vX.Y.X` branch
   - [ ] Verify the tag is created
 - [ ] Announce the release
   - [ ] Click [this link](https://discuss.ipfs.tech/new-topic?title=Boxo%20vX.Y.Z%20is%20out%21&tags=boxo&category=News&body=%23%23%20Boxo%20vX.Y.Z%20is%20out%21%0A%0ASee%3A%0A-%20Code%3A%20https%3A%2F%2Fgithub.com%2Fipfs%2Fboxo%2Freleases%2Ftag%2FvX.Y.Z%0A-%20Release%20Notes%3A%20https%3A%2F%2Fgithub.com%2Fipfs%2Fboxo%2Fblob%2FvX.Y.Z%2FCHANGELOG.md) to start a new Discourse topic <!--docs: https://meta.discourse.org/t/create-a-link-to-start-a-new-topic-with-pre-filled-information/28074 -->
     - [ ] Update `vX.Y.Z` in the title and body
 	- [ ] Create the topic
-- [ ] Create a PR merging `release` into `main`
-  - [ ] Name it "Merge release vX.Y.Z"
-  - [ ] Wait for approval
-  - [ ] Merge it _using "Create a Merge Commit"_, and do not delete the `release` branch
 - [ ] Update the Kubo PR to use the newly released version, mark it as "Ready for Review", get approval, and merge into Kubo


### PR DESCRIPTION
Update release procedures to not use the `release` branch. Instead, create separate `release-vX.Y.Z` branch that merges directly into main.

cc https://github.com/ipshipyard/roadmaps/issues/1
