### PR TITLE
bitswap/httpnet: do not follow redirects

### DIFF
--- a/bitswap/network/httpnet/httpnet.go
+++ b/bitswap/network/httpnet/httpnet.go
@@ -267,6 +267,12 @@ func New(host host.Host, opts ...Option) network.BitSwapNetwork {
 
 	c := &http.Client{
 		Transport: t,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			// we do not follow redirects. Providers should keep
+			// announcements up to
+			// date. https://github.com/boxo/issues/862.
+			return http.ErrUseLastResponse
+		},
 	}
 	htnet.client = c
 

--- a/bitswap/network/httpnet/msg_sender.go
+++ b/bitswap/network/httpnet/msg_sender.go
@@ -247,6 +247,7 @@ func (sender *httpMsgSender) tryURL(ctx context.Context, u *senderURL, entry bsm
 
 		return nil, serr
 	}
+	defer resp.Body.Close()
 
 	// Record request size
 	var buf bytes.Buffer

--- a/bitswap/network/httpnet/msg_sender.go
+++ b/bitswap/network/httpnet/msg_sender.go
@@ -302,7 +302,12 @@ func (sender *httpMsgSender) tryURL(ctx context.Context, u *senderURL, entry bsm
 	case http.StatusNotFound,
 		http.StatusGone,
 		http.StatusForbidden,
-		http.StatusUnavailableForLegalReasons:
+		http.StatusUnavailableForLegalReasons,
+		http.StatusMovedPermanently,
+		http.StatusFound,
+		http.StatusSeeOther,
+		http.StatusTemporaryRedirect,
+		http.StatusPermanentRedirect:
 
 		err := fmt.Errorf("%s %q -> %d: %q", req.Method, req.URL, statusCode, string(body))
 		log.Debug(err)


### PR DESCRIPTION
Avoid following redirects. We treat them as an incorrect provider record.  We don't want to be coerced into opening new connections to new hosts and we prefer provider records to be up to date rather than them relying in redirects being followed. There are also problems with potential loops etc.

https://github.com/ipfs/boxo/issues/862

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
