### PR TITLE
feat(gateway): introduce typed errors for blocked content

### DIFF
--- a/gateway/backend_car.go
+++ b/gateway/backend_car.go
@@ -1125,6 +1125,12 @@ func isRetryableError(err error) (bool, error) {
 // blockstoreErrToGatewayErr translates underlying blockstore error into one that gateway code will return as HTTP 502 or 504
 // it also makes sure Retry-After hint from remote blockstore will be passed to HTTP client, if present.
 func blockstoreErrToGatewayErr(err error) error {
+	// Check for blocked content error first
+	var blocked *ErrorContentBlocked
+	if errors.As(err, &blocked) {
+		return err
+	}
+
 	if errors.Is(err, &ErrorStatusCode{}) ||
 		errors.Is(err, &ErrorRetryAfter{}) {
 		// already correct error


### PR DESCRIPTION
<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
Previously, blocked content detection relied on string matching which is fragile and implementation-specific. This PR:

- Adds `ErrorContentBlocked` type to properly handle blocked content errors
- Allows configurable HTTP status codes (410 Gone or 451 Unavailable For Legal Reasons) 
- Makes error handling consistent across implementations (nopfs, Infura etc.)
- Eliminates string matching in favor of proper error type checking

Related: closes #591 
