### PR TITLE
fix: normalize delegated /routing/v1 urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 - `bitswap/client`: Fix sending extra wants [#968](https://github.com/ipfs/boxo/pull/968)
+- `routing/http/client`: Improve URL handling for delegated routing endpoints [#971](https://github.com/ipfs/boxo/pull/971)
 
 ### Security
 

--- a/routing/http/client/client.go
+++ b/routing/http/client/client.go
@@ -43,10 +43,8 @@ func normalizeBaseURL(baseURL string) (string, error) {
 	// Remove trailing slashes first
 	baseURL = strings.TrimRight(baseURL, "/")
 
-	// Check if baseURL ends with /routing/v1 and remove it
-	if strings.HasSuffix(baseURL, "/routing/v1") {
-		baseURL = strings.TrimSuffix(baseURL, "/routing/v1")
-	}
+	// Remove /routing/v1 suffix if present
+	baseURL = strings.TrimSuffix(baseURL, "/routing/v1")
 
 	// After deduplication, check if there's any path remaining
 	u, err := gourl.Parse(baseURL)


### PR DESCRIPTION
Quality of life fix that avoids silent errors like one described in https://github.com/ipfs/kubo/issues/10853

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
