### PR TITLE
chore(ipns): lower `DefaultRecordTTL` to 5m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The following emojis are used to highlight certain changes:
 
 ### Changed
 
+- `ipns`: The `DefaultRecordTTL` changed from `1h` to `5m` [#859](https://github.com/ipfs/boxo/pull/859)
+
 ### Removed
 
 ### Fixed

--- a/ipns/defaults.go
+++ b/ipns/defaults.go
@@ -13,5 +13,5 @@ const (
 	// cache before checking for update again. The function of this TTL is
 	// similar to TTL of DNS record, and the default here is a trade-off
 	// between faster updates and benefiting from various types of caching.
-	DefaultRecordTTL = 1 * time.Hour
+	DefaultRecordTTL = 5 * time.Minute
 )


### PR DESCRIPTION
See rationale in https://github.com/ipfs/kubo/issues/10718
Spec update: https://github.com/ipfs/specs/pull/492
