### PR TITLE
Queue all changes in order using non-blocking async queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
-- `bitswap/httpnet`: fix an issue where boxo silently stops making http retrieval requests.
+- `bitswap`: fix an issue where boxo silently stops making http retrieval requests. [#981](https://github.com/ipfs/boxo/pull/978), [#980](https://github.com/ipfs/boxo/pull/980), [#979](https://github.com/ipfs/boxo/pull/978)
 
 ### Security
 

--- a/bitswap/client/internal/session/sessionwantsender.go
+++ b/bitswap/client/internal/session/sessionwantsender.go
@@ -183,7 +183,6 @@ func (sws *sessionWantSender) SignalAvailability(p peer.ID, isAvailable bool) {
 
 // Run is the main loop for processing incoming changes
 func (sws *sessionWantSender) Run() {
-	defer sws.changes.Shutdown()
 	changes := sws.changes.Out()
 
 	for {


### PR DESCRIPTION
It is possible for changes to get our of order when they are submitted by goroutines for non-blocking operations. Instead of goroutines, use an asynchronous queue to maintain order of events.

This may prevent provlems caused by mis-ordering of events shuch as connect and disconnect events.