### PR TITLE
Improve performance of data onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The following emojis are used to highlight certain changes:
 
 - upgrade to `go-libp2p` [v0.41.1](https://github.com/libp2p/go-libp2p/releases/tag/v0.41.1)
 - `bitswap/network`: Add a new `requests_in_flight` metric gauge that measures how many bitswap streams are being written or read at a given time.
+- improve speed of data onboarding by batching/bufering provider queue writes [#888](https://github.com/ipfs/boxo/pull/888)
 
 ### Removed
 

--- a/provider/internal/queue/queue.go
+++ b/provider/internal/queue/queue.go
@@ -37,7 +37,6 @@ const (
 type Queue struct {
 	// used to differentiate queues in datastore
 	// e.g. provider vs reprovider
-	ctx       context.Context
 	ds        datastore.Datastore // Must be threadsafe
 	dequeue   chan cid.Cid
 	enqueue   *chanqueue.ChanQueue[cid.Cid] // in-memory queue to buffer input

--- a/provider/internal/queue/queue.go
+++ b/provider/internal/queue/queue.go
@@ -21,10 +21,11 @@ const (
 	batchSize           = 16384
 	batchCommitInterval = 5 * time.Second
 
-	// Number of input CIDs to buffer without blocking.
+	// Number of input CIDs to buffer without blocking. This capacity is only
+	// used when writing batches to the datastore takes some time.
 	inputBufferSize = 1024 * 64
 	// Time for Close to wait to finish writing CIDs to datastore.
-	shutdownTimeout = 30 * time.Second
+	shutdownTimeout = 20 * time.Second
 )
 
 // Queue provides a FIFO interface to the datastore for storing cids.
@@ -33,21 +34,17 @@ const (
 // in the queue when the node is brought back online depending on whether they
 // were fully written to the underlying datastore.
 //
-// Input to the queue is buffered in memory, up to inputBufferSize, to increase
-// the speed of data onboarding. This input buffer behaves as a channel with a
-// very large capacity.
+// Input to the queue is buffered in memory, up to inputBufferSize, to maintain
+// the speed at which input is consumed, even if persisting it to the datastore
+// becomes slow. This input buffer behaves as a channel with a dynamic
+// capacity.
 type Queue struct {
-	// used to differentiate queues in datastore
-	// e.g. provider vs reprovider
-	ds        datastore.Batching
-	dequeue   chan cid.Cid
-	inBuf     *chanqueue.ChanQueue[cid.Cid] // in-memory queue to buffer input
 	close     context.CancelFunc
 	closed    chan struct{}
 	closeOnce sync.Once
-
-	syncDone  chan struct{}
-	syncMutex sync.Mutex
+	dequeue   chan cid.Cid
+	ds        datastore.Batching
+	inBuf     *chanqueue.ChanQueue[cid.Cid]
 }
 
 // NewQueue creates a queue for cids
@@ -55,24 +52,16 @@ func NewQueue(ds datastore.Batching) *Queue {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	q := &Queue{
-		close:    cancel,
-		closed:   make(chan struct{}),
-		ds:       namespace.Wrap(ds, datastore.NewKey("/queue")),
-		dequeue:  make(chan cid.Cid),
-		inBuf:    chanqueue.New(chanqueue.WithCapacity[cid.Cid](inputBufferSize)),
-		syncDone: make(chan struct{}, 1),
+		close:   cancel,
+		closed:  make(chan struct{}),
+		dequeue: make(chan cid.Cid),
+		ds:      namespace.Wrap(ds, datastore.NewKey("/queue")),
+		inBuf:   chanqueue.New(chanqueue.WithCapacity[cid.Cid](inputBufferSize)),
 	}
 
 	go q.worker(ctx)
 
 	return q
-}
-
-func (q *Queue) Sync() {
-	q.syncMutex.Lock()
-	q.inBuf.In() <- cid.Undef
-	<-q.syncDone
-	q.syncMutex.Unlock()
 }
 
 // Close stops the queue
@@ -131,7 +120,6 @@ func (q *Queue) worker(ctx context.Context) {
 				log.Errorf("Failed to write cid batch: %s", err)
 			}
 		}
-		close(q.syncDone)
 	}()
 
 	refreshBatch := func(ctx context.Context) error {
@@ -153,6 +141,7 @@ func (q *Queue) worker(ctx context.Context) {
 	var (
 		counter    uint64
 		c, lastCid cid.Cid
+		commit     bool
 		cstr       string
 		k          datastore.Key = datastore.Key{}
 	)
@@ -180,26 +169,31 @@ func (q *Queue) worker(ctx context.Context) {
 					}
 					continue
 				}
-			} // else queue is empty
+			} else if batchCount != 0 {
+				// There were no queued CIDs in the datastore, but there were
+				// some waiting to be written. Write them and re-read from
+				// datastore.
+				if err = refreshBatch(ctx); err != nil {
+					if !errors.Is(err, context.Canceled) {
+						log.Errorf("%w, stopping provider", err)
+					}
+					return
+				}
+				continue
+			}
 			cstr = c.String()
 		}
 
-		// If c != cid.Undef set dequeue and attempt write, otherwise wait for enqueue
+		// If c != cid.Undef set dequeue and attempt write.
 		var dequeue chan cid.Cid
 		if c != cid.Undef {
 			dequeue = q.dequeue
 		}
-		var commit, needSync bool
 
 		select {
 		case toQueue, ok := <-readInBuf:
 			if !ok {
 				return
-			}
-			if toQueue == cid.Undef {
-				commit = true
-				needSync = true
-				break
 			}
 			if toQueue == lastCid {
 				continue
@@ -229,7 +223,9 @@ func (q *Queue) worker(ctx context.Context) {
 		case <-batchTicker.C:
 			commit = q.inBuf.Len() == 0
 		case dequeue <- c:
-			// CID may still be in uncommitted batch, so commit current batch first.
+			// Commit current batch first so that if CID being read is still in
+			// the uncommitted batch, that CID is written and deleted from the
+			// datastore.
 			if batchCount != 0 {
 				if err = refreshBatch(ctx); err != nil {
 					if !errors.Is(err, context.Canceled) {
@@ -239,7 +235,8 @@ func (q *Queue) worker(ctx context.Context) {
 				}
 			}
 
-			// Do not batch delete. Delete must be committed immediately, otherwise the same head cid will be read from the datastore.
+			// Do not batch delete. Delete must be committed immediately,
+			// otherwise the same head cid will be read from the datastore.
 			if err = q.ds.Delete(ctx, k); err != nil {
 				log.Errorf("Failed to delete queued cid %s with key %s: %s", c, k, err)
 				continue
@@ -257,15 +254,6 @@ func (q *Queue) worker(ctx context.Context) {
 					log.Errorf("%w, stopping provider", err)
 				}
 				return
-			}
-
-			if needSync {
-				needSync = false
-				select {
-				case q.syncDone <- struct{}{}:
-				case <-ctx.Done():
-					return
-				}
 			}
 		}
 	}

--- a/provider/internal/queue/queue.go
+++ b/provider/internal/queue/queue.go
@@ -47,8 +47,8 @@ type Queue struct {
 	inBuf     *chanqueue.ChanQueue[cid.Cid]
 }
 
-// NewQueue creates a queue for cids
-func NewQueue(ds datastore.Batching) *Queue {
+// New creates a queue for cids.
+func New(ds datastore.Batching) *Queue {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	q := &Queue{
@@ -64,7 +64,7 @@ func NewQueue(ds datastore.Batching) *Queue {
 	return q
 }
 
-// Close stops the queue
+// Close stops the queue.
 func (q *Queue) Close() error {
 	var err error
 	q.closeOnce.Do(func() {
@@ -86,7 +86,7 @@ func (q *Queue) Close() error {
 	return err
 }
 
-// Enqueue puts a cid in the queue
+// Enqueue puts a cid in the queue.
 func (q *Queue) Enqueue(cid cid.Cid) (err error) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/provider/internal/queue/queue.go
+++ b/provider/internal/queue/queue.go
@@ -90,13 +90,16 @@ func (q *Queue) Close() error {
 }
 
 // Enqueue puts a cid in the queue.
-func (q *Queue) Enqueue(cid cid.Cid) (err error) {
+func (q *Queue) Enqueue(c cid.Cid) (err error) {
+	if c == cid.Undef {
+		return
+	}
 	defer func() {
 		if r := recover(); r != nil {
 			err = errors.New("failed to enqueue CID: shutting down")
 		}
 	}()
-	q.enqueue <- cid
+	q.enqueue <- c
 	return
 }
 
@@ -107,7 +110,10 @@ func (q *Queue) Dequeue() <-chan cid.Cid {
 
 func makeCidString(c cid.Cid) string {
 	data := c.Bytes()
-	return base64.RawURLEncoding.EncodeToString(data[len(data)-6:])
+	if len(data) > 4 {
+		data = data[len(data)-4:]
+	}
+	return base64.RawURLEncoding.EncodeToString(data)
 }
 
 func makeKey(c cid.Cid, counter uint64) datastore.Key {

--- a/provider/internal/queue/queue.go
+++ b/provider/internal/queue/queue.go
@@ -51,7 +51,6 @@ func NewQueue(ds datastore.Datastore) *Queue {
 	q := &Queue{
 		ds:      namespace.Wrap(ds, datastore.NewKey("/queue")),
 		dequeue: make(chan cid.Cid),
-		//enqueue: make(chan cid.Cid, 1024),
 		enqueue: chanqueue.New(chanqueue.WithCapacity[cid.Cid](inputBufferSize)),
 		close:   cancel,
 		closed:  make(chan struct{}),

--- a/provider/internal/queue/queue.go
+++ b/provider/internal/queue/queue.go
@@ -79,7 +79,7 @@ func (q *Queue) Close() error {
 		case <-time.After(shutdownTimeout):
 			q.close() // force immediate shutdown
 			<-q.closed
-			err = errors.New("provider queue: some cids not written to datastore")
+			err = fmt.Errorf("provider queue: %d cids not written to datastore", q.inBuf.Len())
 		}
 		close(q.dequeue) // no more output from this queue
 	})

--- a/provider/internal/queue/queue.go
+++ b/provider/internal/queue/queue.go
@@ -18,12 +18,12 @@ import (
 var log = logging.Logger("provider.queue")
 
 const (
-	batchSize           = 16384
+	batchSize           = 16 * 1024
 	batchCommitInterval = 5 * time.Second
 
 	// Number of input CIDs to buffer without blocking. This capacity is only
 	// used when writing batches to the datastore takes some time.
-	inputBufferSize = 1024 * 64
+	inputBufferSize = 64 * 1024
 	// Time for Close to wait to finish writing CIDs to datastore.
 	shutdownTimeout = 20 * time.Second
 )

--- a/provider/internal/queue/queue.go
+++ b/provider/internal/queue/queue.go
@@ -118,13 +118,13 @@ func (q *Queue) Dequeue() <-chan cid.Cid {
 func (q *Queue) worker(ctx context.Context) {
 	defer close(q.closed)
 
-	var k datastore.Key = datastore.Key{}
-	var c cid.Cid = cid.Undef
-	var cstr string
-	var counter uint64
-
-	var readInBuf <-chan cid.Cid
-	readInBuf = q.inBuf.Out()
+	var (
+		c       cid.Cid = cid.Undef
+		counter uint64
+		cstr    string
+		k       datastore.Key = datastore.Key{}
+	)
+	readInBuf := q.inBuf.Out()
 
 	for {
 		if c == cid.Undef {

--- a/provider/internal/queue/queue.go
+++ b/provider/internal/queue/queue.go
@@ -2,10 +2,13 @@ package queue
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
+	"github.com/gammazero/chanqueue"
 	cid "github.com/ipfs/go-cid"
 	datastore "github.com/ipfs/go-datastore"
 	namespace "github.com/ipfs/go-datastore/namespace"
@@ -15,96 +18,111 @@ import (
 
 var log = logging.Logger("provider.queue")
 
-// Queue provides a best-effort durability, FIFO interface to the datastore for storing cids
+const (
+	// Number of input CIDs to buffer without blocking.
+	inputBufferSize = 65536
+	// Time for Close to wait to finish writing CIDs to datastore.
+	shutdownTimeout = 5 * time.Second
+)
+
+// Queue provides a FIFO interface to the datastore for storing cids.
 //
-// Best-effort durability just means that cids in the process of being provided when a
-// crash or shutdown occurs may be in the queue when the node is brought back online
-// depending on whether the underlying datastore has synchronous or asynchronous writes.
+// Cids in the process of being provided when a crash or shutdown occurs may be
+// in the queue when the node is brought back online depending on whether they
+// were fully written to the underlying datastore.
+//
+// Input to the queue is buffered in memory, up to inputBufferSize, to increase
+// the speed of data onboarding. This input buffer behaves as a channel with a
+// very large capacity.
 type Queue struct {
 	// used to differentiate queues in datastore
 	// e.g. provider vs reprovider
-	ctx     context.Context
-	ds      datastore.Datastore // Must be threadsafe
-	dequeue chan cid.Cid
-	enqueue chan cid.Cid
-	close   context.CancelFunc
-	closed  sync.WaitGroup
-
-	counter uint64
+	ctx       context.Context
+	ds        datastore.Datastore // Must be threadsafe
+	dequeue   chan cid.Cid
+	enqueue   *chanqueue.ChanQueue[cid.Cid] // in-memory queue to buffer input
+	close     context.CancelFunc
+	closed    chan struct{}
+	closeOnce sync.Once
 }
 
 // NewQueue creates a queue for cids
 func NewQueue(ds datastore.Datastore) *Queue {
-	namespaced := namespace.Wrap(ds, datastore.NewKey("/queue"))
-	cancelCtx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
 	q := &Queue{
-		ctx:     cancelCtx,
-		ds:      namespaced,
+		ds:      namespace.Wrap(ds, datastore.NewKey("/queue")),
 		dequeue: make(chan cid.Cid),
-		enqueue: make(chan cid.Cid),
+		//enqueue: make(chan cid.Cid, 1024),
+		enqueue: chanqueue.New(chanqueue.WithCapacity[cid.Cid](inputBufferSize)),
 		close:   cancel,
+		closed:  make(chan struct{}),
 	}
-	q.closed.Add(1)
-	go q.worker()
+	go q.worker(ctx)
 	return q
 }
 
 // Close stops the queue
 func (q *Queue) Close() error {
-	q.close()
-	q.closed.Wait()
-	// We don't close dequeue because the provider which consume this get caught in
-	// an infinite loop dequeing cid.Undef if we do that.
-	// The provider has it's own select on top of dequeue and will handle this by itself.
-	return nil
+	var err error
+	q.closeOnce.Do(func() {
+		// Close input queue and wait for worker to finish reading it.
+		q.enqueue.Close()
+		select {
+		case <-q.closed:
+		case <-time.After(shutdownTimeout):
+			q.close() // force immediate shutdown
+			<-q.closed
+			err = errors.New("provider queue: some cids not written to datastore")
+		}
+		close(q.dequeue) // no more output from this queue
+	})
+	return err
 }
 
 // Enqueue puts a cid in the queue
-func (q *Queue) Enqueue(cid cid.Cid) error {
-	select {
-	case q.enqueue <- cid:
-		return nil
-	case <-q.ctx.Done():
-		return errors.New("failed to enqueue CID: shutting down")
-	}
+func (q *Queue) Enqueue(cid cid.Cid) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.New("failed to enqueue CID: shutting down")
+		}
+	}()
+	q.enqueue.In() <- cid
+	return
 }
 
-// Dequeue returns a channel that if listened to will remove entries from the queue
+// Dequeue returns a channel that for reading entries from the queue,
 func (q *Queue) Dequeue() <-chan cid.Cid {
 	return q.dequeue
 }
 
 // worker run dequeues and enqueues when available.
-func (q *Queue) worker() {
+func (q *Queue) worker(ctx context.Context) {
+	defer close(q.closed)
+	defer q.enqueue.Shutdown()
+
 	var k datastore.Key = datastore.Key{}
 	var c cid.Cid = cid.Undef
-
-	defer q.closed.Done()
-	defer q.close()
+	var counter uint64
 
 	for {
 		if c == cid.Undef {
-			head, err := q.getQueueHead()
-
-			switch {
-			case err != nil:
+			head, err := q.getQueueHead(ctx)
+			if err != nil {
 				log.Errorf("error querying for head of queue: %s, stopping provider", err)
 				return
-			case head != nil:
+			}
+			if head != nil {
 				k = datastore.NewKey(head.Key)
 				c, err = cid.Parse(head.Value)
 				if err != nil {
 					log.Warnf("error parsing queue entry cid with key (%s), removing it from queue: %s", head.Key, err)
-					err = q.ds.Delete(q.ctx, k)
-					if err != nil {
+					if err = q.ds.Delete(ctx, k); err != nil {
 						log.Errorf("error deleting queue entry with key (%s), due to error (%s), stopping provider", head.Key, err)
 						return
 					}
 					continue
 				}
-			default:
-				c = cid.Undef
-			}
+			} // else queue is empty
 		}
 
 		// If c != cid.Undef set dequeue and attempt write, otherwise wait for enqueue
@@ -114,10 +132,16 @@ func (q *Queue) worker() {
 		}
 
 		select {
-		case toQueue := <-q.enqueue:
-			keyPath := fmt.Sprintf("%020d/%s", q.counter, c.String())
-			q.counter++
-			nextKey := datastore.NewKey(keyPath)
+		case toQueue, ok := <-q.enqueue.Out():
+			if !ok {
+				return
+			}
+			// Add unique suffix to key path to allow multiple entries with the
+			// same sequence.
+			toQueueBytes := toQueue.Bytes()
+			sfx := base64.RawURLEncoding.EncodeToString(toQueueBytes[len(toQueueBytes)-6:])
+			nextKey := datastore.NewKey(fmt.Sprintf("%020d/%s", counter, sfx))
+			counter++
 
 			if c == cid.Undef {
 				// fast path, skip rereading the datastore if we don't have anything in hand yet
@@ -125,26 +149,29 @@ func (q *Queue) worker() {
 				k = nextKey
 			}
 
-			if err := q.ds.Put(q.ctx, nextKey, toQueue.Bytes()); err != nil {
+			if err := q.ds.Put(ctx, nextKey, toQueueBytes); err != nil {
 				log.Errorf("Failed to enqueue cid: %s", err)
 				continue
 			}
 		case dequeue <- c:
-			err := q.ds.Delete(q.ctx, k)
+			err := q.ds.Delete(ctx, k)
 			if err != nil {
 				log.Errorf("Failed to delete queued cid %s with key %s: %s", c, k, err)
 				continue
 			}
 			c = cid.Undef
-		case <-q.ctx.Done():
+		case <-ctx.Done():
 			return
 		}
 	}
 }
 
-func (q *Queue) getQueueHead() (*query.Entry, error) {
-	qry := query.Query{Orders: []query.Order{query.OrderByKey{}}, Limit: 1}
-	results, err := q.ds.Query(q.ctx, qry)
+func (q *Queue) getQueueHead(ctx context.Context) (*query.Entry, error) {
+	qry := query.Query{
+		Orders: []query.Order{query.OrderByKey{}},
+		Limit:  1,
+	}
+	results, err := q.ds.Query(ctx, qry)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/internal/queue/queue_test.go
+++ b/provider/internal/queue/queue_test.go
@@ -5,73 +5,65 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ipfs/boxo/internal/test"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/sync"
 	"github.com/ipfs/go-test/random"
 )
 
-const blockSize = 4
-
-func makeCids(n int) []cid.Cid {
-	blks := random.BlocksOfSize(n, blockSize)
-	cids := make([]cid.Cid, n)
-	for i := 0; i < n; i++ {
-		cids[i] = blks[i].Cid()
-	}
-	return cids
-}
-
 func assertOrdered(cids []cid.Cid, q *Queue, t *testing.T) {
-	for _, c := range cids {
+	t.Helper()
+	for i, c := range cids {
 		select {
-		case dequeued := <-q.dequeue:
+		case dequeued, ok := <-q.dequeue:
+			if !ok {
+				t.Fatal("queue closed")
+			}
 			if c != dequeued {
-				t.Fatalf("Error in ordering of CIDs retrieved from queue. Expected: %s, got: %s", c, dequeued)
+				t.Fatalf("Error in ordering of CID %d retrieved from queue. Expected: %s, got: %s", i, c, dequeued)
 			}
 
-		case <-time.After(time.Second * 1):
+		case <-time.After(time.Second):
 			t.Fatal("Timeout waiting for cids to be provided.")
 		}
 	}
 }
 
 func TestBasicOperation(t *testing.T) {
-	test.Flaky(t)
-	ctx := context.Background()
-	defer ctx.Done()
-
 	ds := sync.MutexWrap(datastore.NewMapDatastore())
 	queue := NewQueue(ds)
 	defer queue.Close()
 
-	cids := makeCids(10)
-
+	cids := random.Cids(10)
 	for _, c := range cids {
+		//t.Log(c.String())
 		queue.Enqueue(c)
 	}
 
 	assertOrdered(cids, queue, t)
+
+	err := queue.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = queue.Close(); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestMangledData(t *testing.T) {
-	test.Flaky(t)
-	ctx := context.Background()
-	defer ctx.Done()
-
 	ds := sync.MutexWrap(datastore.NewMapDatastore())
 	queue := NewQueue(ds)
 	defer queue.Close()
 
-	cids := makeCids(10)
+	cids := random.Cids(10)
 	for _, c := range cids {
 		queue.Enqueue(c)
 	}
 
 	// put bad data in the queue
 	queueKey := datastore.NewKey("/test/0")
-	err := queue.ds.Put(ctx, queueKey, []byte("borked"))
+	err := queue.ds.Put(context.Background(), queueKey, []byte("borked"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,20 +74,21 @@ func TestMangledData(t *testing.T) {
 }
 
 func TestInitialization(t *testing.T) {
-	test.Flaky(t)
-	ctx := context.Background()
-	defer ctx.Done()
-
 	ds := sync.MutexWrap(datastore.NewMapDatastore())
 	queue := NewQueue(ds)
 	defer queue.Close()
 
-	cids := makeCids(10)
+	cids := random.Cids(10)
 	for _, c := range cids {
 		queue.Enqueue(c)
 	}
 
 	assertOrdered(cids[:5], queue, t)
+
+	err := queue.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// make a new queue, same data
 	queue = NewQueue(ds)
@@ -105,19 +98,19 @@ func TestInitialization(t *testing.T) {
 }
 
 func TestInitializationWithManyCids(t *testing.T) {
-	test.Flaky(t)
-	ctx := context.Background()
-	defer ctx.Done()
-
 	ds := sync.MutexWrap(datastore.NewMapDatastore())
 	queue := NewQueue(ds)
+	defer queue.Close()
 
-	cids := makeCids(25)
+	cids := random.Cids(25)
 	for _, c := range cids {
 		queue.Enqueue(c)
 	}
 
-	queue.Close()
+	err := queue.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// make a new queue, same data
 	queue = NewQueue(ds)

--- a/provider/internal/queue/queue_test.go
+++ b/provider/internal/queue/queue_test.go
@@ -14,10 +14,9 @@ import (
 func assertOrdered(cids []cid.Cid, q *Queue, t *testing.T) {
 	t.Helper()
 
-	q.Sync()
 	for i, c := range cids {
 		select {
-		case dequeued, ok := <-q.dequeue:
+		case dequeued, ok := <-q.Dequeue():
 			if !ok {
 				t.Fatal("queue closed")
 			}

--- a/provider/internal/queue/queue_test.go
+++ b/provider/internal/queue/queue_test.go
@@ -50,6 +50,26 @@ func TestBasicOperation(t *testing.T) {
 	}
 }
 
+func TestBasicOperationNoDS(t *testing.T) {
+	queue := NewQueue(nil)
+	defer queue.Close()
+
+	cids := random.Cids(10)
+	for _, c := range cids {
+		queue.Enqueue(c)
+	}
+
+	assertOrdered(cids, queue, t)
+
+	err := queue.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = queue.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestMangledData(t *testing.T) {
 	ds := sync.MutexWrap(datastore.NewMapDatastore())
 	queue := NewQueue(ds)

--- a/provider/internal/queue/queue_test.go
+++ b/provider/internal/queue/queue_test.go
@@ -32,7 +32,7 @@ func assertOrdered(cids []cid.Cid, q *Queue, t *testing.T) {
 
 func TestBasicOperation(t *testing.T) {
 	ds := sync.MutexWrap(datastore.NewMapDatastore())
-	queue := NewQueue(ds)
+	queue := New(ds)
 	defer queue.Close()
 
 	cids := random.Cids(10)
@@ -53,7 +53,7 @@ func TestBasicOperation(t *testing.T) {
 
 func TestMangledData(t *testing.T) {
 	ds := sync.MutexWrap(datastore.NewMapDatastore())
-	queue := NewQueue(ds)
+	queue := New(ds)
 	defer queue.Close()
 
 	cids := random.Cids(10)
@@ -75,7 +75,7 @@ func TestMangledData(t *testing.T) {
 
 func TestInitialization(t *testing.T) {
 	ds := sync.MutexWrap(datastore.NewMapDatastore())
-	queue := NewQueue(ds)
+	queue := New(ds)
 	defer queue.Close()
 
 	cids := random.Cids(10)
@@ -91,7 +91,7 @@ func TestInitialization(t *testing.T) {
 	}
 
 	// make a new queue, same data
-	queue = NewQueue(ds)
+	queue = New(ds)
 	defer queue.Close()
 
 	assertOrdered(cids[5:], queue, t)
@@ -99,7 +99,7 @@ func TestInitialization(t *testing.T) {
 
 func TestInitializationWithManyCids(t *testing.T) {
 	ds := sync.MutexWrap(datastore.NewMapDatastore())
-	queue := NewQueue(ds)
+	queue := New(ds)
 	defer queue.Close()
 
 	cids := random.Cids(25)
@@ -113,7 +113,7 @@ func TestInitializationWithManyCids(t *testing.T) {
 	}
 
 	// make a new queue, same data
-	queue = NewQueue(ds)
+	queue = New(ds)
 	defer queue.Close()
 
 	assertOrdered(cids, queue, t)

--- a/provider/internal/queue/queue_test.go
+++ b/provider/internal/queue/queue_test.go
@@ -36,7 +36,6 @@ func TestBasicOperation(t *testing.T) {
 
 	cids := random.Cids(10)
 	for _, c := range cids {
-		//t.Log(c.String())
 		queue.Enqueue(c)
 	}
 

--- a/provider/internal/queue/queue_test.go
+++ b/provider/internal/queue/queue_test.go
@@ -13,6 +13,8 @@ import (
 
 func assertOrdered(cids []cid.Cid, q *Queue, t *testing.T) {
 	t.Helper()
+
+	q.Sync()
 	for i, c := range cids {
 		select {
 		case dequeued, ok := <-q.dequeue:
@@ -32,26 +34,6 @@ func assertOrdered(cids []cid.Cid, q *Queue, t *testing.T) {
 func TestBasicOperation(t *testing.T) {
 	ds := sync.MutexWrap(datastore.NewMapDatastore())
 	queue := NewQueue(ds)
-	defer queue.Close()
-
-	cids := random.Cids(10)
-	for _, c := range cids {
-		queue.Enqueue(c)
-	}
-
-	assertOrdered(cids, queue, t)
-
-	err := queue.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err = queue.Close(); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestBasicOperationNoDS(t *testing.T) {
-	queue := NewQueue(nil)
 	defer queue.Close()
 
 	cids := random.Cids(10)

--- a/provider/reprovider.go
+++ b/provider/reprovider.go
@@ -57,6 +57,8 @@ type reprovider struct {
 	q  *queue.Queue
 	ds datastore.Batching
 
+	memOnlyQueue bool
+
 	reprovideCh         chan cid.Cid
 	noReprovideInFlight chan struct{}
 
@@ -138,7 +140,11 @@ func New(ds datastore.Batching, opts ...Option) (System, error) {
 	}
 
 	s.ds = namespace.Wrap(ds, s.keyPrefix)
-	s.q = queue.NewQueue(s.ds)
+	if s.memOnlyQueue {
+		s.q = queue.NewQueue(nil)
+	} else {
+		s.q = queue.NewQueue(s.ds)
+	}
 
 	// This is after the options processing so we do not have to worry about leaking a context if there is an
 	// initialization error processing the options

--- a/provider/reprovider.go
+++ b/provider/reprovider.go
@@ -138,7 +138,7 @@ func New(ds datastore.Batching, opts ...Option) (System, error) {
 	}
 
 	s.ds = namespace.Wrap(ds, s.keyPrefix)
-	s.q = queue.NewQueue(s.ds)
+	s.q = queue.New(s.ds)
 
 	// This is after the options processing so we do not have to worry about leaking a context if there is an
 	// initialization error processing the options

--- a/provider/reprovider.go
+++ b/provider/reprovider.go
@@ -429,10 +429,12 @@ func (s *reprovider) run() {
 		// after the first reprovide, schedule periodical reprovides
 		nextReprovideTicker := time.NewTicker(s.reprovideInterval)
 
-		for s.ctx.Err() == nil {
+		for {
 			err := s.Reprovide(context.Background())
-
-			if s.ctx.Err() == nil && err != nil {
+			if err != nil {
+				if s.ctx.Err() != nil {
+					return
+				}
 				log.Errorf("failed to reprovide: %s", err)
 			}
 			select {

--- a/provider/reprovider.go
+++ b/provider/reprovider.go
@@ -57,8 +57,6 @@ type reprovider struct {
 	q  *queue.Queue
 	ds datastore.Batching
 
-	memOnlyQueue bool
-
 	reprovideCh         chan cid.Cid
 	noReprovideInFlight chan struct{}
 
@@ -140,11 +138,7 @@ func New(ds datastore.Batching, opts ...Option) (System, error) {
 	}
 
 	s.ds = namespace.Wrap(ds, s.keyPrefix)
-	if s.memOnlyQueue {
-		s.q = queue.NewQueue(nil)
-	} else {
-		s.q = queue.NewQueue(s.ds)
-	}
+	s.q = queue.NewQueue(s.ds)
 
 	// This is after the options processing so we do not have to worry about leaking a context if there is an
 	// initialization error processing the options

--- a/provider/reprovider_test.go
+++ b/provider/reprovider_test.go
@@ -75,15 +75,23 @@ func TestReprovider(t *testing.T) {
 	t.Parallel()
 	t.Run("many", func(t *testing.T) {
 		t.Parallel()
-		testProvider(t, false)
+		testProvider(t, false, false)
 	})
 	t.Run("single", func(t *testing.T) {
 		t.Parallel()
-		testProvider(t, true)
+		testProvider(t, true, false)
 	})
 }
 
-func testProvider(t *testing.T, singleProvide bool) {
+func TestReproviderMemOnly(t *testing.T) {
+	t.Parallel()
+	t.Run("many", func(t *testing.T) {
+		t.Parallel()
+		testProvider(t, false, true)
+	})
+}
+
+func testProvider(t *testing.T, singleProvide, memOnlyQueue bool) {
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
 
 	// It has to be so big because the combo of noisy CI runners + OSes that don't
@@ -110,7 +118,7 @@ func testProvider(t *testing.T, singleProvide bool) {
 
 	var keyWait sync.Mutex
 	keyWait.Lock()
-	batchSystem, err := New(ds, Online(provider), KeyProvider(func(ctx context.Context) (<-chan cid.Cid, error) {
+	batchSystem, err := New(ds, Online(provider), WithMemOnlyQueue(memOnlyQueue), KeyProvider(func(ctx context.Context) (<-chan cid.Cid, error) {
 		ch := make(chan cid.Cid)
 		go func() {
 			defer keyWait.Unlock()

--- a/provider/reprovider_test.go
+++ b/provider/reprovider_test.go
@@ -75,23 +75,15 @@ func TestReprovider(t *testing.T) {
 	t.Parallel()
 	t.Run("many", func(t *testing.T) {
 		t.Parallel()
-		testProvider(t, false, false)
+		testProvider(t, false)
 	})
 	t.Run("single", func(t *testing.T) {
 		t.Parallel()
-		testProvider(t, true, false)
+		testProvider(t, true)
 	})
 }
 
-func TestReproviderMemOnly(t *testing.T) {
-	t.Parallel()
-	t.Run("many", func(t *testing.T) {
-		t.Parallel()
-		testProvider(t, false, true)
-	})
-}
-
-func testProvider(t *testing.T, singleProvide, memOnlyQueue bool) {
+func testProvider(t *testing.T, singleProvide bool) {
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
 
 	// It has to be so big because the combo of noisy CI runners + OSes that don't
@@ -118,7 +110,7 @@ func testProvider(t *testing.T, singleProvide, memOnlyQueue bool) {
 
 	var keyWait sync.Mutex
 	keyWait.Lock()
-	batchSystem, err := New(ds, Online(provider), WithMemOnlyQueue(memOnlyQueue), KeyProvider(func(ctx context.Context) (<-chan cid.Cid, error) {
+	batchSystem, err := New(ds, Online(provider), KeyProvider(func(ctx context.Context) (<-chan cid.Cid, error) {
 		ch := make(chan cid.Cid)
 		go func() {
 			defer keyWait.Unlock()


### PR DESCRIPTION
Adding a large directory of data to IPFS can take a long time. A significant amount of this time is spent writing to and reading from the persisted provider queue, depending on the underlying datastore. The time spent doing this can be greatly reduced by writing queued items to the datastore in batches. In addition to batched writes, reading queued items can be read directly from the input buffer if there are no queued items in the datastore. This allows in-memory only operation when the number of queued items is below the batch size, and when the queue is not idle for too long.

kubo PR: https://github.com/ipfs/kubo/pull/10758
part of: https://github.com/ipshipyard/roadmaps/issues/6 / https://github.com/ipshipyard/roadmaps/issues/7

## Time Comparison
Using freshly initialized kubo each time. All files in test data were 1Mib and filled with random data.

### Before PR (No Buffer)

```
> time kubo/cmd/ipfs/ipfs add -r /tmp/testfiles-100M > /dev/null
 100.00 MiB / 100.00 MiB [=====================================================================] 100.00%
real	0m6.464s

> time kubo/cmd/ipfs/ipfs add -r /tmp/testfiles-1G > /dev/null
 1000.00 MiB / 1000.00 MiB [===================================================================] 100.00%
real	1m10.542s

> time kubo/cmd/ipfs/ipfs add -r /tmp/testfiles-10G > /dev/null
 10.00 GiB / 10.00 GiB [=======================================================================] 100.00%
real	24m5.744s
```

### After PR (With Buffer)
```
> time kubo/cmd/ipfs/ipfs add -r /tmp/testfiles-100M > /dev/null
 100.00 MiB / 100.00 MiB [=====================================================================] 100.00%
real	0m0.323s

> time kubo/cmd/ipfs/ipfs add -r /tmp/testfiles-1G > /dev/null
 1.00 GiB / 1.00 GiB [=========================================================================] 100.00%
real	0m2.721s

> time kubo/cmd/ipfs/ipfs add -r /tmp/testfiles-10G > /dev/null
 10.00 GiB / 10.00 GiB [=======================================================================] 100.00%
real	0m35.042s
```

### Summary

| Data     | Before PR | After PR | 
| -------- | --------- | ----------- |
| 100M     | 6.5s    | 0.32s      | 
| 1G       | 70.5s | 2.7s      | 
| 10G      | 1446s  | 35s    | 
