### PR TITLE
another approach to fixing goroutine runaway

### DIFF
--- a/bitswap/client/internal/messagequeue/messagequeue.go
+++ b/bitswap/client/internal/messagequeue/messagequeue.go
@@ -503,7 +503,10 @@ func (mq *MessageQueue) runQueue() {
 			workScheduled = time.Time{}
 			newWork = mq.sendIfReady()
 
-		case req := <-requests:
+		case req, ok := <-requests:
+			if !ok {
+				return
+			}
 			newWork = req()
 
 		case res := <-mq.responses:

--- a/bitswap/client/internal/messagequeue/messagequeue.go
+++ b/bitswap/client/internal/messagequeue/messagequeue.go
@@ -451,7 +451,6 @@ func (mq *MessageQueue) Startup() {
 // Shutdown stops the processing of messages for a message queue.
 func (mq *MessageQueue) Shutdown() {
 	mq.shutdown()
-	mq.requests.Shutdown()
 }
 
 func (mq *MessageQueue) onShutdown() {


### PR DESCRIPTION
Instead of having each session goroutine acquire the messagequeue mutex to update the lists of CIDs in a peer's message queue, write an update to an actual queue - a channel read by a dedicated goroutine. This will effectively separate enqueuing new messages from the peer's messagequeue being busy.
