### PR TITLE
refactor: use a more straightforward return value

### DIFF
--- a/gateway/handler_car.go
+++ b/gateway/handler_car.go
@@ -239,7 +239,7 @@ func getCarRootCidAndLastSegment(imPath path.ImmutablePath) (cid.Cid, string, er
 		lastSegment = lastSegment[i+1:]
 	}
 
-	return rootCid, lastSegment, err
+	return rootCid, lastSegment, nil
 }
 
 func getCarEtag(imPath path.ImmutablePath, params CarParams, rootCid cid.Cid) string {


### PR DESCRIPTION
<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->

The logic of err not being nil has been processed and returned before, so err must be nil here.
