### PR TITLE
bitswap: add requestsInFlight metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The following emojis are used to highlight certain changes:
 ### Changed
 
 - upgrade to `go-libp2p` [v0.41.1](https://github.com/libp2p/go-libp2p/releases/tag/v0.41.1)
+- `bitswap/network`: Add a new `requests_in_flight` metric gauge that measures how many bitswap streams are being written or read at a given time.
 
 ### Removed
 

--- a/bitswap/network/bsnet/metrics.go
+++ b/bitswap/network/bsnet/metrics.go
@@ -10,6 +10,10 @@ var durationHistogramBuckets = []float64{0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 
 
 var blockSizesHistogramBuckets = []float64{1, 128 << 10, 256 << 10, 512 << 10, 1024 << 10, 2048 << 10, 4092 << 10}
 
+func requestsInFlight(ctx context.Context) imetrics.Gauge {
+	return imetrics.NewCtx(ctx, "requests_in_flight", "Current number of in-flight requests").Gauge()
+}
+
 func responseSizes(ctx context.Context) imetrics.Histogram {
 	return imetrics.NewCtx(ctx, "response_bytes", "Histogram of bitswap response sizes").Histogram(blockSizesHistogramBuckets)
 }
@@ -27,6 +31,7 @@ func wantlistsSeconds(ctx context.Context) imetrics.Histogram {
 }
 
 type metrics struct {
+	RequestsInFlight    imetrics.Gauge
 	WantlistsTotal      imetrics.Counter
 	WantlistsItemsTotal imetrics.Counter
 	WantlistsSeconds    imetrics.Histogram
@@ -37,6 +42,7 @@ func newMetrics() *metrics {
 	ctx := imetrics.CtxScope(context.Background(), "exchange_bitswap")
 
 	return &metrics{
+		RequestsInFlight:    requestsInFlight(ctx),
 		WantlistsTotal:      wantlistsTotal(ctx),
 		WantlistsItemsTotal: wantlistsItemsTotal(ctx),
 		WantlistsSeconds:    wantlistsSeconds(ctx),


### PR DESCRIPTION
This metric mimics requestsInFlight in httpnet.

It should tell how many streams are being written or read at a given time, just like in HTTP we measure how many requests are ongoing at a given time.

The main insight is knowing with how many "workers" (or how much concurrency) bitswap is using for writing/reading wantlists to/from other hosts. It should roughly match the following, if both things have the same performance:

bitswapRequestsInFlight = elementsInWantlist * httpRequestsInFlight

However, since httpRequestsInFlight is limited by the number of http workers, it may signal that the number of workers is too low to compete with bitswap and that it should increase to make better use of available concurrent stream capacities.

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->

cc https://github.com/ipshipyard/roadmaps/issues/17