### PR TITLE
Always send cancels even if peer has no interest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
+- Fix memory leak due to not cleaning up wantlists [#829](https://github.com/ipfs/boxo/pull/829)
+
 ### Security
 
 

--- a/bitswap/client/internal/messagequeue/messagequeue.go
+++ b/bitswap/client/internal/messagequeue/messagequeue.go
@@ -44,7 +44,7 @@ const (
 	sendTimeout = 30 * time.Second
 
 	defaultPerPeerDelay = time.Millisecond / 8
-	maxSendMessageDelay = time.Second
+	maxSendMessageDelay = 2 * time.Second
 	minSendMessageDelay = 20 * time.Millisecond
 )
 

--- a/bitswap/client/internal/sessionmanager/sessionmanager.go
+++ b/bitswap/client/internal/sessionmanager/sessionmanager.go
@@ -157,7 +157,9 @@ func (sm *SessionManager) GetNextSessionID() uint64 {
 // their contents. If the caller needs to preserve a copy of the lists it
 // should make a copy before calling ReceiveFrom.
 func (sm *SessionManager) ReceiveFrom(ctx context.Context, p peer.ID, blks []cid.Cid, haves []cid.Cid, dontHaves []cid.Cid) {
-	// Send CANCEL to all peers with want-have / want-block
+	// Send CANCEL to all peers with want-have / want-block. This needs to be
+	// done before filtering out CIDs that peers are no longer interested in,
+	// to ensure they are removed from PeerManager and PeerQueue want lists.
 	sm.peerManager.SendCancels(ctx, blks)
 
 	// Keep only the keys that at least one session wants

--- a/bitswap/client/internal/sessionmanager/sessionmanager.go
+++ b/bitswap/client/internal/sessionmanager/sessionmanager.go
@@ -157,6 +157,9 @@ func (sm *SessionManager) GetNextSessionID() uint64 {
 // their contents. If the caller needs to preserve a copy of the lists it
 // should make a copy before calling ReceiveFrom.
 func (sm *SessionManager) ReceiveFrom(ctx context.Context, p peer.ID, blks []cid.Cid, haves []cid.Cid, dontHaves []cid.Cid) {
+	// Send CANCEL to all peers with want-have / want-block
+	sm.peerManager.SendCancels(ctx, blks)
+
 	// Keep only the keys that at least one session wants
 	keys := sm.sessionInterestManager.FilterInterests(blks, haves, dontHaves)
 	blks = keys[0]
@@ -179,9 +182,6 @@ func (sm *SessionManager) ReceiveFrom(ctx context.Context, p peer.ID, blks []cid
 			sess.ReceiveFrom(p, blks, haves, dontHaves)
 		}
 	}
-
-	// Send CANCEL to all peers with want-have / want-block
-	sm.peerManager.SendCancels(ctx, blks)
 }
 
 // CancelSessionWants is called when a session cancels wants because a call to


### PR DESCRIPTION
Possible fix for memory leak in wantlists.

It appears necessary to send cancels even if the receiving peer has no interest in the CIDs according to the session interest manager. The handling of cancels cleans up the CIDs that remain on the peerwantmanager wantlists.