### PR TITLE
provider: deduplicate cids in queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The following emojis are used to highlight certain changes:
 - upgrade to `go-libp2p` [v0.41.1](https://github.com/libp2p/go-libp2p/releases/tag/v0.41.1)
 - `bitswap/network`: Add a new `requests_in_flight` metric gauge that measures how many bitswap streams are being written or read at a given time.
 - improve speed of data onboarding by batching/bufering provider queue writes [#888](https://github.com/ipfs/boxo/pull/888)
+- `provider/queue` deduplicates CIDs [#910](https://github.com/ipfs/boxo/pull/910)
 
 ### Removed
 

--- a/provider/internal/queue/queue.go
+++ b/provider/internal/queue/queue.go
@@ -212,6 +212,8 @@ func (q *Queue) worker(ctx context.Context) {
 				return
 			}
 			if found, _ := dedupCache.ContainsOrAdd(toQueue, struct{}{}); found {
+				// update recentness in LRU cache
+				dedupCache.Add(toQueue, struct{}{})
 				continue
 			}
 			idle = false

--- a/provider/internal/queue/queue.go
+++ b/provider/internal/queue/queue.go
@@ -25,7 +25,7 @@ const (
 	batchSize = 16 * 1024
 	// dedupCacheSize is the size of the LRU cache used to deduplicate CIDs in
 	// the queue.
-	dedupCacheSize = 1024
+	dedupCacheSize = 2 * 1024
 	// idleWriteTime is the amout of time to check if the queue has been idle
 	// (no input or output). If the queue has been idle since the last check,
 	// then write all buffered CIDs to the datastore.

--- a/provider/internal/queue/queue_test.go
+++ b/provider/internal/queue/queue_test.go
@@ -118,3 +118,21 @@ func TestInitializationWithManyCids(t *testing.T) {
 
 	assertOrdered(cids, queue, t)
 }
+
+func TestDeduplicateCids(t *testing.T) {
+	ds := sync.MutexWrap(datastore.NewMapDatastore())
+	queue := New(ds)
+	defer queue.Close()
+
+	cids := random.Cids(5)
+	queue.Enqueue(cids[0])
+	queue.Enqueue(cids[0])
+	queue.Enqueue(cids[1])
+	queue.Enqueue(cids[2])
+	queue.Enqueue(cids[1])
+	queue.Enqueue(cids[3])
+	queue.Enqueue(cids[0])
+	queue.Enqueue(cids[4])
+
+	assertOrdered(cids, queue, t)
+}


### PR DESCRIPTION
Superseeds https://github.com/ipfs/boxo/pull/909

We cannot use a lru cache as a drop in replacement for the internal buffer queue. When an item is read from the internal buffer queue, we don't want it out of the lru cache for deduplication. Also we don't want to clear the lru cache every time the queue is persisted to the datastore.

Unfortunately, it is necessary to keep additional state. Note that the lru cache size can be reduced if deemed too large.

Alternatively, it would be more lean not to push duplicate in the queue in the first place, so that we don't any deduplication inside the provider queue. This is tracked in https://github.com/ipfs/boxo/issues/901.

https://github.com/ipfs/boxo/pull/907 doesn't need to wait on this PR
