### PR TITLE
fix: replace fmt.Printf with fmt.Println for empty line output

### DIFF
--- a/cmd/boxo-migrate/boxomigrate.go
+++ b/cmd/boxo-migrate/boxomigrate.go
@@ -71,7 +71,7 @@ func main() {
 						return err
 					}
 
-					fmt.Printf("\n\n")
+					fmt.Println()
 
 					if !force {
 						p, err := os.Getwd()


### PR DESCRIPTION
I noticed we're using `fmt.Printf` to print two empty lines, but since we're not utilizing any formatting, it's more straightforward to use `fmt.Println()`.

This change simplifies the code and achieves the same result, as `fmt.Println` automatically adds a newline.  
