### PR TITLE
chore: pass options to tracer start

### DIFF
--- a/namesys/republisher/repub.go
+++ b/namesys/republisher/repub.go
@@ -196,5 +196,5 @@ func (rp *Republisher) getLastIPNSRecord(ctx context.Context, name ipns.Name) (*
 var tracer = otel.Tracer("boxo/namesys/republisher")
 
 func startSpan(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
-	return tracer.Start(ctx, "Namesys."+name)
+	return tracer.Start(ctx, "Namesys."+name, opts...)
 }


### PR DESCRIPTION
<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->

When I was reading the code, I found the problem of missing parameters. Maybe `boxo` needs a static checking tool like `golangci-lint` to standardize the code?

I can also change this pr to add a static checking tool and fix the lint if needed