### PR TITLE
Remove an unused timestamp from traceability.Block

### DIFF
--- a/bitswap/client/internal/notifications/notifications.go
+++ b/bitswap/client/internal/notifications/notifications.go
@@ -3,7 +3,6 @@ package notifications
 import (
 	"context"
 	"sync"
-	"time"
 
 	pubsub "github.com/cskr/pubsub"
 	"github.com/ipfs/boxo/bitswap/client/traceability"
@@ -87,8 +86,6 @@ func (ps *impl) Subscribe(ctx context.Context, keys ...cid.Cid) <-chan blocks.Bl
 	default:
 	}
 
-	subscribe := time.Now()
-
 	// AddSubOnceEach listens for each key in the list, and closes the channel
 	// once all keys have been received
 	ps.wrapped.AddSubOnceEach(valuesCh, toStrings(keys)...)
@@ -123,7 +120,6 @@ func (ps *impl) Subscribe(ctx context.Context, keys ...cid.Cid) <-chan blocks.Bl
 					// FIXME: silently dropping errors wtf ?
 					return
 				}
-				block.Delay = time.Since(subscribe)
 
 				select {
 				case <-ctx.Done():

--- a/bitswap/client/traceability/block.go
+++ b/bitswap/client/traceability/block.go
@@ -1,8 +1,6 @@
 package traceability
 
 import (
-	"time"
-
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
@@ -15,7 +13,4 @@ type Block struct {
 	// It will be the zero value if we did not downloaded this block from the
 	// network. (such as by getting the block from NotifyNewBlocks).
 	From peer.ID
-	// Delay contains how long did we had to wait between when we started being
-	// intrested and when we actually got the block.
-	Delay time.Duration
 }


### PR DESCRIPTION
Remove unused `time.Duration` that is taking up extra space and incurring an unnecessary time calculation.