### PR TITLE
fix: cidqueue gc must iterate all elements in queue

### DIFF
--- a/bitswap/client/internal/session/cidqueue.go
+++ b/bitswap/client/internal/session/cidqueue.go
@@ -49,7 +49,8 @@ func (cq *cidQueue) len() int {
 
 func (cq *cidQueue) gc() {
 	if cq.elems.Len() > cq.eset.Len() {
-		for i := 0; i < cq.elems.Len(); i++ {
+		n := cq.elems.Len()
+		for i := 0; i < n; i++ {
 			c := cq.elems.PopFront()
 			if cq.eset.Has(c) {
 				cq.elems.PushBack(c)

--- a/bitswap/client/internal/session/cidqueue_test.go
+++ b/bitswap/client/internal/session/cidqueue_test.go
@@ -1,0 +1,22 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/ipfs/go-test/random"
+)
+
+func TestCidQueueGC(t *testing.T) {
+	cq := newCidQueue()
+
+	for _, c := range random.Cids(5) {
+		cq.push(c)
+		cq.remove(c)
+	}
+
+	cq.gc()
+
+	if cq.elems.Len() != 0 {
+		t.Fatal("all elements were not removed")
+	}
+}


### PR DESCRIPTION
Fix an error that could make cidqueue fail to clean up some elements from its map during gc. This error had no effect other than keeping some CIDs in memory longer than needed.
