### PR TITLE
[skip changelog] Use routing.ContentRouting interface

### DIFF
--- a/bitswap/bitswap.go
+++ b/bitswap/bitswap.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/routing"
 
 	"go.uber.org/multierr"
 )
@@ -56,7 +57,7 @@ type Bitswap struct {
 	net    network.BitSwapNetwork
 }
 
-func New(ctx context.Context, net network.BitSwapNetwork, providerFinder client.ProviderFinder, bstore blockstore.Blockstore, options ...Option) *Bitswap {
+func New(ctx context.Context, net network.BitSwapNetwork, providerFinder routing.ContentDiscovery, bstore blockstore.Blockstore, options ...Option) *Bitswap {
 	bs := &Bitswap{
 		net: net,
 	}

--- a/bitswap/client/internal/session/session.go
+++ b/bitswap/client/internal/session/session.go
@@ -15,6 +15,7 @@ import (
 	delay "github.com/ipfs/go-ipfs-delay"
 	logging "github.com/ipfs/go-log/v2"
 	peer "github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/routing"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
@@ -72,12 +73,6 @@ type SessionPeerManager interface {
 	ProtectConnection(peer.ID)
 }
 
-// ProviderFinder is used to find providers for a given key
-type ProviderFinder interface {
-	// FindProvidersAsync searches for peers that provide the given CID
-	FindProvidersAsync(ctx context.Context, k cid.Cid, max int) <-chan peer.AddrInfo
-}
-
 // opType is the kind of operation that is being processed by the event loop
 type opType int
 
@@ -109,7 +104,7 @@ type Session struct {
 	sm             SessionManager
 	pm             PeerManager
 	sprm           SessionPeerManager
-	providerFinder ProviderFinder
+	providerFinder routing.ContentDiscovery
 	sim            *bssim.SessionInterestManager
 
 	sw  sessionWants
@@ -142,7 +137,7 @@ func New(
 	sm SessionManager,
 	id uint64,
 	sprm SessionPeerManager,
-	providerFinder ProviderFinder,
+	providerFinder routing.ContentDiscovery,
 	sim *bssim.SessionInterestManager,
 	pm PeerManager,
 	bpm *bsbpm.BlockPresenceManager,

--- a/bitswap/network/interface.go
+++ b/bitswap/network/interface.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/connmgr"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/routing"
 	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
 )
 
@@ -85,8 +86,7 @@ type Receiver interface {
 // Routing is an interface to providing and finding providers on a bitswap
 // network.
 type Routing interface {
-	// FindProvidersAsync returns a channel of providers for the given key.
-	FindProvidersAsync(context.Context, cid.Cid, int) <-chan peer.AddrInfo
+	routing.ContentDiscovery
 
 	// Provide provides the key to the network.
 	Provide(context.Context, cid.Cid) error


### PR DESCRIPTION
We have a couple of interfaces for FindProvidersAsync.

These were aligned to libp2p's routing.ContentRouting and now that it has been released and bubbled, we can remove our custom interfaces and rely on the canonical.

Should be cosmetic, I hope it doesn't break anything.