### PR TITLE
Handle Bitswap messages without `Wantlist`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The following emojis are used to highlight certain changes:
 
 ### Security
 
+- fix panic when incoming Bitswap protobuf message does not contain `Wantlist` [#961](https://github.com/ipfs/boxo/pull/961)
 
 ## [v0.32.0]
 

--- a/bitswap/message/message.go
+++ b/bitswap/message/message.go
@@ -190,16 +190,19 @@ func (m *impl) Reset(full bool) {
 var errCidMissing = errors.New("missing cid")
 
 func newMessageFromProto(pbm *pb.Message) (BitSwapMessage, error) {
-	m := newMsg(pbm.Wantlist.Full)
-	for _, e := range pbm.Wantlist.Entries {
-		if len(e.Block) == 0 {
-			return nil, errCidMissing
+	m := newMsg(pbm.Wantlist != nil && pbm.Wantlist.Full)
+
+	if pbm.Wantlist != nil {
+		for _, e := range pbm.Wantlist.Entries {
+			if len(e.Block) == 0 {
+				return nil, errCidMissing
+			}
+			c, err := cid.Cast(e.Block)
+			if err != nil {
+				return nil, err
+			}
+			m.addEntry(c, e.Priority, e.Cancel, e.WantType, e.SendDontHave)
 		}
-		c, err := cid.Cast(e.Block)
-		if err != nil {
-			return nil, err
-		}
-		m.addEntry(c, e.Priority, e.Cancel, e.WantType, e.SendDontHave)
 	}
 
 	// deprecated


### PR DESCRIPTION
Correctly handle Bitswap protobuf messages without `Wantlist` field.