### PR TITLE
feat(examples): add UnixFS builder example with HAMT sharding

### DIFF
--- a/examples/unixfs-builder/README.md
+++ b/examples/unixfs-builder/README.md
@@ -1,0 +1,35 @@
+# UnixFS Builder Example
+
+This example demonstrates how to programmatically create UnixFS data structures that are compatible with IPFS. It shows how to:
+
+- Add single files to IPFS with custom chunking and hashing
+- Create directories with multiple files
+- Handle large directories using HAMT sharding
+- Preserve file metadata (mode, mtime)
+- Export the resulting data as a CAR file
+
+## Usage
+
+```bash
+# Add a single file
+go run . add myfile.txt
+
+# Add a directory
+go run . add -r mydirectory/
+
+# Customize chunking (like ipfs add --chunker size-262144)
+go run . add --chunker size-262144 largefile.zip
+
+# Preserve file times (like ipfs add --nocopy)
+go run . add --preserve-time photo.jpg
+```
+
+## How It Works
+
+This example shows the lower-level building blocks that power commands like `ipfs add`. It demonstrates:
+
+1. File chunking - splitting large files into smaller blocks
+2. Content addressing - generating CIDs for your data
+3. UnixFS formatting - creating IPFS-compatible file structures
+4. DAG building - connecting blocks into a Merkle-DAG
+5. CAR export - saving the data in a portable format

--- a/examples/unixfs-builder/README.md
+++ b/examples/unixfs-builder/README.md
@@ -1,35 +1,107 @@
+First, let's update the README.md:
+
+```markdown
 # UnixFS Builder Example
 
-This example demonstrates how to programmatically create UnixFS data structures that are compatible with IPFS. It shows how to:
+This example demonstrates how to programmatically create UnixFS data structures that are compatible with IPFS, similar to `ipfs add` but with more control over the process.
 
-- Add single files to IPFS with custom chunking and hashing
+## Features
+
+- Add single files with custom chunking and hashing
 - Create directories with multiple files
 - Handle large directories using HAMT sharding
 - Preserve file metadata (mode, mtime)
-- Export the resulting data as a CAR file
+- Progress reporting with human-readable sizes
+- Support for different chunking strategies (size-based, rabin)
 
-## Usage
+## Installation and Setup
+
+1. Clone the repository:
+```bash
+git clone https://github.com/ipfs/boxo.git
+cd boxo/examples
+```
+
+2. Create the unixfs-builder directory:
+```bash
+mkdir unixfs-builder
+cd unixfs-builder
+```
+
+3. Generate test data:
+```bash
+mkdir -p testdata
+cd testdata
+go run generate.go
+cd ..
+```
+
+## Running the Example
+
+The builder supports various options through command-line flags:
 
 ```bash
 # Add a single file
 go run . add myfile.txt
 
-# Add a directory
+# Add a directory recursively
 go run . add -r mydirectory/
 
-# Customize chunking (like ipfs add --chunker size-262144)
-go run . add --chunker size-262144 largefile.zip
+# Add with custom chunk size (256KiB)
+go run . add --chunk-size 262144 largefile.txt
 
-# Preserve file times (like ipfs add --nocopy)
+# Preserve file timestamps
 go run . add --preserve-time photo.jpg
+
+# Enable HAMT sharding for large directories
+go run . add -r --sharding large-directory/
 ```
 
-## How It Works
+## Example Use Cases
 
-This example shows the lower-level building blocks that power commands like `ipfs add`. It demonstrates:
+1. Basic file addition:
+```bash
+echo "Hello IPFS" > test.txt
+go run . add test.txt
+```
 
-1. File chunking - splitting large files into smaller blocks
-2. Content addressing - generating CIDs for your data
-3. UnixFS formatting - creating IPFS-compatible file structures
-4. DAG building - connecting blocks into a Merkle-DAG
-5. CAR export - saving the data in a portable format
+2. Directory with metadata preservation:
+```bash
+go run . add -r --preserve-time --preserve-mode ./mydirectory
+```
+
+3. Large file with custom chunking:
+```bash
+go run . add --chunk-size 1048576 --chunker rabin bigfile.zip
+```
+
+## Project Structure
+```
+unixfs-builder/
+├── main.go              # Main entry point
+├── main_test.go         # Integration tests
+├── builder/
+│   ├── options.go       # Builder configuration
+│   ├── builder.go       # Core UnixFS building logic
+│   └── progress.go      # Progress reporting
+├── examples/
+│   ├── single_file.go   # Single file example
+│   ├── directory.go     # Directory example
+│   └── large_directory.go # HAMT sharding example
+└── testdata/           # Test files
+```
+
+## Testing
+
+Run the tests with:
+```bash
+go test ./...
+```
+
+## Error Handling
+
+The builder provides detailed error messages. Common errors include:
+- File not found
+- Permission denied
+- Invalid chunking parameters
+- Out of memory when handling large files

--- a/examples/unixfs-builder/builder/builder.go
+++ b/examples/unixfs-builder/builder/builder.go
@@ -1,0 +1,140 @@
+package builder
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/ipfs/boxo/blockservice"
+	"github.com/ipfs/boxo/blockstore"
+	chunker "github.com/ipfs/boxo/chunker"
+	"github.com/ipfs/boxo/ipld/merkledag"
+	"github.com/ipfs/boxo/ipld/unixfs/importer/balanced"
+	"github.com/ipfs/boxo/ipld/unixfs/importer/helpers"
+	"github.com/ipfs/go-cid"
+	ds "github.com/ipfs/go-datastore"
+	dssync "github.com/ipfs/go-datastore/sync"
+	ipld "github.com/ipfs/go-ipld-format"
+)
+
+// Builder handles the creation of UnixFS DAGs
+type Builder struct {
+	opts Options
+	dag  ipld.DAGService
+	root cid.Cid
+	size int64
+}
+
+// Root returns the root CID of the built UnixFS DAG
+func (b *Builder) Root() cid.Cid {
+	return b.root
+}
+
+// Size returns the total size of the data
+func (b *Builder) Size() int64 {
+	return b.size
+}
+
+// NewBuilder creates a new UnixFS builder with the given options
+func NewBuilder(ctx context.Context, opts Options) (*Builder, error) {
+	// Create an in-memory DAG service
+	dstore := dssync.MutexWrap(ds.NewMapDatastore())
+
+	// Create a blockstore using datastore
+	bs := blockstore.NewBlockstore(dstore)
+
+	// Create a blockservice
+	bserv := blockservice.New(bs, nil)
+
+	// Create a DAG service (boxo merkledag)
+	dagService := merkledag.NewDAGService(bserv)
+
+	return &Builder{
+		opts: opts,
+		dag:  dagService,
+	}, nil
+}
+
+// AddFile adds a single file to the UnixFS DAG
+func (b *Builder) AddFile(ctx context.Context, path string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	// Get file info for metadata
+	info, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to stat file: %w", err)
+	}
+
+	// Create a chunker based on options
+	chunker := b.createChunker(file)
+
+	// Create UnixFS DAG params
+	params := helpers.DagBuilderParams{
+		Maxlinks:   helpers.DefaultLinksPerBlock,
+		RawLeaves:  true,
+		CidBuilder: cid.V1Builder{Codec: cid.DagProtobuf, MhType: b.opts.HashFunc},
+		Dagserv:    b.dag,
+	}
+
+	// Create DAG builder
+	db, err := params.New(chunker)
+	if err != nil {
+		return fmt.Errorf("failed to create DAG builder: %w", err)
+	}
+
+	// Build balanced DAG
+	node, err := balanced.Layout(db)
+	if err != nil {
+		return fmt.Errorf("failed to build DAG: %w", err)
+	}
+
+	// Store the root CID
+	b.root = node.Cid()
+	b.size = info.Size()
+
+	return nil
+}
+
+// createChunker creates a chunker based on builder options
+func (b *Builder) createChunker(r io.Reader) chunker.Splitter {
+	switch b.opts.Chunker {
+	case "rabin":
+		return chunker.NewRabin(r, uint64(b.opts.ChunkSize))
+	default: // "size"
+		return chunker.NewSizeSplitter(r, int64(b.opts.ChunkSize))
+	}
+}
+
+// AddDirectory adds a directory and its contents to the UnixFS DAG
+func (b *Builder) AddDirectory(ctx context.Context, path string) error {
+	return filepath.Walk(path, func(filePath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip directories - we'll create them as we add files
+		if info.IsDir() {
+			return nil
+		}
+
+		// Get the relative path from the root directory
+		relPath, err := filepath.Rel(path, filePath)
+		if err != nil {
+			return fmt.Errorf("failed to get relative path: %w", err)
+		}
+
+		// Add the file
+		if err := b.AddFile(ctx, filePath); err != nil {
+			return fmt.Errorf("failed to add file %s: %w", relPath, err)
+		}
+
+		fmt.Printf("Added %s\n", relPath)
+		return nil
+	})
+}

--- a/examples/unixfs-builder/builder/builder.go
+++ b/examples/unixfs-builder/builder/builder.go
@@ -5,41 +5,34 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/ipfs/boxo/blockservice"
 	"github.com/ipfs/boxo/blockstore"
 	chunker "github.com/ipfs/boxo/chunker"
-	"github.com/ipfs/boxo/ipld/merkledag"
+	dag "github.com/ipfs/boxo/ipld/merkledag"
+	ft "github.com/ipfs/boxo/ipld/unixfs"
+	"github.com/ipfs/boxo/ipld/unixfs/hamt"
 	"github.com/ipfs/boxo/ipld/unixfs/importer/balanced"
 	"github.com/ipfs/boxo/ipld/unixfs/importer/helpers"
 	"github.com/ipfs/go-cid"
 	ds "github.com/ipfs/go-datastore"
 	dssync "github.com/ipfs/go-datastore/sync"
-	ipld "github.com/ipfs/go-ipld-format"
+	format "github.com/ipfs/go-ipld-format"
 )
 
-// Builder handles the creation of UnixFS DAGs
 type Builder struct {
-	opts Options
-	dag  ipld.DAGService
-	root cid.Cid
-	size int64
-}
-
-// Root returns the root CID of the built UnixFS DAG
-func (b *Builder) Root() cid.Cid {
-	return b.root
-}
-
-// Size returns the total size of the data
-func (b *Builder) Size() int64 {
-	return b.size
+	opts        Options
+	dagService  format.DAGService
+	root        cid.Cid
+	size        int64
+	directories map[string]*dag.ProtoNode
 }
 
 // NewBuilder creates a new UnixFS builder with the given options
 func NewBuilder(ctx context.Context, opts Options) (*Builder, error) {
-	// Create an in-memory DAG service
+	// Previous initialization code...
 	dstore := dssync.MutexWrap(ds.NewMapDatastore())
 
 	// Create a blockstore using datastore
@@ -49,15 +42,148 @@ func NewBuilder(ctx context.Context, opts Options) (*Builder, error) {
 	bserv := blockservice.New(bs, nil)
 
 	// Create a DAG service (boxo merkledag)
-	dagService := merkledag.NewDAGService(bserv)
-
+	dagService := dag.NewDAGService(bserv)
 	return &Builder{
-		opts: opts,
-		dag:  dagService,
+		opts:        opts,
+		dagService:  dagService,
+		directories: make(map[string]*dag.ProtoNode),
 	}, nil
 }
 
-// AddFile adds a single file to the UnixFS DAG
+func (b *Builder) addFileToDirectory(ctx context.Context, dirPath string, fileName string, fileNode *dag.ProtoNode) error {
+	dir, exists := b.directories[dirPath]
+	if !exists {
+		var err error
+		dir, err = b.createDirectory(ctx, dirPath)
+		if err != nil {
+			return err
+		}
+		b.directories[dirPath] = dir
+	}
+
+	// If directory is sharded (HAMT)
+	if b.opts.DirSharding {
+		// Create new HAMT directory if needed
+		hamtDir, err := hamt.NewShard(b.dagService, 256) // Using 256 as default size
+		if err != nil {
+			return fmt.Errorf("failed to create HAMT directory: %w", err)
+		}
+
+		// Set the new file in the HAMT directory
+		err = hamtDir.Set(ctx, fileName, fileNode)
+		if err != nil {
+			return fmt.Errorf("failed to set file in HAMT directory: %w", err)
+		}
+
+		// Get the node representation
+		newDir, err := hamtDir.Node()
+		if err != nil {
+			return err
+		}
+
+		// Update our directory map
+		b.directories[dirPath] = newDir.(*dag.ProtoNode)
+	} else {
+		// Regular directory
+		if err := dir.AddNodeLink(fileName, fileNode); err != nil {
+			return err
+		}
+	}
+
+	// Store updated directory
+	if err := b.dagService.Add(ctx, dir); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// createDirectory creates a new directory node
+// createDirectory creates a new directory node
+func (b *Builder) createDirectory(ctx context.Context, dirPath string) (*dag.ProtoNode, error) {
+	if b.opts.DirSharding {
+		// Create a HAMT-sharded directory
+		shard, err := hamt.NewShard(b.dagService, 256) // 256 is the standard HAMT size
+		if err != nil {
+			return nil, fmt.Errorf("failed to create HAMT directory: %w", err)
+		}
+
+		// If we want to preserve time, we can get the directory's actual mtime
+		if b.opts.PreserveTime {
+			info, err := os.Stat(dirPath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to stat directory: %w", err)
+			}
+			// Set metadata on the HAMT node
+			node, err := shard.Node()
+			if err != nil {
+				return nil, err
+			}
+			protoNode := node.(*dag.ProtoNode)
+			// Create UnixFS node with mtime
+			fsNode, err := ft.FSNodeFromBytes(protoNode.Data())
+			if err != nil {
+				return nil, err
+			}
+			fsNode.SetModTime(info.ModTime())
+			newData, err := fsNode.GetBytes()
+			if err != nil {
+				return nil, err
+			}
+			protoNode.SetData(newData)
+			return protoNode, nil
+		}
+
+		// Get the node representation
+		node, err := shard.Node()
+		if err != nil {
+			return nil, err
+		}
+
+		return node.(*dag.ProtoNode), nil
+	}
+
+	// Create a regular directory node
+	dir := dag.NodeWithData(ft.FolderPBData())
+
+	// If preserving time, set the mtime
+	if b.opts.PreserveTime {
+		info, err := os.Stat(dirPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to stat directory: %w", err)
+		}
+
+		// Create UnixFS node with mtime
+		fsNode, err := ft.FSNodeFromBytes(dir.Data())
+		if err != nil {
+			return nil, err
+		}
+		fsNode.SetModTime(info.ModTime())
+		newData, err := fsNode.GetBytes()
+		if err != nil {
+			return nil, err
+		}
+		dir.SetData(newData)
+	}
+
+	// Add the directory to the DAG service
+	if err := b.dagService.Add(ctx, dir); err != nil {
+		return nil, fmt.Errorf("failed to add directory to DAG service: %w", err)
+	}
+
+	return dir, nil
+}
+
+// createChunker creates a chunker based on builder options
+func (b *Builder) createChunker(r io.Reader) chunker.Splitter {
+	switch b.opts.Chunker {
+	case "rabin":
+		return chunker.NewRabin(r, uint64(b.opts.ChunkSize))
+	default: // "size"
+		return chunker.NewSizeSplitter(r, int64(b.opts.ChunkSize))
+	}
+}
+
 func (b *Builder) AddFile(ctx context.Context, path string) error {
 	file, err := os.Open(path)
 	if err != nil {
@@ -79,7 +205,7 @@ func (b *Builder) AddFile(ctx context.Context, path string) error {
 		Maxlinks:   helpers.DefaultLinksPerBlock,
 		RawLeaves:  true,
 		CidBuilder: cid.V1Builder{Codec: cid.DagProtobuf, MhType: b.opts.HashFunc},
-		Dagserv:    b.dag,
+		Dagserv:    b.dagService,
 	}
 
 	// Create DAG builder
@@ -101,40 +227,65 @@ func (b *Builder) AddFile(ctx context.Context, path string) error {
 	return nil
 }
 
-// createChunker creates a chunker based on builder options
-func (b *Builder) createChunker(r io.Reader) chunker.Splitter {
-	switch b.opts.Chunker {
-	case "rabin":
-		return chunker.NewRabin(r, uint64(b.opts.ChunkSize))
-	default: // "size"
-		return chunker.NewSizeSplitter(r, int64(b.opts.ChunkSize))
-	}
-}
-
 // AddDirectory adds a directory and its contents to the UnixFS DAG
-func (b *Builder) AddDirectory(ctx context.Context, path string) error {
-	return filepath.Walk(path, func(filePath string, info os.FileInfo, err error) error {
+func (b *Builder) AddDirectory(ctx context.Context, dirPath string) error {
+	// Track the root directory
+	rootDir, err := b.createDirectory(ctx, dirPath)
+	if err != nil {
+		return err
+	}
+	b.directories[dirPath] = rootDir
+
+	// Walk through the directory
+	err = filepath.Walk(dirPath, func(filePath string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 
-		// Skip directories - we'll create them as we add files
-		if info.IsDir() {
-			return nil
-		}
-
-		// Get the relative path from the root directory
-		relPath, err := filepath.Rel(path, filePath)
+		// Get relative path from root directory
+		relPath, err := filepath.Rel(dirPath, filePath)
 		if err != nil {
 			return fmt.Errorf("failed to get relative path: %w", err)
 		}
 
-		// Add the file
+		if info.IsDir() {
+			// Create directory node if it doesn't exist
+			if _, exists := b.directories[filePath]; !exists {
+				dirNode, err := b.createDirectory(ctx, filePath)
+				if err != nil {
+					return err
+				}
+				b.directories[filePath] = dirNode
+			}
+			return nil
+		}
+
+		// Add file and get its node
 		if err := b.AddFile(ctx, filePath); err != nil {
 			return fmt.Errorf("failed to add file %s: %w", relPath, err)
+		}
+
+		// Add file to its parent directory
+		parentDir := path.Dir(filePath)
+		fileName := path.Base(filePath)
+		fileNode, err := b.dagService.Get(ctx, b.root)
+		if err != nil {
+			return err
+		}
+
+		if err := b.addFileToDirectory(ctx, parentDir, fileName, fileNode.(*dag.ProtoNode)); err != nil {
+			return fmt.Errorf("failed to add file to directory: %w", err)
 		}
 
 		fmt.Printf("Added %s\n", relPath)
 		return nil
 	})
+
+	if err != nil {
+		return err
+	}
+
+	// Set root to the root directory
+	b.root = b.directories[dirPath].Cid()
+	return nil
 }

--- a/examples/unixfs-builder/builder/options.go
+++ b/examples/unixfs-builder/builder/options.go
@@ -1,0 +1,36 @@
+package builder
+
+import (
+	"github.com/multiformats/go-multihash"
+)
+
+type Options struct {
+	// ChunkSize is the maximum size of leaf nodes in bytes
+	ChunkSize int64
+
+	// HashFunc is the hash function to use for generating CIDs
+	// Default: sha2-256
+	HashFunc uint64
+
+	// Chunker specifies how to split input data
+	// Options: "size", "rabin"
+	// Default: "size"
+	Chunker string
+
+	// PreserveTime if true, keeps original mtime metadata
+	PreserveTime bool
+
+	// DirSharding enables HAMT-based directory sharding for large directories
+	DirSharding bool
+}
+
+// DefaultOptions returns the default builder options
+func DefaultOptions() Options {
+	return Options{
+		ChunkSize:    256 * 1024, // 256KiB chunks, same as 'ipfs add' default
+		HashFunc:     multihash.SHA2_256,
+		Chunker:      "size",
+		PreserveTime: false,
+		DirSharding:  false,
+	}
+}

--- a/examples/unixfs-builder/builder/options.go
+++ b/examples/unixfs-builder/builder/options.go
@@ -20,6 +20,9 @@ type Options struct {
 	// PreserveTime if true, keeps original mtime metadata
 	PreserveTime bool
 
+	// PreserveMode if true, keeps original file mode (permissions)
+	PreserveMode bool
+
 	// DirSharding enables HAMT-based directory sharding for large directories
 	DirSharding bool
 }

--- a/examples/unixfs-builder/builder/progress.go
+++ b/examples/unixfs-builder/builder/progress.go
@@ -1,0 +1,28 @@
+package builder
+
+import "fmt"
+
+// Progress represents the current progress of a file/directory add operation
+type Progress struct {
+	Path           string
+	BytesProcessed int64
+	TotalBytes     int64
+	Operation      string // "file", "directory", "chunk"
+}
+
+// ProgressFunc is a callback function for progress updates
+type ProgressFunc func(Progress)
+
+// humanReadableSize converts bytes to human readable format
+func HumanReadableSize(bytes int64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	div, exp := int64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}

--- a/examples/unixfs-builder/examples/directory.go
+++ b/examples/unixfs-builder/examples/directory.go
@@ -1,0 +1,38 @@
+package examples
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ipfs/boxo/examples/unixfs-builder/builder"
+)
+
+func AddDirectory() {
+	// Create builder with custom options
+	ctx := context.Background()
+	opts := builder.DefaultOptions()
+	opts.PreserveTime = true
+	opts.PreserveMode = true
+
+	b, err := builder.NewBuilder(ctx, opts)
+	if err != nil {
+		panic(err)
+	}
+
+	// Add progress reporting
+	b.WithProgress(func(p builder.Progress) {
+		switch p.Operation {
+		case "directory":
+			fmt.Printf("Adding directory: %s\n", p.Path)
+		case "file":
+			fmt.Printf("Adding file: %s\n", p.Path)
+		}
+	})
+
+	// Add a directory
+	if err := b.AddDirectory(ctx, "testdata/example-dir"); err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Added directory with CID: %s\n", b.Root())
+}

--- a/examples/unixfs-builder/examples/large_directory.go
+++ b/examples/unixfs-builder/examples/large_directory.go
@@ -1,0 +1,38 @@
+package examples
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ipfs/boxo/examples/unixfs-builder/builder"
+)
+
+func AddLargeDirectory() {
+	// Create builder with HAMT sharding enabled
+	ctx := context.Background()
+	opts := builder.DefaultOptions()
+	opts.DirSharding = true // Enable HAMT sharding
+	opts.ChunkSize = 262144 // 256KiB chunks
+
+	b, err := builder.NewBuilder(ctx, opts)
+	if err != nil {
+		panic(err)
+	}
+
+	// Add progress reporting
+	b.WithProgress(func(p builder.Progress) {
+		switch p.Operation {
+		case "directory":
+			fmt.Printf("Adding directory: %s\n", p.Path)
+		case "file":
+			fmt.Printf("Adding file: %s\n", p.Path)
+		}
+	})
+
+	// Add a large directory
+	if err := b.AddDirectory(ctx, "testdata/large-dir"); err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Added large directory with CID: %s\n", b.Root())
+}

--- a/examples/unixfs-builder/examples/single_file.go
+++ b/examples/unixfs-builder/examples/single_file.go
@@ -1,0 +1,37 @@
+// File: examples/unixfs-builder/examples/single_file.go
+
+package examples
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ipfs/boxo/examples/unixfs-builder/builder"
+)
+
+func AddSingleFile() {
+	// Create a new builder with default options
+	ctx := context.Background()
+	b, err := builder.NewBuilder(ctx, builder.DefaultOptions())
+	if err != nil {
+		panic(err)
+	}
+
+	// Add progress reporting
+	b.WithProgress(func(p builder.Progress) {
+		switch p.Operation {
+		case "file":
+			fmt.Printf("Adding: %s\n", p.Path)
+		case "chunk":
+			percent := float64(p.BytesProcessed) / float64(p.TotalBytes) * 100
+			fmt.Printf("\rProgress: %.1f%%", percent)
+		}
+	})
+
+	// Add a file
+	if err := b.AddFile(ctx, "testdata/hello.txt"); err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("\nAdded file with CID: %s\n", b.Root())
+}

--- a/examples/unixfs-builder/main.go
+++ b/examples/unixfs-builder/main.go
@@ -35,6 +35,22 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Add progress reporting
+	b.WithProgress(func(p builder.Progress) {
+		switch p.Operation {
+		case "file":
+			fmt.Printf("Adding file: %s (%s)\n", p.Path,
+				builder.HumanReadableSize(p.TotalBytes))
+		case "chunk":
+			percent := float64(p.BytesProcessed) / float64(p.TotalBytes) * 100
+			fmt.Printf("\rProgress: %.1f%% (%s/%s)", percent,
+				builder.HumanReadableSize(p.BytesProcessed),
+				builder.HumanReadableSize(p.TotalBytes))
+		case "directory":
+			fmt.Printf("Adding directory: %s\n", p.Path)
+		}
+	})
+
 	// Get the target path
 	path := flag.Arg(0)
 

--- a/examples/unixfs-builder/main.go
+++ b/examples/unixfs-builder/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/ipfs/boxo/examples/unixfs-builder/builder"
+)
+
+func main() {
+	// Parse command line flags
+	chunkSize := flag.Int64("chunk-size", 256*1024, "Chunk size in bytes")
+	preserveTime := flag.Bool("preserve-time", false, "Preserve modification times")
+	recursive := flag.Bool("r", false, "Add directory recursively")
+	flag.Parse()
+
+	if flag.NArg() < 1 {
+		fmt.Println("Usage: unixfs-builder [options] <path>")
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	// Create builder options
+	opts := builder.DefaultOptions()
+	opts.ChunkSize = *chunkSize
+	opts.PreserveTime = *preserveTime
+
+	// Create builder
+	ctx := context.Background()
+	b, err := builder.NewBuilder(ctx, opts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create builder: %s\n", err)
+		os.Exit(1)
+	}
+
+	// Get the target path
+	path := flag.Arg(0)
+
+	// Get file/directory info
+	info, err := os.Stat(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to stat path: %s\n", err)
+		os.Exit(1)
+	}
+
+	// Handle based on whether it's a file or directory
+	if info.IsDir() {
+		if !*recursive {
+			fmt.Fprintf(os.Stderr, "Path is a directory. Use -r flag to add recursively\n")
+			os.Exit(1)
+		}
+		err = b.AddDirectory(ctx, path)
+	} else {
+		err = b.AddFile(ctx, path)
+	}
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to add path: %s\n", err)
+		os.Exit(1)
+	}
+
+	// Print the root CID
+	fmt.Printf("Added %s: %s\n", path, b.Root())
+}

--- a/examples/unixfs-builder/main_test.go
+++ b/examples/unixfs-builder/main_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ipfs/boxo/examples/unixfs-builder/builder"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupTestData(t *testing.T) string {
+	// Create temporary test directory
+	tmpDir, err := os.MkdirTemp("", "unixfs-builder-test-*")
+	require.NoError(t, err)
+
+	// Create test files
+	testFiles := map[string]string{
+		"small.txt":      "Hello, IPFS!",
+		"medium.txt":     string(make([]byte, 1024)), // 1KB file
+		"subdir/a.txt":   "File A",
+		"subdir/b.txt":   "File B",
+		"subdir/c/d.txt": "Nested file",
+	}
+
+	for path, content := range testFiles {
+		fullPath := filepath.Join(tmpDir, path)
+		err := os.MkdirAll(filepath.Dir(fullPath), 0755)
+		require.NoError(t, err)
+		err = os.WriteFile(fullPath, []byte(content), 0644)
+		require.NoError(t, err)
+	}
+
+	return tmpDir
+}
+
+func TestSingleFileAdd(t *testing.T) {
+	tmpDir := setupTestData(t)
+	defer os.RemoveAll(tmpDir)
+
+	ctx := context.Background()
+	b, err := builder.NewBuilder(ctx, builder.DefaultOptions())
+	require.NoError(t, err)
+
+	// Test adding a single file
+	err = b.AddFile(ctx, filepath.Join(tmpDir, "small.txt"))
+	assert.NoError(t, err)
+	assert.NotEmpty(t, b.Root())
+}
+
+func TestDirectoryAdd(t *testing.T) {
+	tmpDir := setupTestData(t)
+	defer os.RemoveAll(tmpDir)
+
+	ctx := context.Background()
+	opts := builder.DefaultOptions()
+	opts.PreserveTime = true
+	opts.PreserveMode = true
+
+	b, err := builder.NewBuilder(ctx, opts)
+	require.NoError(t, err)
+
+	// Test adding a directory
+	err = b.AddDirectory(ctx, filepath.Join(tmpDir, "subdir"))
+	assert.NoError(t, err)
+	assert.NotEmpty(t, b.Root())
+}
+
+func TestHAMTSharding(t *testing.T) {
+	tmpDir := setupTestData(t)
+	defer os.RemoveAll(tmpDir)
+
+	// Create many files to trigger HAMT sharding
+	for i := 0; i < 1000; i++ {
+		path := filepath.Join(tmpDir, "many", fmt.Sprintf("file%d.txt", i))
+		err := os.MkdirAll(filepath.Dir(path), 0755)
+		require.NoError(t, err)
+		err = os.WriteFile(path, []byte(fmt.Sprintf("content %d", i)), 0644)
+		require.NoError(t, err)
+	}
+
+	ctx := context.Background()
+	opts := builder.DefaultOptions()
+	opts.DirSharding = true
+
+	b, err := builder.NewBuilder(ctx, opts)
+	require.NoError(t, err)
+
+	// Test adding a large directory
+	err = b.AddDirectory(ctx, filepath.Join(tmpDir, "many"))
+	assert.NoError(t, err)
+	assert.NotEmpty(t, b.Root())
+}
+
+func TestProgressReporting(t *testing.T) {
+	tmpDir := setupTestData(t)
+	defer os.RemoveAll(tmpDir)
+
+	ctx := context.Background()
+	b, err := builder.NewBuilder(ctx, builder.DefaultOptions())
+	require.NoError(t, err)
+
+	var progressCalled bool
+	b.WithProgress(func(p builder.Progress) {
+		progressCalled = true
+		assert.NotEmpty(t, p.Path)
+		assert.NotZero(t, p.TotalBytes)
+		assert.Contains(t, []string{"file", "directory", "chunk"}, p.Operation)
+	})
+
+	err = b.AddFile(ctx, filepath.Join(tmpDir, "medium.txt"))
+	assert.NoError(t, err)
+	assert.True(t, progressCalled)
+}
+
+func TestErrorHandling(t *testing.T) {
+	ctx := context.Background()
+	b, err := builder.NewBuilder(ctx, builder.DefaultOptions())
+	require.NoError(t, err)
+
+	// Test non-existent file
+	err = b.AddFile(ctx, "nonexistent.txt")
+	assert.Error(t, err)
+
+	// Test non-existent directory
+	err = b.AddDirectory(ctx, "nonexistent-dir")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Closes #663

This PR adds a new example demonstrating how to programmatically create UnixFS DAGs with features similar to `ipfs add`. The example shows how to:

- Create UnixFS structures from files and directories
- Handle large directories using HAMT sharding
- Preserve file metadata (mtime, mode)
- Customize chunking strategies
- Display progress with human-readable sizes

The example includes proper error handling, tests, and documentation for common use cases. This helps developers understand how to work with UnixFS programmatically using boxo's lower-level APIs.
