### PR TITLE
Bitswap: fix double-worker in connectEventManager. Logging improvements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
-- `bitswap`: fix an issue where boxo silently stops making http retrieval requests. [#981](https://github.com/ipfs/boxo/pull/978), [#980](https://github.com/ipfs/boxo/pull/980), [#979](https://github.com/ipfs/boxo/pull/978) and [#984 (writeup)](https://github.com/ipfs/boxo/pull/984).
+- `bitswap`: fix an issue where boxo silently stops making http retrieval requests. [#981](https://github.com/ipfs/boxo/pull/978), [#980](https://github.com/ipfs/boxo/pull/980), [#979](https://github.com/ipfs/boxo/pull/978) and [#984 (writeup)](https://github.com/ipfs/boxo/pull/984), [#986](https://github.com/ipfs/boxo/pull/986).
 
 ### Security
 

--- a/bitswap/client/internal/peermanager/peermanager.go
+++ b/bitswap/client/internal/peermanager/peermanager.go
@@ -90,6 +90,7 @@ func (pm *PeerManager) ConnectedPeers() []peer.ID {
 func (pm *PeerManager) Connected(p peer.ID) {
 	pm.pqLk.Lock()
 
+	log.Debugf("connect notification for %s", p)
 	pq := pm.getOrCreate(p)
 	// Inform the peer want manager that there's a new peer
 	pm.pwm.addPeer(pq, p)
@@ -104,6 +105,7 @@ func (pm *PeerManager) Connected(p peer.ID) {
 func (pm *PeerManager) Disconnected(p peer.ID) {
 	pm.pqLk.Lock()
 
+	log.Debugf("disconnect notification for %s", p)
 	pq, ok := pm.peerQueues[p]
 	if !ok {
 		pm.pqLk.Unlock()
@@ -202,6 +204,9 @@ func (pm *PeerManager) getOrCreate(p peer.ID) PeerQueue {
 		}
 		pq.Startup()
 		pm.peerQueues[p] = pq
+		log.Debugf("getOrCreate: new queue for %s", p)
+	} else {
+		log.Debugf("getOrCreate: queue exists already for %s", p)
 	}
 	return pq
 }

--- a/bitswap/client/internal/peermanager/peerwantmanager.go
+++ b/bitswap/client/internal/peermanager/peerwantmanager.go
@@ -118,6 +118,7 @@ func newPeerWantManager(wantGauge, wantBlockGauge Gauge, bcastControl BroadcastC
 // current list of broadcast wants to the peer.
 func (pwm *peerWantManager) addPeer(peerQueue PeerQueue, p peer.ID) {
 	if _, ok := pwm.peerWants[p]; ok {
+		log.Debugf("peerWantManager: addPeer: peerWants already existed for %s", p)
 		return
 	}
 

--- a/bitswap/client/internal/session/session.go
+++ b/bitswap/client/internal/session/session.go
@@ -406,7 +406,7 @@ func (s *Session) findMorePeers(ctx context.Context, c cid.Cid) {
 		for p := range s.providerFinder.FindProvidersAsync(ctx, k, 0) {
 			// When a provider indicates that it has a cid, it's equivalent to
 			// the providing peer sending a HAVE
-			log.Infof("FoundPeer %s for CID %s", p, k)
+			log.Infow("Found peer for CID", "peer", p, "cid", k)
 			span.AddEvent("FoundPeer")
 			s.sws.Update(p.ID, nil, []cid.Cid{c}, nil)
 		}

--- a/bitswap/client/internal/session/session.go
+++ b/bitswap/client/internal/session/session.go
@@ -406,6 +406,7 @@ func (s *Session) findMorePeers(ctx context.Context, c cid.Cid) {
 		for p := range s.providerFinder.FindProvidersAsync(ctx, k, 0) {
 			// When a provider indicates that it has a cid, it's equivalent to
 			// the providing peer sending a HAVE
+			log.Infof("FoundPeer %s for CID %s", p, k)
 			span.AddEvent("FoundPeer")
 			s.sws.Update(p.ID, nil, []cid.Cid{c}, nil)
 		}

--- a/bitswap/client/internal/session/sessionwantsender.go
+++ b/bitswap/client/internal/session/sessionwantsender.go
@@ -262,6 +262,7 @@ func (sws *sessionWantSender) onChange(changes []change) {
 			// the peer is available
 			if len(chng.update.ks) > 0 || len(chng.update.haves) > 0 {
 				p := chng.update.from
+				log.Debugf("change: availability (update includes blocks/haves): %s -> true", p)
 				availability[p] = true
 
 				// Register with the PeerManager
@@ -270,8 +271,9 @@ func (sws *sessionWantSender) onChange(changes []change) {
 
 			updates = append(updates, chng.update)
 		}
-		if chng.availability.target != "" {
-			availability[chng.availability.target] = chng.availability.available
+		if t := chng.availability.target; t != "" {
+			log.Debugf("change: availability: %s -> %t", t, chng.availability.available)
+			availability[t] = chng.availability.available
 		}
 	}
 
@@ -329,7 +331,9 @@ func (sws *sessionWantSender) processAvailability(availability map[peer.ID]bool)
 			delete(sws.peerConsecutiveDontHaves, p)
 		}
 	}
-
+	if len(newlyAvailable)+len(newlyUnavailable) > 0 {
+		log.Infof("newly available: %s, newlyUnavailable: %s", newlyAvailable, newlyUnavailable)
+	}
 	return newlyAvailable, newlyUnavailable
 }
 

--- a/bitswap/network/bsnet/ipfs_impl.go
+++ b/bitswap/network/bsnet/ipfs_impl.go
@@ -329,6 +329,7 @@ func (bsnet *impl) msgToStream(ctx context.Context, s network.Stream, msg bsmsg.
 }
 
 func (bsnet *impl) NewMessageSender(ctx context.Context, p peer.ID, opts *iface.MessageSenderOpts) (iface.MessageSender, error) {
+	log.Debugf("NewMessageSender: %s", p)
 	opts = setDefaultOpts(opts)
 
 	sender := &streamMessageSender{

--- a/bitswap/network/connecteventmanager.go
+++ b/bitswap/network/connecteventmanager.go
@@ -138,6 +138,7 @@ func (c *ConnectEventManager) worker() {
 			// We could be transitioning from unresponsive to disconnected.
 			if oldState == stateResponsive {
 				c.lk.Unlock()
+				log.Debugf("PeerDisconnected notification: %s", pid)
 				for _, v := range c.connListeners {
 					v.PeerDisconnected(pid)
 				}
@@ -145,6 +146,7 @@ func (c *ConnectEventManager) worker() {
 			}
 		case stateResponsive:
 			c.lk.Unlock()
+			log.Debugf("PeerConnected notification: %s", pid)
 			for _, v := range c.connListeners {
 				v.PeerConnected(pid)
 			}

--- a/bitswap/network/connecteventmanager.go
+++ b/bitswap/network/connecteventmanager.go
@@ -51,8 +51,8 @@ func NewConnectEventManager(connListeners ...ConnectionListener) *ConnectEventMa
 	return evtManager
 }
 
-// SetListeners sets or replaces the current listeners. It will not take effect
-// after Start().
+// SetListeners sets or replaces the current listeners. It has no effect after
+// Start is called.
 func (c *ConnectEventManager) SetListeners(connListeners ...ConnectionListener) {
 	if workerStarted := c.workerStarted.Load(); !workerStarted {
 		c.connListeners = connListeners

--- a/bitswap/network/httpnet/msg_sender.go
+++ b/bitswap/network/httpnet/msg_sender.go
@@ -470,9 +470,10 @@ WANTLIST_LOOP:
 			// against bsnet requests-time.
 			// sender.ht.metrics.RequestTime.Observe(float64(time.Since(reqStart))
 			// / float64(time.Second))
+			log.Debugf("wantlist msg %d/%d: %s %s cancel", i, lenWantlist-1, sender.peer, entry.Cid)
 			continue
 		}
-		log.Debugf("wantlist msg %d/%d: %s %s %s DH:%t", i, lenWantlist, sender.peer, entry.Cid, entry.WantType, entry.SendDontHave)
+		log.Debugf("wantlist msg %d/%d: %s %s %s DH:%t", i, lenWantlist-1, sender.peer, entry.Cid, entry.WantType, entry.SendDontHave)
 
 		reqInfo := httpRequestInfo{
 			ctx:       entryCtxs[i],
@@ -551,7 +552,6 @@ WANTLIST_LOOP:
 		if err := sender.ht.errorTracker.logErrors(sender.peer, totalClientErrors, sender.ht.maxDontHaveErrors); err != nil {
 			log.Debugf("too many client errors. Disconnecting from %s", sender.peer)
 			sender.ht.DisconnectFrom(ctx, sender.peer)
-
 		}
 
 		// We return a special "cancel" function that we need to call
@@ -581,7 +581,7 @@ func (sender *httpMsgSender) notifyReceivers(bsresp bsmsg.BitSwapMessage) {
 	}
 
 	for i, recv := range sender.ht.receivers {
-		log.Debugf("ReceiveMessage from %s#%d. Blocks: %d. Haves: %d", sender.peer, i, lb, lh)
+		log.Debugf("ReceiveMessage from %s#%d. Blocks: %d. Haves: %d. DontHaves: %d", sender.peer, i, lb, lh, ldh)
 		recv.ReceiveMessage(
 			context.Background(),
 			sender.peer,

--- a/bitswap/network/router.go
+++ b/bitswap/network/router.go
@@ -49,6 +49,11 @@ func (rt *router) Start(receivers ...Receiver) {
 	// manager has the power to remove a peer from everywhere, and the
 	// router may in some edge cases or due to bugs route requests wrongly,
 	// this may cause connection-state mismatches.
+	//
+	// The Start() calls call ConnectEventManager.Start(), which makes
+	// sure only one worker starts. SetListeners does not have effect if
+	// called when the manager has started. We still call Start() on both
+	// in case they are using separate connectEventManagers.
 	rt.Bitswap.Start(receivers...)
 	rt.HTTP.Start(receivers...)
 }


### PR DESCRIPTION
This should potentially fix the last source of racing connect-disconnects.