### PR TITLE
fix(gateway): update DoH resolver for .eth DNSLink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The following emojis are used to highlight certain changes:
 
 ### Changed
 
+- `gateway` The default DNSLink resolver for `.eth` TLD changed to `https://dns.eth.limo/dns-query` [#781](https://github.com/ipfs/boxo/pull/781)
+
 ### Removed
 
 ### Fixed

--- a/gateway/dns.go
+++ b/gateway/dns.go
@@ -10,7 +10,7 @@ import (
 )
 
 var defaultResolvers = map[string]string{
-	"eth.":    "https://resolver.cloudflare-eth.com/dns-query",
+	"eth.":    "https://dns.eth.limo/dns-query",
 	"crypto.": "https://resolver.cloudflare-eth.com/dns-query",
 }
 


### PR DESCRIPTION
> Ref. https://developers.cloudflare.com/fundamentals/api/reference/deprecations/#2025-07-01:
> ![image](https://github.com/user-attachments/assets/4171a1f0-6918-4b7e-9496-233c2aded13d)

Cloudflare decommissioned their resolver and started redirecting (HTTP 308) to https://dns.eth.link/dns-query which is an alias for eth.limo.

We change default to https://dns.eth.limo/dns-query to avoid redirects and cache splitting.

Closes #771 by implementing option (C)

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
