### PR TITLE
ipld/unixfs/io: MaxLinks and MaxHAMTFanout for directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ The following emojis are used to highlight certain changes:
 
 ### Added
 
+- `ipld/unixfs/io/directory`: We have made some changes to unixfs directory tooling:
+  - We have exposed creator methods for new `BasicDirectory` and `HAMTDirectory`, that complement the existing `NewDirectory()` which creates dynamic directories.
+  - We have added `WithCidBuilder(...)` and `WithMaxLinks(...)` as options to these new methods so that empty directories can be initilized as wished from the get-go.
+  - `WithMaxLinks(...)` is a new option that allows to set a limit to the number of children that a directory DAG node can have. For details on what exactly it does for each of the directory types, please check the documentation.
+  - `WithStats(...)` is a new option that allows to set the Stat information for the new directory node.
+
 ### Changed
 
 - upgrade to `go-libp2p` [v0.41.1](https://github.com/libp2p/go-libp2p/releases/tag/v0.41.1)

--- a/ipld/unixfs/io/directory.go
+++ b/ipld/unixfs/io/directory.go
@@ -119,8 +119,11 @@ func WithMaxLinks(n int) DirectoryOption {
 // 8. If it is not the case, it will not be used and DefaultHAMTWidth will be
 // used instead.
 func WithMaxHAMTFanout(n int) DirectoryOption {
-	if !validShardWidth(n) {
+	if n > 0 && !validShardWidth(n) {
 		log.Warnf("Invalid HAMTMaxFanout: %d. Using default (%d)", n, DefaultShardWidth)
+		n = DefaultShardWidth
+	}
+	if n == 0 {
 		n = DefaultShardWidth
 	}
 	return func(d directoryWithOptions) {

--- a/ipld/unixfs/io/directory_test.go
+++ b/ipld/unixfs/io/directory_test.go
@@ -205,12 +205,14 @@ func mockLinkSizeFunc(fixedSize int) func(linkName string, linkCid cid.Cid) int 
 }
 
 func checkBasicDirectory(t *testing.T, dir Directory, errorMessage string) {
+	t.Helper()
 	if _, ok := dir.(*DynamicDirectory).directoryWithOptions.(*BasicDirectory); !ok {
 		t.Fatal(errorMessage)
 	}
 }
 
 func checkHAMTDirectory(t *testing.T, dir Directory, errorMessage string) {
+	t.Helper()
 	if _, ok := dir.(*DynamicDirectory).directoryWithOptions.(*HAMTDirectory); !ok {
 		t.Fatal(errorMessage)
 	}
@@ -557,7 +559,7 @@ func TestHAMTDirectoryWithMaxLinks(t *testing.T) {
 	ds := mdtest.Mock()
 	ctx := context.Background()
 
-	dir, err := NewHAMTDirectory(ds, 0, WithMaxLinks(8))
+	dir, err := NewHAMTDirectory(ds, 0, WithMaxHAMTFanout(8))
 	require.NoError(t, err)
 
 	// Ensure we have at least 2 levels of HAMT by adding many nodes
@@ -587,7 +589,7 @@ func TestDynamicDirectoryWithMaxLinks(t *testing.T) {
 	ds := mdtest.Mock()
 	ctx := context.Background()
 
-	dir := NewDirectory(ds, WithMaxLinks(8))
+	dir := NewDirectory(ds, WithMaxLinks(8), WithMaxHAMTFanout(16))
 
 	for i := 0; i < 8; i++ {
 		child := ft.EmptyDirNode()
@@ -608,7 +610,7 @@ func TestDynamicDirectoryWithMaxLinks(t *testing.T) {
 	// Check that the directory root node has 8 links
 	dirnd, err := dir.GetNode()
 	require.NoError(t, err)
-	assert.Equal(t, 8, len(dirnd.Links()), "HAMT Directory root node should have 8 links")
+	assert.Equal(t, 16, len(dirnd.Links()), "HAMT Directory root node should have 16 links")
 
 	// Continue the code by removing 50 elements while checking that the underlying directory is a HAMT directory.
 	for i := 57; i >= 9; i-- {

--- a/ipld/unixfs/io/directory_test.go
+++ b/ipld/unixfs/io/directory_test.go
@@ -625,6 +625,34 @@ func TestDynamicDirectoryWithMaxLinks(t *testing.T) {
 	}
 }
 
+// add a test that tests that validShardWidth(n) only returns true with positive numbers that are powers of 8 and multiples of 8.
+func TestValidShardWidth(t *testing.T) {
+	testCases := []struct {
+		width  int
+		expect bool
+	}{
+		{0, false},
+		{-1, false},
+		{1, false},
+		{2, false},
+		{4, false},
+		{8, true},
+		{16, true},
+		{32, true},
+		{64, true},
+		{512, true},
+		{1024, true},
+		{4096, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("Width%d", tc.width), func(t *testing.T) {
+			result := validShardWidth(tc.width)
+			assert.Equal(t, tc.expect, result, "Expected %v for width %d", tc.expect, tc.width)
+		})
+	}
+}
+
 // countGetsDS is a DAG service that keeps track of the number of
 // unique CIDs fetched.
 type countGetsDS struct {


### PR DESCRIPTION
This PR paves the way to support controlling and limiting the max number of links a directory can have by supporting option-based limitations on the unixfs directory implementation.

The result is that we can set a maximum number of links in Dynamic folders that will trigger conversion to HAMT, which has in turn it's own Fanout option.

This PR has a follow up at #906 .