### PR TITLE
bitswap: messagequeue: lock only needed sections

### DIFF
--- a/bitswap/client/internal/messagequeue/messagequeue.go
+++ b/bitswap/client/internal/messagequeue/messagequeue.go
@@ -318,7 +318,6 @@ func (mq *MessageQueue) AddBroadcastWantHaves(wantHaves []cid.Cid) {
 	}
 
 	mq.wllock.Lock()
-	defer mq.wllock.Unlock()
 
 	for _, c := range wantHaves {
 		mq.bcstWants.Add(c, mq.priority, pb.Message_Wantlist_Have)
@@ -328,6 +327,8 @@ func (mq *MessageQueue) AddBroadcastWantHaves(wantHaves []cid.Cid) {
 		// for the cid
 		mq.cancels.Remove(c)
 	}
+
+	mq.wllock.Unlock()
 
 	// Schedule a message send
 	mq.signalWorkReady()
@@ -340,7 +341,6 @@ func (mq *MessageQueue) AddWants(wantBlocks []cid.Cid, wantHaves []cid.Cid) {
 	}
 
 	mq.wllock.Lock()
-	defer mq.wllock.Unlock()
 
 	for _, c := range wantHaves {
 		mq.peerWants.Add(c, mq.priority, pb.Message_Wantlist_Have)
@@ -358,6 +358,8 @@ func (mq *MessageQueue) AddWants(wantBlocks []cid.Cid, wantHaves []cid.Cid) {
 		// for the cid
 		mq.cancels.Remove(c)
 	}
+
+	mq.wllock.Unlock()
 
 	// Schedule a message send
 	mq.signalWorkReady()
@@ -844,7 +846,6 @@ FINISH:
 		now := mq.clock.Now()
 
 		mq.wllock.Lock()
-		defer mq.wllock.Unlock()
 
 		for _, e := range peerEntries[:sentPeerEntries] {
 			if e.Cid.Defined() { // Check if want was canceled in the interim
@@ -857,6 +858,9 @@ FINISH:
 				mq.bcstWants.SentAt(e.Cid, now)
 			}
 		}
+
+		mq.wllock.Unlock()
+
 		if mq.events != nil {
 			mq.events <- messageFinishedSending
 		}


### PR DESCRIPTION
A couple of locks here seem to lock also while doing things like sending things on channels. This seems prone to deadlocks and is wasteful.

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
