### PR TITLE
fix/gateway: escape directory redirect url

### DIFF
--- a/.github/workflows/gateway-conformance.yml
+++ b/.github/workflows/gateway-conformance.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       # 1. Download the gateway-conformance fixtures
       - name: Download gateway-conformance fixtures
-        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@8f8898bc621b64ebe8570a992778c2ac0718fe36
+        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.7
         with:
           output: fixtures
           merged: true
@@ -47,7 +47,7 @@ jobs:
 
       # 4. Run the gateway-conformance tests
       - name: Run gateway-conformance tests
-        uses: ipfs/gateway-conformance/.github/actions/test@8f8898bc621b64ebe8570a992778c2ac0718fe36
+        uses: ipfs/gateway-conformance/.github/actions/test@v0.7
         with:
           gateway-url: http://127.0.0.1:8040
           subdomain-url: http://example.net:8040
@@ -84,7 +84,7 @@ jobs:
     steps:
       # 1. Download the gateway-conformance fixtures
       - name: Download gateway-conformance fixtures
-        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@8f8898bc621b64ebe8570a992778c2ac0718fe36
+        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.7
         with:
           output: fixtures
           merged: true
@@ -114,7 +114,7 @@ jobs:
 
       # 4. Run the gateway-conformance tests
       - name: Run gateway-conformance tests
-        uses: ipfs/gateway-conformance/.github/actions/test@8f8898bc621b64ebe8570a992778c2ac0718fe36
+        uses: ipfs/gateway-conformance/.github/actions/test@v0.7
         with:
           gateway-url: http://127.0.0.1:8040 # we test gateway that is backed by a remote block gateway
           subdomain-url: http://example.net:8040
@@ -152,7 +152,7 @@ jobs:
     steps:
       # 1. Download the gateway-conformance fixtures
       - name: Download gateway-conformance fixtures
-        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@8f8898bc621b64ebe8570a992778c2ac0718fe36
+        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.7
         with:
           output: fixtures
           merged: true
@@ -182,7 +182,7 @@ jobs:
 
       # 4. Run the gateway-conformance tests
       - name: Run gateway-conformance tests
-        uses: ipfs/gateway-conformance/.github/actions/test@8f8898bc621b64ebe8570a992778c2ac0718fe36
+        uses: ipfs/gateway-conformance/.github/actions/test@v0.7
         with:
           gateway-url: http://127.0.0.1:8040 # we test gateway that is backed by a remote car gateway
           subdomain-url: http://example.net:8040

--- a/.github/workflows/gateway-conformance.yml
+++ b/.github/workflows/gateway-conformance.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       # 1. Download the gateway-conformance fixtures
       - name: Download gateway-conformance fixtures
-        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.6
+        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@8f8898bc621b64ebe8570a992778c2ac0718fe36
         with:
           output: fixtures
           merged: true
@@ -47,7 +47,7 @@ jobs:
 
       # 4. Run the gateway-conformance tests
       - name: Run gateway-conformance tests
-        uses: ipfs/gateway-conformance/.github/actions/test@v0.6
+        uses: ipfs/gateway-conformance/.github/actions/test@8f8898bc621b64ebe8570a992778c2ac0718fe36
         with:
           gateway-url: http://127.0.0.1:8040
           subdomain-url: http://example.net:8040
@@ -84,7 +84,7 @@ jobs:
     steps:
       # 1. Download the gateway-conformance fixtures
       - name: Download gateway-conformance fixtures
-        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.6
+        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@8f8898bc621b64ebe8570a992778c2ac0718fe36
         with:
           output: fixtures
           merged: true
@@ -114,7 +114,7 @@ jobs:
 
       # 4. Run the gateway-conformance tests
       - name: Run gateway-conformance tests
-        uses: ipfs/gateway-conformance/.github/actions/test@v0.6
+        uses: ipfs/gateway-conformance/.github/actions/test@8f8898bc621b64ebe8570a992778c2ac0718fe36
         with:
           gateway-url: http://127.0.0.1:8040 # we test gateway that is backed by a remote block gateway
           subdomain-url: http://example.net:8040
@@ -152,7 +152,7 @@ jobs:
     steps:
       # 1. Download the gateway-conformance fixtures
       - name: Download gateway-conformance fixtures
-        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.6
+        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@8f8898bc621b64ebe8570a992778c2ac0718fe36
         with:
           output: fixtures
           merged: true
@@ -182,7 +182,7 @@ jobs:
 
       # 4. Run the gateway-conformance tests
       - name: Run gateway-conformance tests
-        uses: ipfs/gateway-conformance/.github/actions/test@v0.6
+        uses: ipfs/gateway-conformance/.github/actions/test@8f8898bc621b64ebe8570a992778c2ac0718fe36
         with:
           gateway-url: http://127.0.0.1:8040 # we test gateway that is backed by a remote car gateway
           subdomain-url: http://example.net:8040

--- a/.github/workflows/gateway-sharness.yml
+++ b/.github/workflows/gateway-sharness.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           repository: ipfs/kubo
           path: kubo
+          ref: fix-gateway-percent-in-dirname
       - name: Install Missing Tools
         run: sudo apt install -y socat net-tools fish libxml2-utils
       - name: Replace boxo in Kubo go.mod

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
-- `gateway` Fix links for subdirectories with "%" in name. [#779](https://github.com/ipfs/boxo/pull/779)
+- `gateway` Fix redirect URLs for subdirectories with characters that need escaping. [#779](https://github.com/ipfs/boxo/pull/779)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
+- `gateway` Fix links for subdirectories with "%" in name. [#779](https://github.com/ipfs/boxo/pull/779)
+
 ### Security
 
 

--- a/gateway/handler_unixfs_dir.go
+++ b/gateway/handler_unixfs_dir.go
@@ -50,7 +50,7 @@ func (i *handler) serveDirectory(ctx context.Context, w http.ResponseWriter, r *
 				suffix = suffix + "?" + r.URL.RawQuery
 			}
 			// /ipfs/cid/foo?bar must be redirected to /ipfs/cid/foo/?bar
-			redirectURL := originalURLPath + suffix
+			redirectURL := requestURI.EscapedPath() + suffix
 			rq.logger.Debugw("directory location moved permanently", "status", http.StatusMovedPermanently)
 			http.Redirect(w, r, redirectURL, http.StatusMovedPermanently)
 			return true


### PR DESCRIPTION
When a directory gets redirected to a URL with a treailing slash, special chars in the directory name must be escaped in the redirect URL.

Depends on https://github.com/ipfs/gateway-conformance/pull/225
Required by: https://github.com/ipfs/kubo/pull/10649

Fixes issue https://github.com/ipfs/kubo/issues/10536

TODO:
- [x] Merge gateway-conformance PR and bump version
- [x] Update to latest gateway-conformance version in `.github/workflows/gateway-sharness.yml`
- [X] Remove `ref` from `.github/workflows/gateway-sharness.yml` after merge of this PR and merge of kubo PR
  - Handled in #780
