### PR TITLE
feat(bitswap/client): MinTimeout for DontHaveTimeoutConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The following emojis are used to highlight certain changes:
 
 ## [Unreleased]
 
+- feat(bitswap/client): MinTimeout for DontHaveTimeoutConfig [#865](https://github.com/ipfs/boxo/pull/865)
 - ✨ `httpnet`: Transparent HTTP-block retrieval support over Trustless Gateways [#747]((https://github.com/ipfs/boxo/pull/747):
   - Complements Bitswap as a block-retrieval mechanism, implementing `bitswap/network`.
   - Understands peers found in provider records with `/.../http` endpoints (trustless gateway).

--- a/bitswap/client/internal/messagequeue/donthavetimeoutmgr.go
+++ b/bitswap/client/internal/messagequeue/donthavetimeoutmgr.go
@@ -25,7 +25,8 @@ type DontHaveTimeoutConfig struct {
 
 	// MaxTimeout is the maximum allowed timeout, regardless of latency
 	MaxTimeout time.Duration
-
+	// MinTimeout is the minimum allowed timeout, regardless of latency
+	MinTimeout time.Duration
 	// PingLatencyMultiplier is multiplied by the average ping time to
 	// get an upper bound on how long we expect to wait for a peer's response
 	// to arrive
@@ -363,6 +364,8 @@ func (dhtm *dontHaveTimeoutMgr) calculateTimeoutFromPingLatency(latency time.Dur
 	timeout := dhtm.config.MaxExpectedWantProcessTime + time.Duration(dhtm.config.PingLatencyMultiplier)*latency
 	if timeout > dhtm.config.MaxTimeout {
 		timeout = dhtm.config.MaxTimeout
+	} else if timeout < dhtm.config.MinTimeout {
+		timeout = dhtm.config.MinTimeout
 	}
 	return timeout
 }
@@ -372,6 +375,8 @@ func (dhtm *dontHaveTimeoutMgr) calculateTimeoutFromMessageLatency() time.Durati
 	timeout := dhtm.messageLatency.latency * time.Duration(dhtm.config.MessageLatencyMultiplier)
 	if timeout > dhtm.config.MaxTimeout {
 		timeout = dhtm.config.MaxTimeout
+	} else if timeout < dhtm.config.MinTimeout {
+		timeout = dhtm.config.MinTimeout
 	}
 	return timeout
 }


### PR DESCRIPTION
In low latency environments, the latency estimation becomes very sensitive to sudden spikes in serving time for a Block.
It may happen that Block serving takes more than expected for a ordinary reason, yet triggering don't have timeout to fire a new often duplicate request. The min timeout configuration allows us to set the baseline timeout, beyond which a new request should be fired, substantially minimizing amount of duplicates.