### PR TITLE
Update README.md

### DIFF
--- a/examples/gateway/car-file/README.md
+++ b/examples/gateway/car-file/README.md
@@ -2,7 +2,7 @@
 
 This is an example that shows how to build a Gateway backed by the contents of
 a CAR file. A [CAR file](https://ipld.io/specs/transport/car/) is a Content
-Addressable aRchive that contains blocks.
+Addressable Archive that contains blocks.
 
 The `main.go` sets up a `blockService` backed by a static CAR file,
 and then uses it to initialize `gateway.NewBlocksBackend(blockService)`.
@@ -16,7 +16,7 @@ and then uses it to initialize `gateway.NewBlocksBackend(blockService)`.
 ## Usage
 
 First of all, you will need some content stored as a CAR file. You can easily
-export your favorite website, or content, using:
+export your favorite website or content, using:
 
 ```
 ipfs dag export <CID> > data.car


### PR DESCRIPTION
Hello,

Noticed two typos here and suggest changes.

First: "a Content Addressable aRchive" should be "a Content Addressable Archive". "aRchive" seems to be a typo with mixed case letters.

Second: "export your favorite website, or content" could be "export your favorite website or content", as the comma after "website" is unnecessary.

Thanks.

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
