### PR TITLE
bitswap/httpnet: adjust error logging

### DIFF
--- a/bitswap/network/httpnet/httpnet.go
+++ b/bitswap/network/httpnet/httpnet.go
@@ -660,7 +660,11 @@ func (ht *Network) httpWorker(i int) {
 						continue // retry again ignoring current url
 					case typeContext:
 					case typeFatal:
-						log.Error(err)
+						// noop. Return result. tryURL
+						// never returns
+						// typeFatal. Error logging
+						// happens in the result
+						// collector
 					case typeServer:
 						u.serverErrors.Add(1)
 						continue // retry until bestURL forces abort
@@ -690,7 +694,7 @@ func buildRequest(ctx context.Context, u network.ParsedURL, method string, cid s
 		nil,
 	)
 	if err != nil {
-		log.Error(err)
+		log.Error("error building request:", err)
 		return nil, err
 	}
 

--- a/bitswap/network/httpnet/msg_sender.go
+++ b/bitswap/network/httpnet/msg_sender.go
@@ -369,7 +369,7 @@ func (sender *httpMsgSender) tryURL(ctx context.Context, u *senderURL, entry bsm
 		// server issues, and simply return 404 when they cannot find
 		// the content but everything else is fine.
 		err := fmt.Errorf("%q -> %d: %q", req.URL, statusCode, string(body))
-		log.Error(err)
+		log.Warn(err)
 		retryAfter := resp.Header.Get("Retry-After")
 		cooldownUntil, ok := parseRetryAfter(retryAfter)
 		if ok { // it means we should retry, so we will retry.
@@ -391,7 +391,7 @@ func (sender *httpMsgSender) tryURL(ctx context.Context, u *senderURL, entry bsm
 	// it fails MaxRetries, we will fully disconnect.
 	default:
 		err := fmt.Errorf("%q -> %d: %q", req.URL, statusCode, string(body))
-		log.Error(err)
+		log.Warn(err)
 		sender.ht.cooldownTracker.setByDuration(req.URL.Host, sender.opts.SendErrorBackoff)
 		u.cooldown.Store(time.Now().Add(sender.opts.SendErrorBackoff))
 		return nil, &senderError{
@@ -522,7 +522,7 @@ WANTLIST_LOOP:
 				// error handling
 				switch result.err.Type {
 				case typeFatal:
-					log.Errorf("fatal error. Disconnecting from %s: %s", sender.peer, result.err.Err)
+					log.Warnf("disconnecting from %s: %s", sender.peer, result.err.Err)
 					sender.ht.DisconnectFrom(ctx, sender.peer)
 					err = result.err
 					// continue processing responses as workers


### PR DESCRIPTION
Moved some error logging to warn level.

The errors are useful when figuring out why something is not loading from somewhere (particularly in an scenario where an allowlist is configured), but in an all-open setup they will spam the logs. Default log level is error I think, so warn messages should not show and can be activated without getting into the debug details.

Fixes #955.
Fixes #954.

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
