### PR TITLE
Fix sending extra wants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The following emojis are used to highlight certain changes:
 ### Removed
 
 ### Fixed
+- `bitswap/client`: Fix sending extra wants [#968](https://github.com/ipfs/boxo/pull/968)
 
 ### Security
 

--- a/bitswap/message/message.go
+++ b/bitswap/message/message.go
@@ -262,11 +262,11 @@ func (m *impl) Empty() bool {
 func (m *impl) FillWantlist(out []Entry) []Entry {
 	if cap(out) < len(m.wantlist) {
 		out = make([]Entry, len(m.wantlist))
+	} else {
+		out = out[:0]
 	}
-	var i int
 	for _, e := range m.wantlist {
-		out[i] = *e
-		i++
+		out = append(out, *e)
 	}
 	return out
 }


### PR DESCRIPTION
It is possible for extra wants to be send due to an error causing additional wants to be left in a reused buffer. This fixes the problem by correctly truncating the buffer.
