### PR TITLE
feat(bitswap): add option to disable Bitswap server 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The following emojis are used to highlight certain changes:
   - `fetcher/impl/blockservice`: new option `SkipNotFound` for the IPLD fetcher. It will skip not found nodes when traversing the DAG. This allows offline traversal of DAGs when using, for example, an offline blockservice.
   - This enables use case of providing lazy-loaded, partially local DAGs (like `ipfs files` in Kubo's MFS implementation, see [kubo#10386](https://github.com/ipfs/kubo/issues/10386))
 - `gateway`: generated HTML with UnixFS directory listings now include a button for copying CIDs of child entities [#899](https://github.com/ipfs/boxo/pull/899)
+- `bitswap/server`: Add ability to enable/disable bitswap server using `WithServerEnabled` bitswap option (#911)[https://github.com/ipfs/boxo/pull/911]
 
 ### Changed
 

--- a/bitswap/bitswap.go
+++ b/bitswap/bitswap.go
@@ -96,7 +96,7 @@ func New(ctx context.Context, net network.BitSwapNetwork, providerFinder routing
 }
 
 func (bs *Bitswap) NotifyNewBlocks(ctx context.Context, blks ...blocks.Block) error {
-	if bs.serverEnabled {
+	if bs.Server != nil {
 		return multierr.Combine(
 			bs.Client.NotifyNewBlocks(ctx, blks...),
 			bs.Server.NotifyNewBlocks(ctx, blks...),

--- a/bitswap/bitswap.go
+++ b/bitswap/bitswap.go
@@ -134,15 +134,12 @@ func (bs *Bitswap) Stat() (*Stat, error) {
 		// Server stats will be added conditionally
 	}
 
-	// Check if the server is enabled/initialized
-	if bs.serverEnabled {
-		// Server is enabled, get its stats
+	// Stats only available if server is enabled
+	if bs.Server != nil {
 		ss, err := bs.Server.Stat()
 		if err != nil {
-			// Return client stats along with the server error, or handle differently
 			return stat, fmt.Errorf("failed to get server stats: %w", err)
 		}
-		// Populate server-specific fields
 		stat.Peers = ss.Peers
 		stat.BlocksSent = ss.BlocksSent
 		stat.DataSent = ss.DataSent
@@ -154,7 +151,7 @@ func (bs *Bitswap) Stat() (*Stat, error) {
 func (bs *Bitswap) Close() error {
 	bs.net.Stop()
 	bs.Client.Close()
-	if bs.serverEnabled {
+	if bs.Server != nil {
 		bs.Server.Close()
 	}
 	return nil
@@ -169,14 +166,14 @@ func (bs *Bitswap) WantlistForPeer(p peer.ID) []cid.Cid {
 
 func (bs *Bitswap) PeerConnected(p peer.ID) {
 	bs.Client.PeerConnected(p)
-	if bs.serverEnabled {
+	if bs.Server != nil {
 		bs.Server.PeerConnected(p)
 	}
 }
 
 func (bs *Bitswap) PeerDisconnected(p peer.ID) {
 	bs.Client.PeerDisconnected(p)
-	if bs.serverEnabled {
+	if bs.Server != nil {
 		bs.Server.PeerDisconnected(p)
 	}
 }
@@ -193,7 +190,7 @@ func (bs *Bitswap) ReceiveMessage(ctx context.Context, p peer.ID, incoming messa
 	}
 
 	bs.Client.ReceiveMessage(ctx, p, incoming)
-	if bs.serverEnabled {
+	if bs.Server != nil {
 		bs.Server.ReceiveMessage(ctx, p, incoming)
 	}
 }

--- a/bitswap/bitswap.go
+++ b/bitswap/bitswap.go
@@ -51,15 +51,17 @@ type Bitswap struct {
 	*client.Client
 	*server.Server
 
-	tracer tracer.Tracer
-	net    network.BitSwapNetwork
+	tracer        tracer.Tracer
+	net           network.BitSwapNetwork
+	serverEnabled bool
 }
 
 func New(ctx context.Context, net network.BitSwapNetwork, providerFinder routing.ContentDiscovery, bstore blockstore.Blockstore, options ...Option) *Bitswap {
 	bs := &Bitswap{
 		net: net,
 	}
-
+	// by default, iniitalize the server
+	bs.serverEnabled = true
 	var serverOptions []server.Option
 	var clientOptions []client.Option
 
@@ -83,19 +85,24 @@ func New(ctx context.Context, net network.BitSwapNetwork, providerFinder routing
 	}
 
 	ctx = metrics.CtxSubScope(ctx, "bitswap")
-
-	bs.Server = server.New(ctx, net, bstore, serverOptions...)
-	bs.Client = client.New(ctx, net, providerFinder, bstore, append(clientOptions, client.WithBlockReceivedNotifier(bs.Server))...)
+	if bs.serverEnabled {
+		bs.Server = server.New(ctx, net, bstore, serverOptions...)
+		clientOptions = append(clientOptions, client.WithBlockReceivedNotifier(bs.Server))
+	}
+	bs.Client = client.New(ctx, net, providerFinder, bstore, clientOptions...)
 	net.Start(bs) // use the polyfill receiver to log received errors and trace messages only once
 
 	return bs
 }
 
 func (bs *Bitswap) NotifyNewBlocks(ctx context.Context, blks ...blocks.Block) error {
-	return multierr.Combine(
-		bs.Client.NotifyNewBlocks(ctx, blks...),
-		bs.Server.NotifyNewBlocks(ctx, blks...),
-	)
+	if bs.serverEnabled {
+		return multierr.Combine(
+			bs.Client.NotifyNewBlocks(ctx, blks...),
+			bs.Server.NotifyNewBlocks(ctx, blks...),
+		)
+	}
+	return bs.Client.NotifyNewBlocks(ctx, blks...)
 }
 
 type Stat struct {
@@ -115,28 +122,41 @@ func (bs *Bitswap) Stat() (*Stat, error) {
 	if err != nil {
 		return nil, err
 	}
-	ss, err := bs.Server.Stat()
-	if err != nil {
-		return nil, err
-	}
 
-	return &Stat{
+	// Initialize stat with client stats
+	stat := &Stat{
 		Wantlist:         cs.Wantlist,
 		BlocksReceived:   cs.BlocksReceived,
 		DataReceived:     cs.DataReceived,
 		DupBlksReceived:  cs.DupBlksReceived,
 		DupDataReceived:  cs.DupDataReceived,
 		MessagesReceived: cs.MessagesReceived,
-		Peers:            ss.Peers,
-		BlocksSent:       ss.BlocksSent,
-		DataSent:         ss.DataSent,
-	}, nil
+		// Server stats will be added conditionally
+	}
+
+	// Check if the server is enabled/initialized
+	if bs.serverEnabled {
+		// Server is enabled, get its stats
+		ss, err := bs.Server.Stat()
+		if err != nil {
+			// Return client stats along with the server error, or handle differently
+			return stat, fmt.Errorf("failed to get server stats: %w", err)
+		}
+		// Populate server-specific fields
+		stat.Peers = ss.Peers
+		stat.BlocksSent = ss.BlocksSent
+		stat.DataSent = ss.DataSent
+	}
+
+	return stat, nil
 }
 
 func (bs *Bitswap) Close() error {
 	bs.net.Stop()
 	bs.Client.Close()
-	bs.Server.Close()
+	if bs.serverEnabled {
+		bs.Server.Close()
+	}
 	return nil
 }
 
@@ -144,17 +164,21 @@ func (bs *Bitswap) WantlistForPeer(p peer.ID) []cid.Cid {
 	if p == bs.net.Self() {
 		return bs.Client.GetWantlist()
 	}
-	return bs.Server.WantlistForPeer(p)
+	return nil
 }
 
 func (bs *Bitswap) PeerConnected(p peer.ID) {
 	bs.Client.PeerConnected(p)
-	bs.Server.PeerConnected(p)
+	if bs.serverEnabled {
+		bs.Server.PeerConnected(p)
+	}
 }
 
 func (bs *Bitswap) PeerDisconnected(p peer.ID) {
 	bs.Client.PeerDisconnected(p)
-	bs.Server.PeerDisconnected(p)
+	if bs.serverEnabled {
+		bs.Server.PeerDisconnected(p)
+	}
 }
 
 func (bs *Bitswap) ReceiveError(err error) {
@@ -169,5 +193,7 @@ func (bs *Bitswap) ReceiveMessage(ctx context.Context, p peer.ID, incoming messa
 	}
 
 	bs.Client.ReceiveMessage(ctx, p, incoming)
-	bs.Server.ReceiveMessage(ctx, p, incoming)
+	if bs.serverEnabled {
+		bs.Server.ReceiveMessage(ctx, p, incoming)
+	}
 }

--- a/bitswap/bitswap.go
+++ b/bitswap/bitswap.go
@@ -61,8 +61,6 @@ func New(ctx context.Context, net network.BitSwapNetwork, providerFinder routing
 		net: net,
 		serverEnabled: true,
 	}
-	// by default, iniitalize the server
-	bs.serverEnabled = true
 	var serverOptions []server.Option
 	var clientOptions []client.Option
 

--- a/bitswap/bitswap.go
+++ b/bitswap/bitswap.go
@@ -59,6 +59,7 @@ type Bitswap struct {
 func New(ctx context.Context, net network.BitSwapNetwork, providerFinder routing.ContentDiscovery, bstore blockstore.Blockstore, options ...Option) *Bitswap {
 	bs := &Bitswap{
 		net: net,
+		serverEnabled: true,
 	}
 	// by default, iniitalize the server
 	bs.serverEnabled = true

--- a/bitswap/bitswap.go
+++ b/bitswap/bitswap.go
@@ -58,9 +58,10 @@ type Bitswap struct {
 
 func New(ctx context.Context, net network.BitSwapNetwork, providerFinder routing.ContentDiscovery, bstore blockstore.Blockstore, options ...Option) *Bitswap {
 	bs := &Bitswap{
-		net: net,
+		net:           net,
 		serverEnabled: true,
 	}
+
 	var serverOptions []server.Option
 	var clientOptions []client.Option
 
@@ -159,6 +160,9 @@ func (bs *Bitswap) Close() error {
 func (bs *Bitswap) WantlistForPeer(p peer.ID) []cid.Cid {
 	if p == bs.net.Self() {
 		return bs.Client.GetWantlist()
+	}
+	if bs.Server != nil {
+		return bs.Server.WantlistForPeer(p)
 	}
 	return nil
 }

--- a/bitswap/options.go
+++ b/bitswap/options.go
@@ -103,6 +103,14 @@ func WithTracer(tap tracer.Tracer) Option {
 	}
 }
 
+func WithServerEnabled(enabled bool) Option {
+	return Option{
+		option(func(bs *Bitswap) {
+			bs.serverEnabled = enabled
+		}),
+	}
+}
+
 func WithClientOption(opt client.Option) Option {
 	return Option{opt}
 }


### PR DESCRIPTION

Follow-up from [feat(config): ability to disable Bitswap fully or just server #10782](https://github.com/ipfs/kubo/pull/10782)
This pull request introduces the ability to enable or disable the server functionality in the `Bitswap` component, along with associated updates to the codebase and new tests. The changes ensure that `Bitswap` can operate in a client-only mode when the server is disabled, while maintaining backward compatibility.

### Core functionality changes:
* Added a `serverEnabled` field to the `Bitswap` struct, defaulting to `true`, and updated the `New` function to conditionally initialize the server based on this flag.
* Modified methods such as `Stat`, `NotifyNewBlocks`, `PeerConnected`, and `PeerDisconnected` to handle cases where the server is disabled, ensuring no server-related operations are performed in this mode. 

### New configuration option:
* Introduced a `WithServerEnabled` option to allow users to explicitly enable or disable the server when creating a `Bitswap` instance. 

### Testing enhancements:
* Added a new test, `TestWithServerDisabled`, to verify that `Bitswap` operates correctly in client-only mode, including requesting blocks, handling `Stat` output, and ensuring no responses to incoming requests. 
* Added `TestServerDisabledNotifyNewBlocks` to confirm that the `NotifyNewBlocks` method works as expected when the server is disabled.
