### PR TITLE
Refactor(hostname): Skip DNSLink for local IP addresses to avoid DNS queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,7 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
-- `gateway`: Skip DNSLink lookup for local IP addresses to avoid unnecessary DNS queries
-
+- `gateway`: Skip DNSLink lookup for IP addresses to avoid unnecessary DNS queries [#880](https://github.com/ipfs/boxo/pull/880)
 - `bitswap/client`: Fix unintentional ignoring `DontHaveTimeoutConfig` [#872](https://github.com/ipfs/boxo/pull/872)
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
+- `gateway`: Skip DNSLink lookup for local IP addresses to avoid unnecessary DNS queries
+
 - `bitswap/client`: Fix unintentional ignoring `DontHaveTimeoutConfig` [#872](https://github.com/ipfs/boxo/pull/872)
 
 ### Security

--- a/gateway/hostname.go
+++ b/gateway/hostname.go
@@ -254,37 +254,12 @@ func isDomainNameAndNotPeerID(hostname string) bool {
 	return ok
 }
 
-// isLocalIPAddress returns true if the host is a local IP address (e.g., 127.0.0.1, ::1)
-func isLocalIPAddress(host string) bool {
-	// Strip port if present
-	host = stripPort(host)
-	
-	// Check for IPv4 localhost
-	if host == "127.0.0.1" {
-		return true
-	}
-	
-	// Check for IPv6 localhost
-	if host == "::1" || host == "0:0:0:0:0:0:0:1" {
-		return true
-	}
-	
-	// Parse as IP address
-	ip := net.ParseIP(host)
-	if ip == nil {
-		return false
-	}
-	
-	// Check if it's a loopback address
-	return ip.IsLoopback()
-}
-
 // hasDNSLinkRecord returns if a DNS TXT record exists for the provided host.
 func hasDNSLinkRecord(ctx context.Context, backend IPFSBackend, host string) bool {
 	dnslinkName := stripPort(host)
-	
-	// Skip DNSLink lookup for local IP addresses
-	if isLocalIPAddress(dnslinkName) {
+
+	// Skip DNSLink lookup for IP addresses
+	if net.ParseIP(dnslinkName) != nil {
 		return false
 	}
 

--- a/gateway/hostname_test.go
+++ b/gateway/hostname_test.go
@@ -370,26 +370,6 @@ func BenchmarkInlineDNSLink(b *testing.B) {
 	}
 }
 
-// Test function for isLocalIPAddress
-func TestIsLocalIPAddress(t *testing.T) {
-	t.Parallel()
-	for _, test := range []struct {
-		host string
-		out  bool
-	}{
-		{"127.0.0.1", true},       // IPv4 loopback address
-		{"::1", true},             // IPv6 loopback address, short form
-		{"0:0:0:0:0:0:0:1", true}, // IPv6 loopback address, full form
-		{"127.0.0.1:8080", true},  // IPv4 loopback address with port
-		{"[::1]:8080", true},      // IPv6 loopback address with port
-	} {
-		t.Run(test.host, func(t *testing.T) {
-			out := isLocalIPAddress(test.host)
-			require.Equal(t, test.out, out)
-		})
-	}
-}
-
 // Test function for hasDNSLinkRecord with local IP addresses
 func TestHasDNSLinkRecordWithLocalIP(t *testing.T) {
 	t.Parallel()
@@ -405,10 +385,12 @@ func TestHasDNSLinkRecordWithLocalIP(t *testing.T) {
 	// Test local IP addresses
 	localIPs := []string{
 		"127.0.0.1",
-		"127.0.0.1:8080",
+		"8.8.8.8",
+		"192.168.100.22:8080",
 		"::1",
 		"[::1]:8080",
 		"0:0:0:0:0:0:0:1",
+		"fe80::a89c:baff:fece:8c94",
 	}
 
 	for _, ip := range localIPs {


### PR DESCRIPTION
This PR refactors the hostname handling logic to skip DNSLink lookups for IP addresses.

The hasDNSLinkRecord function now explicitly checks if the provided hostname is an IP address. If it is an IP address, the function immediately returns false, skipping the DNSLink lookup.

This change avoids unnecessary DNS queries when the hostname is an IP address. This improves efficiency and reduces potential delays, especially in local development environments where DNS lookups for IPs are not needed and can sometimes cause issues.

 Closes #879 
