### PR TITLE
fix potential crash in unixfs directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The following emojis are used to highlight certain changes:
 
 - `gateway` Fix redirect URLs for subdirectories with characters that need escaping. [#779](https://github.com/ipfs/boxo/pull/779)
 - `ipns` Fix `ipns` protobuf namespace conflicts by using full package name `github.com/ipfs/boxo/ipns/pb/record.proto` instead of the generic `record.proto` [#794](https://github.com/ipfs/boxo/pull/794)
+- `unixfs` Fix possible crash when modifying directory [#798](https://github.com/ipfs/boxo/pull/798)
 
 ### Security
 


### PR DESCRIPTION
Fix potential crash in sizeBelowThreshold when modifying children in a directory.

Closes #675

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
