### PR TITLE
fix(ipns): reading records with raw []byte Value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
+- `ipns`: Improved interop with legacy clients by restoring support for `[]byte` CID in `Value` field. `Value()` will convert it to a valid `path.Path`. Empty `Value()` will produce `NoopPath` (`/ipfs/bafkqaaa`) to avoid breaking existing code that expects a valid record to always produce a valid content path. [#830](https://github.com/ipfs/boxo/pull/830)
+
 ### Security
 
 

--- a/ipns/record.go
+++ b/ipns/record.go
@@ -85,8 +85,10 @@ func MarshalRecord(rec *Record) ([]byte, error) {
 	return proto.Marshal(rec.pb)
 }
 
-// Value returns the [path.Path] that is embedded in this IPNS Record. If the
-// path is invalid, an [ErrInvalidPath] is returned.
+// Value returns the [path.Path] that is embedded in this IPNS Record.
+// If the path is invalid, an error is returned.
+// If the value is a binary CID, it is converted to a [path.Path].
+// If the value is empty, a [NoopValue] is used instead.
 func (rec *Record) Value() (path.Path, error) {
 	value, err := rec.getBytesValue(cborValueKey)
 	if err != nil {
@@ -101,7 +103,7 @@ func (rec *Record) Value() (path.Path, error) {
 	}
 
 	// parse as a string with content path
-	if len(value) > 0 && value[0] == '/' {
+	if value[0] == '/' {
 		p, err := path.NewPath(string(value))
 		if err != nil {
 			return nil, multierr.Combine(ErrInvalidPath, err)


### PR DESCRIPTION
This PR aims to improve / maximize interop with legacy/alternative IPNS clients by restoring support for `[]byte` CID in `Value` field and gracefully handling empty `Value` in scenarios where IPNS is used for its `Data` field, and not IPFS paths.

- [x] `record.Value()` will convert a binary CID to a valid `path.Path`. 
- [x] Empty `Value()` will produce `NoopPath` (`/ipfs/bafkqaaa`) to avoid breaking existing code that expects a valid record to always produce a valid content path.
- [x] tests to ensure we test both + error if `Value()` can't produce a meaningful path

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->

Thank you @ianopolous and @aschmahmann for catching this.

If / once this lands, I'll update phrasing in https://specs.ipfs.tech/ipns/ipns-record/ to make it clear binary CID and empty Value are both allowed.

Aiming to include this in Kubo 0.34.
