### PR TITLE
Deprecate WithPeerLedger option for bitswap server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The following emojis are used to highlight certain changes:
 ### Changed
 
 - upgrade to `go-libp2p-kad-dht` [v0.33.1](https://github.com/libp2p/go-libp2p-kad-dht/releases/tag/v0.33.1)
+- deprecated `WithPeerLedger` option for bitswap server. Will remove option in next release. See [issue #928](https://github.com/ipfs/boxo/issues/928)
 
 ### Removed
 

--- a/bitswap/options.go
+++ b/bitswap/options.go
@@ -55,6 +55,7 @@ func WithScoreLedger(scoreLedger server.ScoreLedger) Option {
 	return Option{server.WithScoreLedger(scoreLedger)}
 }
 
+// Deprecated: This is no longer needed and will be removed.
 func WithPeerLedger(peerLedger server.PeerLedger) Option {
 	return Option{server.WithPeerLedger(peerLedger)}
 }

--- a/bitswap/server/internal/decision/engine.go
+++ b/bitswap/server/internal/decision/engine.go
@@ -281,6 +281,8 @@ func WithScoreLedger(scoreledger ScoreLedger) Option {
 }
 
 // WithPeerLedger sets a custom [PeerLedger] to be used with this [Engine].
+//
+// Deprecated: This is no longer needed and will be removed.
 func WithPeerLedger(peerLedger PeerLedger) Option {
 	return func(e *Engine) {
 		e.peerLedger = peerLedger

--- a/bitswap/server/server.go
+++ b/bitswap/server/server.go
@@ -131,6 +131,8 @@ func WithScoreLedger(scoreLedger decision.ScoreLedger) Option {
 }
 
 // WithPeerLedger configures the engine with a custom [decision.PeerLedger].
+//
+// Deprecated: This is no longer needed and will be removed.
 func WithPeerLedger(peerLedger decision.PeerLedger) Option {
 	o := decision.WithPeerLedger(peerLedger)
 	return func(bs *Server) {


### PR DESCRIPTION
This is no longer needed and should be removed next release.

See issue #928 for more information.
