### PR TITLE
fix(gateway): update DoH resolver for .crypto DNSLink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The following emojis are used to highlight certain changes:
 ### Fixed
 
 - `gateway` Fix redirect URLs for subdirectories with characters that need escaping. [#779](https://github.com/ipfs/boxo/pull/779)
+- `gateway` The default DNSLink resolver for `.crypto` TLD changed to `https://resolver.unstoppable.io/dns-query` [#782](https://github.com/ipfs/boxo/pull/782)
 
 ### Security
 

--- a/gateway/dns.go
+++ b/gateway/dns.go
@@ -11,7 +11,7 @@ import (
 
 var defaultResolvers = map[string]string{
 	"eth.":    "https://resolver.cloudflare-eth.com/dns-query",
-	"crypto.": "https://resolver.cloudflare-eth.com/dns-query",
+	"crypto.": "https://resolver.unstoppable.io/dns-query",
 }
 
 func newResolver(url string, opts ...doh.Option) (madns.BasicResolver, error) {


### PR DESCRIPTION
> Ref. https://developers.cloudflare.com/fundamentals/api/reference/deprecations/#2025-07-01:
> ![image](https://github.com/user-attachments/assets/4171a1f0-6918-4b7e-9496-233c2aded13d)


Cloudflare decomissionned their resolver and started redirecting (HTTP 308) to https://dns.eth.link/dns-query which is an alias for eth.limo.

That endpoint does not support resolving DNSLink of `.crypto` TLD and always returns no results, effectively breaking those DNSLinks for everyone using them with IPFS systems.

This change switches the default implicit DoH resolver of `.crypto` TLS to one provided by UD project, allowing their community to fix issue without involving a third-party.

Allows UD community to fix resolution themselves – see #772

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
