### PR TITLE
Revert "Remove an unused timestamp from traceability.Block"

### DIFF
--- a/bitswap/client/internal/notifications/notifications.go
+++ b/bitswap/client/internal/notifications/notifications.go
@@ -3,6 +3,7 @@ package notifications
 import (
 	"context"
 	"sync"
+	"time"
 
 	pubsub "github.com/cskr/pubsub"
 	"github.com/ipfs/boxo/bitswap/client/traceability"
@@ -86,6 +87,8 @@ func (ps *impl) Subscribe(ctx context.Context, keys ...cid.Cid) <-chan blocks.Bl
 	default:
 	}
 
+	subscribe := time.Now()
+
 	// AddSubOnceEach listens for each key in the list, and closes the channel
 	// once all keys have been received
 	ps.wrapped.AddSubOnceEach(valuesCh, toStrings(keys)...)
@@ -120,6 +123,7 @@ func (ps *impl) Subscribe(ctx context.Context, keys ...cid.Cid) <-chan blocks.Bl
 					// FIXME: silently dropping errors wtf ?
 					return
 				}
+				block.Delay = time.Since(subscribe)
 
 				select {
 				case <-ctx.Done():

--- a/bitswap/client/traceability/block.go
+++ b/bitswap/client/traceability/block.go
@@ -1,6 +1,8 @@
 package traceability
 
 import (
+	"time"
+
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
@@ -13,4 +15,7 @@ type Block struct {
 	// It will be the zero value if we did not downloaded this block from the
 	// network. (such as by getting the block from NotifyNewBlocks).
 	From peer.ID
+	// Delay contains how long did we had to wait between when we started being
+	// intrested and when we actually got the block.
+	Delay time.Duration
 }


### PR DESCRIPTION
Reverts ipfs/boxo#923

Reverting to avoid possible breaking change for users of bitswap other than kubo and rainbow.