### PR TITLE
test with latest gateway-sharness

### DIFF
--- a/.github/workflows/gateway-sharness.yml
+++ b/.github/workflows/gateway-sharness.yml
@@ -28,7 +28,6 @@ jobs:
         with:
           repository: ipfs/kubo
           path: kubo
-          ref: fix-gateway-percent-in-dirname
       - name: Install Missing Tools
         run: sudo apt install -y socat net-tools fish libxml2-utils
       - name: Replace boxo in Kubo go.mod


### PR DESCRIPTION
Now that the latest gateway-sharness is merged into kubo master, there is no need to pull it from a branch.

This completes one remaining task from #779