### PR TITLE
fix sending cancels when excluding peer

### DIFF
--- a/bitswap/client/internal/peermanager/peermanager_test.go
+++ b/bitswap/client/internal/peermanager/peermanager_test.go
@@ -281,7 +281,7 @@ func TestSendCancelsExclude(t *testing.T) {
 	// Clear messages
 	collectMessages(msgs, 2*time.Millisecond)
 
-	// Send cancels for 1 want-block and 1 want-have
+	// Send cancels for 1 want-block and 1 want-have, excluding peer1.
 	peerManager.SendCancels(ctx, []cid.Cid{cids[0], cids[2]}, peer1)
 	collected := collectMessages(msgs, 2*time.Millisecond)
 
@@ -292,15 +292,15 @@ func TestSendCancelsExclude(t *testing.T) {
 		t.Fatal("Expected no cancels to be sent to excluded peer")
 	}
 
-	// Send cancels for all cids
+	// Send cancels for all cids. Expect cancels for the 1 remaining sid that
+	// was not previously canceled.
 	peerManager.SendCancels(ctx, cids, "")
 	collected = collectMessages(msgs, 2*time.Millisecond)
-
 	if _, ok := collected[peer2]; ok {
 		t.Fatal("Expected no cancels to be sent to peer that was not sent messages")
 	}
-	if len(collected[peer1].cancels) != 3 {
-		t.Fatal("Expected cancel to be sent for want-blocks")
+	if len(collected[peer1].cancels) != 1 {
+		t.Fatalf("Expected cancel to be sent for 1 want-blocks, got %d", len(collected[peer1].cancels))
 	}
 }
 


### PR DESCRIPTION
When sending cancels for want-block and want-have requests, a peer may be excluded because it was the sender of a block and that peer will cancel the want itself without having to receive a cancel message. The would-be sender of the cancel message still needs to do everything, such as adjusting want counts, as if the cancel were being sent and then not send out the cancel message.

Closes #694
