### PR TITLE
fix(bitswap): blockpresencemanager leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
-- Fix memory leak due to not cleaning up wantlists [#829](https://github.com/ipfs/boxo/pull/829)
+- Fix memory leak due to not cleaning up wantlists [#829](https://github.com/ipfs/boxo/pull/829), [#833](https://github.com/ipfs/boxo/pull/833)
 
 ### Security
 

--- a/bitswap/client/internal/session/session.go
+++ b/bitswap/client/internal/session/session.go
@@ -437,9 +437,9 @@ func (s *Session) handleReceive(ks []cid.Cid) {
 	// Record latency
 	s.latencyTrkr.receiveUpdate(len(wanted), totalLatency)
 
-	// Inform the SessionInterestManager that this session is no longer
-	// expecting to receive the wanted keys
-	s.sim.RemoveSessionWants(s.id, wanted)
+	// Inform the SessionManager that this session is no longer expecting to
+	// receive the wanted keys, since we now have them
+	s.sm.CancelSessionWants(s.id, wanted)
 
 	s.idleTick.Stop()
 

--- a/bitswap/client/internal/session/sessionwantsender_test.go
+++ b/bitswap/client/internal/session/sessionwantsender_test.go
@@ -8,6 +8,7 @@ import (
 
 	bsbpm "github.com/ipfs/boxo/bitswap/client/internal/blockpresencemanager"
 	bspm "github.com/ipfs/boxo/bitswap/client/internal/peermanager"
+	bssim "github.com/ipfs/boxo/bitswap/client/internal/sessioninterestmanager"
 	bsspm "github.com/ipfs/boxo/bitswap/client/internal/sessionpeermanager"
 	cid "github.com/ipfs/go-cid"
 	"github.com/ipfs/go-test/random"
@@ -147,7 +148,8 @@ func TestSendWants(t *testing.T) {
 	const sid = uint64(1)
 	pm := newMockPeerManager()
 	fpm := newFakeSessionPeerManager()
-	swc := newMockSessionMgr()
+	sim := bssim.New()
+	swc := newMockSessionMgr(sim)
 	bpm := bsbpm.New()
 	onSend := func(peer.ID, []cid.Cid, []cid.Cid) {}
 	onPeersExhausted := func([]cid.Cid) {}
@@ -181,7 +183,8 @@ func TestSendsWantBlockToOnePeerOnly(t *testing.T) {
 	const sid = uint64(1)
 	pm := newMockPeerManager()
 	fpm := newFakeSessionPeerManager()
-	swc := newMockSessionMgr()
+	sim := bssim.New()
+	swc := newMockSessionMgr(sim)
 	bpm := bsbpm.New()
 	onSend := func(peer.ID, []cid.Cid, []cid.Cid) {}
 	onPeersExhausted := func([]cid.Cid) {}
@@ -231,7 +234,8 @@ func TestReceiveBlock(t *testing.T) {
 	const sid = uint64(1)
 	pm := newMockPeerManager()
 	fpm := newFakeSessionPeerManager()
-	swc := newMockSessionMgr()
+	sim := bssim.New()
+	swc := newMockSessionMgr(sim)
 	bpm := bsbpm.New()
 	onSend := func(peer.ID, []cid.Cid, []cid.Cid) {}
 	onPeersExhausted := func([]cid.Cid) {}
@@ -284,7 +288,8 @@ func TestCancelWants(t *testing.T) {
 	const sid = uint64(1)
 	pm := newMockPeerManager()
 	fpm := newFakeSessionPeerManager()
-	swc := newMockSessionMgr()
+	sim := bssim.New()
+	swc := newMockSessionMgr(sim)
 	bpm := bsbpm.New()
 	onSend := func(peer.ID, []cid.Cid, []cid.Cid) {}
 	onPeersExhausted := func([]cid.Cid) {}
@@ -319,7 +324,8 @@ func TestRegisterSessionWithPeerManager(t *testing.T) {
 	const sid = uint64(1)
 	pm := newMockPeerManager()
 	fpm := newFakeSessionPeerManager()
-	swc := newMockSessionMgr()
+	sim := bssim.New()
+	swc := newMockSessionMgr(sim)
 	bpm := bsbpm.New()
 	onSend := func(peer.ID, []cid.Cid, []cid.Cid) {}
 	onPeersExhausted := func([]cid.Cid) {}
@@ -357,7 +363,8 @@ func TestProtectConnFirstPeerToSendWantedBlock(t *testing.T) {
 	pm := newMockPeerManager()
 	fpt := newFakePeerTagger()
 	fpm := bsspm.New(1, fpt)
-	swc := newMockSessionMgr()
+	sim := bssim.New()
+	swc := newMockSessionMgr(sim)
 	bpm := bsbpm.New()
 	onSend := func(peer.ID, []cid.Cid, []cid.Cid) {}
 	onPeersExhausted := func([]cid.Cid) {}
@@ -411,7 +418,8 @@ func TestPeerUnavailable(t *testing.T) {
 	const sid = uint64(1)
 	pm := newMockPeerManager()
 	fpm := newFakeSessionPeerManager()
-	swc := newMockSessionMgr()
+	sim := bssim.New()
+	swc := newMockSessionMgr(sim)
 	bpm := bsbpm.New()
 	onSend := func(peer.ID, []cid.Cid, []cid.Cid) {}
 	onPeersExhausted := func([]cid.Cid) {}
@@ -470,7 +478,8 @@ func TestPeersExhausted(t *testing.T) {
 	const sid = uint64(1)
 	pm := newMockPeerManager()
 	fpm := newFakeSessionPeerManager()
-	swc := newMockSessionMgr()
+	sim := bssim.New()
+	swc := newMockSessionMgr(sim)
 	bpm := bsbpm.New()
 	onSend := func(peer.ID, []cid.Cid, []cid.Cid) {}
 
@@ -543,7 +552,8 @@ func TestPeersExhaustedLastWaitingPeerUnavailable(t *testing.T) {
 	const sid = uint64(1)
 	pm := newMockPeerManager()
 	fpm := newFakeSessionPeerManager()
-	swc := newMockSessionMgr()
+	sim := bssim.New()
+	swc := newMockSessionMgr(sim)
 	bpm := bsbpm.New()
 	onSend := func(peer.ID, []cid.Cid, []cid.Cid) {}
 
@@ -590,7 +600,8 @@ func TestPeersExhaustedAllPeersUnavailable(t *testing.T) {
 	const sid = uint64(1)
 	pm := newMockPeerManager()
 	fpm := newFakeSessionPeerManager()
-	swc := newMockSessionMgr()
+	sim := bssim.New()
+	swc := newMockSessionMgr(sim)
 	bpm := bsbpm.New()
 	onSend := func(peer.ID, []cid.Cid, []cid.Cid) {}
 
@@ -628,7 +639,8 @@ func TestConsecutiveDontHaveLimit(t *testing.T) {
 	const sid = uint64(1)
 	pm := newMockPeerManager()
 	fpm := newFakeSessionPeerManager()
-	swc := newMockSessionMgr()
+	sim := bssim.New()
+	swc := newMockSessionMgr(sim)
 	bpm := bsbpm.New()
 	onSend := func(peer.ID, []cid.Cid, []cid.Cid) {}
 	onPeersExhausted := func([]cid.Cid) {}
@@ -680,7 +692,8 @@ func TestConsecutiveDontHaveLimitInterrupted(t *testing.T) {
 	const sid = uint64(1)
 	pm := newMockPeerManager()
 	fpm := newFakeSessionPeerManager()
-	swc := newMockSessionMgr()
+	sim := bssim.New()
+	swc := newMockSessionMgr(sim)
 	bpm := bsbpm.New()
 	onSend := func(peer.ID, []cid.Cid, []cid.Cid) {}
 	onPeersExhausted := func([]cid.Cid) {}
@@ -733,7 +746,8 @@ func TestConsecutiveDontHaveReinstateAfterRemoval(t *testing.T) {
 	const sid = uint64(1)
 	pm := newMockPeerManager()
 	fpm := newFakeSessionPeerManager()
-	swc := newMockSessionMgr()
+	sim := bssim.New()
+	swc := newMockSessionMgr(sim)
 	bpm := bsbpm.New()
 	onSend := func(peer.ID, []cid.Cid, []cid.Cid) {}
 	onPeersExhausted := func([]cid.Cid) {}
@@ -809,7 +823,8 @@ func TestConsecutiveDontHaveDontRemoveIfHasWantedBlock(t *testing.T) {
 	const sid = uint64(1)
 	pm := newMockPeerManager()
 	fpm := newFakeSessionPeerManager()
-	swc := newMockSessionMgr()
+	sim := bssim.New()
+	swc := newMockSessionMgr(sim)
 	bpm := bsbpm.New()
 	onSend := func(peer.ID, []cid.Cid, []cid.Cid) {}
 	onPeersExhausted := func([]cid.Cid) {}

--- a/bitswap/client/internal/sessionmanager/sessionmanager.go
+++ b/bitswap/client/internal/sessionmanager/sessionmanager.go
@@ -157,11 +157,6 @@ func (sm *SessionManager) GetNextSessionID() uint64 {
 // their contents. If the caller needs to preserve a copy of the lists it
 // should make a copy before calling ReceiveFrom.
 func (sm *SessionManager) ReceiveFrom(ctx context.Context, p peer.ID, blks []cid.Cid, haves []cid.Cid, dontHaves []cid.Cid) {
-	// Send CANCEL to all peers with want-have / want-block. This needs to be
-	// done before filtering out CIDs that peers are no longer interested in,
-	// to ensure they are removed from PeerManager and PeerQueue want lists.
-	sm.peerManager.SendCancels(ctx, blks)
-
 	// Keep only the keys that at least one session wants
 	keys := sm.sessionInterestManager.FilterInterests(blks, haves, dontHaves)
 	blks = keys[0]


### PR DESCRIPTION
## Summary
* Originated from https://github.com/ipfs/boxo/issues/752
* Addresses `BlockPresenceManager` leak uncovered by @Wondertan in https://github.com/ipfs/boxo/commit/7adce5f5ee7afb69684a817bf6578d0ee46762d5
* Modifies when to send out `cancel` (as introduced in https://github.com/ipfs/boxo/pull/829)

## Reasoning
* IIUC before https://github.com/ipfs/boxo/pull/829, no `cancel` was sent directly after receiving a block.
* Maybe I misunderstood, but in https://github.com/ipfs/boxo/pull/829, I don't see a reason why the cancels should be sent out [before filtering the `wanted` keys](https://github.com/ipfs/boxo/blob/9e257a7ab606642ead87618a337dbce1e5c799c4/bitswap/client/internal/sessionmanager/sessionmanager.go#L160-L163). IIUC the filtering (in `SessionsInterestManager`) doesn't use the `PeerManager` wantlist.
* Cancels have to be sent out for blocks that we receive, but they can be sent out later.

@gammazero I suspect this PR is equivalent to https://github.com/ipfs/boxo/pull/829 wrt. sending Cancels, although we don't send cancels for blocks we don't want. I suggest we run a short test to be convinced of it before merging.