### PR TITLE
gateway: validate against subdomains with IP addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The following emojis are used to highlight certain changes:
 
 - `gateway`: query parameters are now supported and preserved in redirects triggered by a [`_redirects`](https://specs.ipfs.tech/http-gateways/web-redirects-file/) file [#886](https://github.com/ipfs/boxo/pull/886)
 - `provider`: adjusted first reprovide timing after node reboot [#890](https://github.com/ipfs/boxo/pull/890)
-- `gateway`: validate against subdomains with IP addresses [#903](https://github.com/ipfs/boxo/pull/903)
+- `gateway`: validate configuration and warn when `UseSubdomains=true` is used with IP-based hostnames [#903](https://github.com/ipfs/boxo/pull/903)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The following emojis are used to highlight certain changes:
 
 - `gateway`: query parameters are now supported and preserved in redirects triggered by a [`_redirects`](https://specs.ipfs.tech/http-gateways/web-redirects-file/) file [#886](https://github.com/ipfs/boxo/pull/886)
 - `provider`: adjusted first reprovide timing after node reboot [#890](https://github.com/ipfs/boxo/pull/890)
+- `gateway`: validate against subdomains with IP addresses [#903](https://github.com/ipfs/boxo/pull/903)
 
 ### Security
 
@@ -75,7 +76,6 @@ The following emojis are used to highlight certain changes:
 ### Added
 
 - `bitswap/client`: Add `DontHaveTimeoutConfig` type alias and `func DontHaveTimeoutConfig()` to expose config defined in internal package.
-
 ### Changed
 
 - move `ipld/unixfs` from gogo protobuf [#841](https://github.com/ipfs/boxo/pull/841)

--- a/gateway/hostname.go
+++ b/gateway/hostname.go
@@ -554,6 +554,14 @@ func prepareHostnameGateways(gateways map[string]*PublicGateway) *hostnameGatewa
 	}
 
 	for hostname, gw := range gateways {
+		// Validate that UseSubdomains is not enabled for IP addresses
+		if gw.UseSubdomains {
+			hostWithoutPort := stripPort(hostname)
+			if net.ParseIP(hostWithoutPort) != nil {
+				log.Warn("invalid gateway configuration: UseSubdomains cannot be enabled for IP address %s", hostname)
+				continue
+			}
+		}
 		if strings.Contains(hostname, "*") {
 			// from *.domain.tld, construct a regexp that match any direct subdomain
 			// of .domain.tld.

--- a/gateway/hostname_test.go
+++ b/gateway/hostname_test.go
@@ -407,3 +407,84 @@ func TestHasDNSLinkRecordWithLocalIP(t *testing.T) {
 		require.True(t, result, "example.com should have a valid DNSLink record")
 	})
 }
+
+func TestValidateSubdomainsForIP(t *testing.T) {
+	t.Parallel()
+
+	// Test cases
+	tests := []struct {
+		name          string
+		hostname      string
+		useSubdomains bool
+		shouldSkip    bool
+	}{
+		{
+			name:          "IP with subdomains enabled",
+			hostname:      "127.0.0.1:8080",
+			useSubdomains: true,
+			shouldSkip:    true,
+		},
+		{
+			name:          "IPv6 with subdomains enabled",
+			hostname:      "[::1]:8080",
+			useSubdomains: true,
+			shouldSkip:    true,
+		},
+		{
+			name:          "IP without port with subdomains enabled",
+			hostname:      "192.168.1.1",
+			useSubdomains: true,
+			shouldSkip:    true,
+		},
+		{
+			name:          "Domain with subdomains enabled",
+			hostname:      "example.com:8080",
+			useSubdomains: true,
+			shouldSkip:    false,
+		},
+		{
+			name:          "IP with subdomains disabled",
+			hostname:      "10.0.0.1:8080",
+			useSubdomains: false,
+			shouldSkip:    false,
+		},
+		{
+			name:          "IPv6 without port with subdomains enabled",
+			hostname:      "::1",
+			useSubdomains: true,
+			shouldSkip:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test gateway config
+			gw := &PublicGateway{
+				UseSubdomains: tt.useSubdomains,
+			}
+
+			// Prepare gateways map
+			gateways := make(map[string]*PublicGateway)
+			gateways[tt.hostname] = gw
+
+			// Run the validation
+			validatedGateways := prepareHostnameGateways(gateways)
+
+			// Check if gateway was skipped by looking in both exact and wildcard maps
+			_, existsExact := validatedGateways.exact[tt.hostname]
+			existsWildcard := false
+			for re := range validatedGateways.wildcard {
+				if re.MatchString(tt.hostname) {
+					existsWildcard = true
+					break
+				}
+			}
+			exists := existsExact || existsWildcard
+			if tt.shouldSkip {
+				assert.False(t, exists, "Gateway with UseSubdomains=true should be skipped for IP address")
+			} else {
+				assert.True(t, exists, "Gateway should not be skipped")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Prevent invalid configurations where UseSubdomains=true is set with IP addresses.

Changes:
- Added validation in prepareHostnameGateways() to check for IP addresses when UseSubdomains is enabled
- Invalid configurations are skipped with a warning log

Closes #902 