### PR TITLE
fix(bitswap/httpnet): idempotent Stop()

### DIFF
--- a/bitswap/network/httpnet/httpnet.go
+++ b/bitswap/network/httpnet/httpnet.go
@@ -319,8 +319,8 @@ func (ht *Network) Start(receivers ...network.Receiver) {
 // Other methods should no longer be used after calling Stop().
 func (ht *Network) Stop() {
 	ht.connEvtMgr.Stop()
-	ht.cooldownTracker.stopCleaner()
 	ht.closeOnce.Do(func() {
+		ht.cooldownTracker.stopCleaner()
 		close(ht.closing)
 	})
 }


### PR DESCRIPTION
This PR aims to avoid closing channel twice (inside of of `stopCleaner`) on shutdown.

Found in Kubo 0.35.0-rc2 (https://github.com/ipfs/kubo/issues/10760), shutdown of `ipfs daemon` sometimes produces noisy panic (not a big deal, since this is shutdown, but unnecessary noise):

```
panic: close of closed channel

goroutine 16518 [running]:
github.com/ipfs/boxo/bitswap/network/httpnet.(*cooldownTracker).stopCleaner(...)
	github.com/ipfs/boxo@v0.30.0/bitswap/network/httpnet/cooldown.go:50
github.com/ipfs/boxo/bitswap/network/httpnet.(*Network).Stop(0xc0014caa50)
	github.com/ipfs/boxo@v0.30.0/bitswap/network/httpnet/httpnet.go:322 +0x2e
github.com/ipfs/boxo/bitswap/network.(*router).Stop(0xc0014fbb00)
	github.com/ipfs/boxo@v0.30.0/bitswap/network/router.go:55 +0x35
github.com/ipfs/boxo/bitswap.(*Bitswap).Close(0xc0014fe100)
	github.com/ipfs/boxo@v0.30.0/bitswap/bitswap.go:152 +0x22
github.com/ipfs/kubo/core/node.Online.ProvidingExchange.func4.1({0x2edbc40?, 0x39f9d20?})
	github.com/ipfs/kubo/core/node/bitswap.go:188 +0x1c
go.uber.org/fx/internal/lifecycle.(*Lifecycle).runStopHook(0xc000000460, {0x3a11130, 0x4f74900}, {0x0, 0xc0014941f8, {0x0, 0x0}, {0x0, 0x0}, {{0xc001580340, ...}, ...}})
	go.uber.org/fx@v1.23.0/internal/lifecycle/lifecycle.go:341 +0x1f2
go.uber.org/fx/internal/lifecycle.(*Lifecycle).Stop(0xc000000460, {0x3a11130, 0x4f74900})
	go.uber.org/fx@v1.23.0/internal/lifecycle/lifecycle.go:303 +0x52e
go.uber.org/fx.(*App).Stop.func2({0x3a11130?, 0x4f74900?})
	go.uber.org/fx@v1.23.0/app.go:725 +0x7a
go.uber.org/fx.withTimeout.func1()
	go.uber.org/fx@v1.23.0/app.go:803 +0x6b
created by go.uber.org/fx.withTimeout in goroutine 42
	go.uber.org/fx@v1.23.0/app.go:791 +0xc5
```

cc @hsanjuan  for visibility, if there is a better way