### PR TITLE
expose DontHaveTimeoutConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The following emojis are used to highlight certain changes:
 
 ### Added
 
+- `bitswap/client`: Add `DontHaveTimeoutConfig` type alias and `func DontHaveTimeoutConfig()` to expose config defined in internal package.
+
 ### Changed
 
 - `provider`: Prevent multiple instances of reprovider.Reprovide() from running at the same time. [#834](https://github.com/ipfs/boxo/pull/834)

--- a/bitswap/client/client.go
+++ b/bitswap/client/client.go
@@ -40,6 +40,12 @@ import (
 
 var log = logging.Logger("bitswap/client")
 
+type DontHaveTimeoutConfig = bsmq.DontHaveTimeoutConfig
+
+func DefaultDontHaveTimeoutConfig() *DontHaveTimeoutConfig {
+	return bsmq.DefaultDontHaveTimeoutConfig()
+}
+
 // Option defines the functional option type that can be used to configure
 // bitswap instances
 type Option func(*Client)
@@ -71,7 +77,7 @@ func SetSimulateDontHavesOnTimeout(send bool) Option {
 	}
 }
 
-func WithDontHaveTimeoutConfig(cfg *bsmq.DontHaveTimeoutConfig) Option {
+func WithDontHaveTimeoutConfig(cfg *DontHaveTimeoutConfig) Option {
 	return func(bs *Client) {
 		bs.dontHaveTimeoutConfig = cfg
 	}
@@ -300,7 +306,7 @@ type Client struct {
 
 	// whether we should actually simulate dont haves on request timeout
 	simulateDontHavesOnTimeout bool
-	dontHaveTimeoutConfig      *bsmq.DontHaveTimeoutConfig
+	dontHaveTimeoutConfig      *DontHaveTimeoutConfig
 
 	// dupMetric will stay at 0
 	skipDuplicatedBlocksStats bool


### PR DESCRIPTION
This was missed in an earlier PR, and the config needs to be exposed using a type alias as the type is defined in an internal package.

- Add `DontHaveConfigConfig` type alias in bitswap client
- Add `DefaultDontHaveConfigConfig` function to get struct populated with default values.

Closes #842

