### PR TITLE
fix(provider): call reprovider throughput callback only if reprovide is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The following emojis are used to highlight certain changes:
 
 ### Changed
 
-- `provider` don't call the reprovide throughput callback function when reprovides are disabled [#871](https://github.com/ipfs/boxo/pull/871) 
+- fix(`provider`): don't reprovide if `reprovideInterval` is set to 0 [#871](https://github.com/ipfs/boxo/pull/871) 
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The following emojis are used to highlight certain changes:
 
 ### Changed
 
+- `provider` don't call the reprovide throughput callback function when reprovides are disabled [#871](https://github.com/ipfs/boxo/pull/871) 
+
 ### Removed
 
 ### Fixed

--- a/provider/reprovider.go
+++ b/provider/reprovider.go
@@ -383,7 +383,7 @@ func (s *reprovider) run() {
 
 			s.throughputDurationSum += dur
 			s.throughputProvideCurrentCount += uint(len(keys))
-			if s.throughputCallback != nil && s.throughputProvideCurrentCount >= s.throughputMinimumProvides {
+			if s.throughputCallback != nil && s.reprovideInterval > 0 && s.throughputProvideCurrentCount >= s.throughputMinimumProvides {
 				if more := s.throughputCallback(performedReprovide, complete, s.throughputProvideCurrentCount, s.throughputDurationSum); !more {
 					s.throughputCallback = nil
 				}


### PR DESCRIPTION
Addresses https://github.com/ipfs/kubo/issues/10714

`shouldReprovide` doesn't test whether the `reprovideInterval` is `0`, and instructs to reprovide even when it shouldn't.