### PR TITLE
fix(bitswap): filter interests from received messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,8 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
-`bitswap/client`: Fix runaway goroutine creation under high load. Under high load conditions, goroutines are created faster than they can complete and the more goroutines creates the slower them complete. This creates a positive feedback cycle that ends in OOM. The fix dynamically adjusts message send scheduling to avoid the runaway condition. [#817](https://github.com/ipfs/boxo/pull/817)
-
+- `bitswap/client`: Fix runaway goroutine creation under high load. Under high load conditions, goroutines are created faster than they can complete and the more goroutines creates the slower them complete. This creates a positive feedback cycle that ends in OOM. The fix dynamically adjusts message send scheduling to avoid the runaway condition. [#817](https://github.com/ipfs/boxo/pull/817)
+- `bitswap/cllient`: Fix resource leak caused by recording the presence of blocks that no session cares about. [#822](https://github.com/ipfs/boxo/pull/822)
 
 ### Security
 

--- a/bitswap/client/internal/sessioninterestmanager/sessioninterestmanager.go
+++ b/bitswap/client/internal/sessioninterestmanager/sessioninterestmanager.go
@@ -181,11 +181,11 @@ func (sim *SessionInterestManager) FilterInterests(keySets ...[]cid.Cid) [][]cid
 	sim.lk.RLock()
 	defer sim.lk.RUnlock()
 
-	result := make([][]cid.Cid, len(keySets))
+	result := keySets[:0]
 	// For each set of keys
 	for i, ks := range keySets {
 		// The set of keys that at least one session is interested in
-		wanted := make([]cid.Cid, 0, len(ks))
+		wanted := ks[:0]
 
 		// For each key in the set
 		for _, c := range ks {
@@ -194,7 +194,7 @@ func (sim *SessionInterestManager) FilterInterests(keySets ...[]cid.Cid) [][]cid
 				wanted = append(wanted, c)
 			}
 		}
-		result[i] = wanted
+		result = appent(result, wanted)
 	}
 	return result
 }

--- a/bitswap/client/internal/sessioninterestmanager/sessioninterestmanager.go
+++ b/bitswap/client/internal/sessioninterestmanager/sessioninterestmanager.go
@@ -183,18 +183,18 @@ func (sim *SessionInterestManager) FilterInterests(keySets ...[]cid.Cid) [][]cid
 
 	result := keySets[:0]
 	// For each set of keys
-	for i, ks := range keySets {
-		// The set of keys that at least one session is interested in
+	for _, ks := range keySets {
+		// The set of keys wanted by at least one session
 		wanted := ks[:0]
 
 		// For each key in the set
 		for _, c := range ks {
-			// If there are any sessions interested in this key
+			// If any session wants the key
 			if _, ok := sim.wants[c]; ok {
 				wanted = append(wanted, c)
 			}
 		}
-		result = appent(result, wanted)
+		result = append(result, wanted)
 	}
 	return result
 }

--- a/bitswap/client/internal/sessioninterestmanager/sessioninterestmanager.go
+++ b/bitswap/client/internal/sessioninterestmanager/sessioninterestmanager.go
@@ -175,3 +175,26 @@ func (sim *SessionInterestManager) InterestedSessions(keySets ...[]cid.Cid) []ui
 	}
 	return ses
 }
+
+// Filters only the keys that are wanted by at least one session
+func (sim *SessionInterestManager) FilterInterests(keySets ...[]cid.Cid) [][]cid.Cid {
+	sim.lk.RLock()
+	defer sim.lk.RUnlock()
+
+	result := make([][]cid.Cid, len(keySets))
+	// For each set of keys
+	for i, ks := range keySets {
+		// The set of keys that at least one session is interested in
+		wanted := make([]cid.Cid, 0, len(ks))
+
+		// For each key in the set
+		for _, c := range ks {
+			// If there are any sessions interested in this key
+			if _, ok := sim.wants[c]; ok {
+				wanted = append(wanted, c)
+			}
+		}
+		result[i] = wanted
+	}
+	return result
+}

--- a/bitswap/client/internal/sessionmanager/sessionmanager.go
+++ b/bitswap/client/internal/sessionmanager/sessionmanager.go
@@ -153,7 +153,7 @@ func (sm *SessionManager) GetNextSessionID() uint64 {
 
 // ReceiveFrom is called when a new message is received
 func (sm *SessionManager) ReceiveFrom(ctx context.Context, p peer.ID, blks []cid.Cid, haves []cid.Cid, dontHaves []cid.Cid) {
-	// Keep only the keys that at least one session is interested in
+	// Keep only the keys that at least one session wants
 	keys := sm.sessionInterestManager.FilterInterests(blks, haves, dontHaves)
 	blks = keys[0]
 	haves = keys[1]

--- a/bitswap/client/internal/sessionmanager/sessionmanager.go
+++ b/bitswap/client/internal/sessionmanager/sessionmanager.go
@@ -153,6 +153,11 @@ func (sm *SessionManager) GetNextSessionID() uint64 {
 
 // ReceiveFrom is called when a new message is received
 func (sm *SessionManager) ReceiveFrom(ctx context.Context, p peer.ID, blks []cid.Cid, haves []cid.Cid, dontHaves []cid.Cid) {
+	// Keep only the keys that at least one session is interested in
+	keys := sm.sessionInterestManager.FilterInterests(blks, haves, dontHaves)
+	blks = keys[0]
+	haves = keys[1]
+	dontHaves = keys[2]
 	// Record block presence for HAVE / DONT_HAVE
 	sm.blockPresenceManager.ReceiveFrom(p, haves, dontHaves)
 

--- a/bitswap/client/internal/sessionmanager/sessionmanager.go
+++ b/bitswap/client/internal/sessionmanager/sessionmanager.go
@@ -151,7 +151,11 @@ func (sm *SessionManager) GetNextSessionID() uint64 {
 	return sm.sessID
 }
 
-// ReceiveFrom is called when a new message is received
+// ReceiveFrom is called when a new message is received.
+//
+// IMPORTANT: ReceiveFrom filters the given Cid slices in place, modifying
+// their contents. If the caller needs to preserve a copy of the lists it
+// should make a copy before calling ReceiveFrom.
 func (sm *SessionManager) ReceiveFrom(ctx context.Context, p peer.ID, blks []cid.Cid, haves []cid.Cid, dontHaves []cid.Cid) {
 	// Keep only the keys that at least one session wants
 	keys := sm.sessionInterestManager.FilterInterests(blks, haves, dontHaves)


### PR DESCRIPTION
Fixresource leak by adding a CID to BlockResponseManager only if there a session interested in it.

Follow up to https://github.com/ipfs/boxo/issues/752
Based on https://github.com/ipfs/boxo/pull/821

@Wondertan does that address the leak that you are referring to in https://github.com/ipfs/boxo/commit/70a650316c3b9e4734df0bcb79ea8e530d86aae8?

cc: @gammazero 