### PR TITLE
bitswap/httpnet: expose the errors on connect when connection impossible

### DIFF
--- a/bitswap/network/httpnet/httpnet_test.go
+++ b/bitswap/network/httpnet/httpnet_test.go
@@ -415,7 +415,7 @@ func TestConnectErrors(t *testing.T) {
 
 	err = connectToPeer(t, ctx, htnet, peer, msrv)
 	if err == nil {
-		t.Error("expected error")
+		t.Fatal("expected error")
 	}
 	t.Log(err)
 	if !strings.Contains(err.Error(), "failed to verify") {
@@ -433,7 +433,7 @@ func TestConnectErrors(t *testing.T) {
 
 	err = connectToPeer(t, ctx, htnet2, peer2, msrv)
 	if err == nil {
-		t.Error("expected error")
+		t.Fatal("expected error")
 	}
 	t.Log(err)
 	if !strings.Contains(err.Error(), "denylist") {


### PR DESCRIPTION
Context: provide useful user feedback in tools like http-check.