### PR TITLE
bitswap/client/internal/messagequeue: run tests in parallel

### DIFF
--- a/bitswap/client/internal/messagequeue/donthavetimeoutmgr_test.go
+++ b/bitswap/client/internal/messagequeue/donthavetimeoutmgr_test.go
@@ -73,6 +73,7 @@ func (tr *timeoutRecorder) clear() {
 }
 
 func TestDontHaveTimeoutMgrTimeout(t *testing.T) {
+	t.Parallel()
 	firstks := random.Cids(2)
 	secondks := append(firstks, random.Cids(3)...)
 	latency := time.Millisecond * 20
@@ -133,6 +134,7 @@ func TestDontHaveTimeoutMgrTimeout(t *testing.T) {
 }
 
 func TestDontHaveTimeoutMgrCancel(t *testing.T) {
+	t.Parallel()
 	ks := random.Cids(3)
 	latency := time.Millisecond * 10
 	latMultiplier := 1
@@ -173,6 +175,7 @@ func TestDontHaveTimeoutMgrCancel(t *testing.T) {
 }
 
 func TestDontHaveTimeoutWantCancelWant(t *testing.T) {
+	t.Parallel()
 	ks := random.Cids(3)
 	latency := time.Millisecond * 20
 	latMultiplier := 1
@@ -229,6 +232,7 @@ func TestDontHaveTimeoutWantCancelWant(t *testing.T) {
 }
 
 func TestDontHaveTimeoutRepeatedAddPending(t *testing.T) {
+	t.Parallel()
 	ks := random.Cids(10)
 	latency := time.Millisecond * 5
 	latMultiplier := 1
@@ -266,6 +270,7 @@ func TestDontHaveTimeoutRepeatedAddPending(t *testing.T) {
 }
 
 func TestDontHaveTimeoutMgrMessageLatency(t *testing.T) {
+	t.Parallel()
 	ks := random.Cids(2)
 	latency := time.Millisecond * 40
 	latMultiplier := 1
@@ -320,6 +325,7 @@ func TestDontHaveTimeoutMgrMessageLatency(t *testing.T) {
 }
 
 func TestDontHaveTimeoutMgrMessageLatencyMax(t *testing.T) {
+	t.Parallel()
 	ks := random.Cids(2)
 	clock := clock.NewMock()
 	pinged := make(chan struct{})
@@ -357,6 +363,7 @@ func TestDontHaveTimeoutMgrMessageLatencyMax(t *testing.T) {
 }
 
 func TestDontHaveTimeoutMgrUsesDefaultTimeoutIfPingError(t *testing.T) {
+	t.Parallel()
 	ks := random.Cids(2)
 	latency := time.Millisecond
 	latMultiplier := 2
@@ -403,6 +410,7 @@ func TestDontHaveTimeoutMgrUsesDefaultTimeoutIfPingError(t *testing.T) {
 }
 
 func TestDontHaveTimeoutMgrUsesDefaultTimeoutIfLatencyLonger(t *testing.T) {
+	t.Parallel()
 	ks := random.Cids(2)
 	latency := time.Millisecond * 200
 	latMultiplier := 1
@@ -448,6 +456,7 @@ func TestDontHaveTimeoutMgrUsesDefaultTimeoutIfLatencyLonger(t *testing.T) {
 }
 
 func TestDontHaveTimeoutNoTimeoutAfterShutdown(t *testing.T) {
+	t.Parallel()
 	ks := random.Cids(2)
 	latency := time.Millisecond * 10
 	latMultiplier := 1

--- a/bitswap/client/internal/messagequeue/messagequeue_test.go
+++ b/bitswap/client/internal/messagequeue/messagequeue_test.go
@@ -163,6 +163,7 @@ func expectEvent(t *testing.T, events <-chan messageEvent, expectedEvent message
 }
 
 func TestStartupAndShutdown(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	messagesSent := make(chan []bsmsg.Entry)
 	resetChan := make(chan struct{}, 1)
@@ -201,6 +202,7 @@ func TestStartupAndShutdown(t *testing.T) {
 }
 
 func TestSendingMessagesDeduped(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	messagesSent := make(chan []bsmsg.Entry)
 	resetChan := make(chan struct{}, 1)
@@ -223,6 +225,7 @@ func TestSendingMessagesDeduped(t *testing.T) {
 }
 
 func TestSendingMessagesPartialDupe(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	messagesSent := make(chan []bsmsg.Entry)
 	resetChan := make(chan struct{}, 1)
@@ -245,6 +248,7 @@ func TestSendingMessagesPartialDupe(t *testing.T) {
 }
 
 func TestSendingMessagesPriority(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	messagesSent := make(chan []bsmsg.Entry)
 	resetChan := make(chan struct{}, 1)
@@ -313,6 +317,7 @@ func TestSendingMessagesPriority(t *testing.T) {
 }
 
 func TestCancelOverridesPendingWants(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	messagesSent := make(chan []bsmsg.Entry)
 	resetChan := make(chan struct{}, 1)
@@ -364,6 +369,7 @@ func TestCancelOverridesPendingWants(t *testing.T) {
 }
 
 func TestWantOverridesPendingCancels(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	messagesSent := make(chan []bsmsg.Entry)
 	resetChan := make(chan struct{}, 1)
@@ -411,6 +417,7 @@ func TestWantOverridesPendingCancels(t *testing.T) {
 }
 
 func TestWantlistRebroadcast(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	messagesSent := make(chan []bsmsg.Entry)
 	resetChan := make(chan struct{}, 1)
@@ -512,6 +519,7 @@ func TestWantlistRebroadcast(t *testing.T) {
 }
 
 func TestSendingLargeMessages(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	messagesSent := make(chan []bsmsg.Entry)
 	resetChan := make(chan struct{}, 1)
@@ -542,6 +550,7 @@ func TestSendingLargeMessages(t *testing.T) {
 }
 
 func TestSendToPeerThatDoesntSupportHave(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	messagesSent := make(chan []bsmsg.Entry)
 	resetChan := make(chan struct{}, 1)
@@ -597,6 +606,7 @@ func TestSendToPeerThatDoesntSupportHave(t *testing.T) {
 }
 
 func TestSendToPeerThatDoesntSupportHaveMonitorsTimeouts(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	messagesSent := make(chan []bsmsg.Entry)
 	resetChan := make(chan struct{}, 1)
@@ -629,6 +639,7 @@ func TestSendToPeerThatDoesntSupportHaveMonitorsTimeouts(t *testing.T) {
 }
 
 func TestResponseReceived(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	messagesSent := make(chan []bsmsg.Entry)
 	resetChan := make(chan struct{}, 1)
@@ -680,6 +691,7 @@ func TestResponseReceived(t *testing.T) {
 }
 
 func TestResponseReceivedAppliesForFirstResponseOnly(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	messagesSent := make(chan []bsmsg.Entry)
 	resetChan := make(chan struct{}, 1)
@@ -725,6 +737,7 @@ func TestResponseReceivedAppliesForFirstResponseOnly(t *testing.T) {
 }
 
 func TestResponseReceivedDiscardsOutliers(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	messagesSent := make(chan []bsmsg.Entry)
 	resetChan := make(chan struct{}, 1)


### PR DESCRIPTION
On my computer, make the tests take 12s rather than 65s. Skimming through them I didn't found any dependency or shared resources in them.