### PR TITLE
feat(gateway): implement request concurrency limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The following emojis are used to highlight certain changes:
 
 ### Added
 
+- `gateway`: Implemented a configurable limit for concurrent in-flight HTTP requests. Returns HTTP 503 Service Unavailable with Retry-After header when the limit is reached. Includes a default limit to protect against traffic spikes when exposed without a reverse proxy. [#881](https://github.com/ipfs/boxo/issues/881)
+
 ### Changed
 
 ### Removed

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -48,6 +48,11 @@ type Config struct {
 	// directory listings, DAG previews and errors. These will be displayed to the
 	// right of "About IPFS" and "Install IPFS".
 	Menu []assets.MenuItem
+
+	// MaxRequestsInFlight limits the number of concurrent requests the gateway will process.
+	// When this limit is reached, new requests will receive a 503 Service Unavailable response
+	// with a Retry-After header. If set to 0 or a negative value, a default of 1024 will be used.
+	MaxRequestsInFlight int
 }
 
 // PublicGateway is the specification of an IPFS Public Gateway.

--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -68,7 +68,9 @@ type handler struct {
 //
 // [IPFS HTTP Gateway]: https://specs.ipfs.tech/http-gateways/
 func NewHandler(c Config, backend IPFSBackend) http.Handler {
-	return newHandlerWithMetrics(&c, backend)
+	handler := newHandlerWithMetrics(&c, backend)
+	// Wrap the handler with a request limiter
+	return newRequestLimiter(handler, c.MaxRequestsInFlight)
 }
 
 // serveContent replies to the request using the content in the provided Reader

--- a/gateway/inflight_limiter.go
+++ b/gateway/inflight_limiter.go
@@ -1,0 +1,51 @@
+package gateway
+
+import (
+	"net/http"
+	"sync/atomic"
+)
+
+// requestLimiter is a wrapper around http.Handler that limits the number of concurrent requests.
+type requestLimiter struct {
+	handler      http.Handler
+	maxInFlight  int32
+	currentCount int32
+}
+
+// defaultMaxRequestsInFlight is the default value for MaxRequestsInFlight if not specified or invalid.
+const defaultMaxRequestsInFlight = 1024
+
+// newRequestLimiter creates a new request limiter that wraps the given handler.
+func newRequestLimiter(handler http.Handler, maxRequestsInFlight int) http.Handler {
+	// Use default if the provided value is invalid
+	max := maxRequestsInFlight
+	if max <= 0 {
+		max = defaultMaxRequestsInFlight
+	}
+
+	return &requestLimiter{
+		handler:     handler,
+		maxInFlight: int32(max),
+	}
+}
+
+// ServeHTTP implements the http.Handler interface.
+func (l *requestLimiter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Try to increment the counter
+	current := atomic.AddInt32(&l.currentCount, 1)
+
+	// Check if we've exceeded the limit
+	if current > l.maxInFlight {
+		// Decrement the counter since we're rejecting this request
+		atomic.AddInt32(&l.currentCount, -1)
+
+		// Return 503 Service Unavailable with a Retry-After header
+		w.Header().Set("Retry-After", "5") // 5 seconds is a reasonable default
+		http.Error(w, "Too many requests in flight", http.StatusServiceUnavailable)
+		return
+	}
+
+	// Process the request and ensure we decrement the counter when done
+	defer atomic.AddInt32(&l.currentCount, -1)
+	l.handler.ServeHTTP(w, r)
+}

--- a/gateway/inflight_limiter_test.go
+++ b/gateway/inflight_limiter_test.go
@@ -1,0 +1,103 @@
+package gateway
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+)
+
+// TestRequestLimiter tests that the request limiter correctly limits the number of concurrent requests.
+func TestRequestLimiter(t *testing.T) {
+	// Create a simple handler that just returns 200 OK
+	baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Create a request limiter with a max of 2 concurrent requests
+	limiter := newRequestLimiter(baseHandler, 2)
+
+	// Test that we can make 2 concurrent requests
+	wg := sync.WaitGroup{}
+	blockCh := make(chan struct{})
+	// Add a channel to signal when requests are being processed
+	inFlightCh := make(chan struct{}, 2)
+
+	// Create a handler that signals when it's processing a request
+	blockingHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Signal that we're processing a request
+		inFlightCh <- struct{}{}
+		// Wait for the signal to complete
+		<-blockCh
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Create a limiter with our blocking handler
+	limiter = newRequestLimiter(blockingHandler, 2)
+
+	// Start 2 requests that will block until we close blockCh
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			// Create a test request
+			req := httptest.NewRequest("GET", "http://example.com/", nil)
+			rec := httptest.NewRecorder()
+
+			// Call the limiter directly (no need for another goroutine)
+			limiter.ServeHTTP(rec, req)
+		}()
+	}
+
+	// Wait for both requests to be in flight
+	for i := 0; i < 2; i++ {
+		<-inFlightCh
+	}
+
+	// Try to make a third request, which should be rejected
+	req := httptest.NewRequest("GET", "http://example.com/", nil)
+	rec := httptest.NewRecorder()
+	limiter.ServeHTTP(rec, req)
+
+	// Check that the third request was rejected with 503
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("Expected status code %d, got %d", http.StatusServiceUnavailable, rec.Code)
+	}
+
+	// Check that the Retry-After header was set
+	if rec.Header().Get("Retry-After") == "" {
+		t.Error("Expected Retry-After header to be set")
+	}
+
+	// Unblock the first two requests
+	close(blockCh)
+
+	// Wait for the first two requests to complete
+	wg.Wait()
+}
+
+// TestRequestLimiterDefault tests that the request limiter uses the default max requests value
+// when an invalid value is provided.
+func TestRequestLimiterDefault(t *testing.T) {
+	// Create a simple handler
+	baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Create a request limiter with an invalid max (should use default)
+	limiter := newRequestLimiter(baseHandler, -1).(*requestLimiter)
+
+	// Check that the max in flight is set to the default
+	if limiter.maxInFlight != defaultMaxRequestsInFlight {
+		t.Errorf("Expected max in flight to be %d, got %d", defaultMaxRequestsInFlight, limiter.maxInFlight)
+	}
+
+	// Create a request limiter with a valid max
+	limiter = newRequestLimiter(baseHandler, 100).(*requestLimiter)
+
+	// Check that the max in flight is set to the provided value
+	if limiter.maxInFlight != 100 {
+		t.Errorf("Expected max in flight to be %d, got %d", 100, limiter.maxInFlight)
+	}
+}


### PR DESCRIPTION
This commit introduces a mechanism to limit the number of concurrent in-flight HTTP requests to the gateway.

- Implements a configurable limit for concurrent requests.
- Returns HTTP 503 Service Unavailable with Retry-After header when the limit is reached.
- Includes a default limit to protect against traffic spikes when exposed without a reverse proxy.

This change enhances gateway's resilience and prevents overload by limiting concurrent requests.

#881 
