### PR TITLE
fix: use %q for logging routing keys with binary data

### DIFF
--- a/bitswap/client/internal/peermanager/peerwantmanager.go
+++ b/bitswap/client/internal/peermanager/peerwantmanager.go
@@ -339,7 +339,7 @@ func (pwm *peerWantManager) sendWants(p peer.ID, wantBlocks []cid.Cid, wantHaves
 	pws, ok := pwm.peerWants[p]
 	if !ok {
 		// In practice this should never happen
-		log.Errorf("sendWants() called with peer %s but peer not found in peerWantManager", string(p))
+		log.Errorf("sendWants() called with peer %s but peer not found in peerWantManager", p)
 		return
 	}
 
@@ -526,7 +526,7 @@ func (pwm *peerWantManager) wantPeerCounts(c cid.Cid) wantPeerCnts {
 	for p := range pwm.wantPeers[c] {
 		pws, ok := pwm.peerWants[p]
 		if !ok {
-			log.Errorf("reverse index has extra peer %s for key %s in peerWantManager", string(p), c)
+			log.Errorf("reverse index has extra peer %s for key %s in peerWantManager", p, c)
 			continue
 		}
 

--- a/namesys/ipns_publisher.go
+++ b/namesys/ipns_publisher.go
@@ -278,7 +278,7 @@ func PutPublicKey(ctx context.Context, r routing.ValueStore, pid peer.ID, pubKey
 		return err
 	}
 
-	log.Debugf("Storing public key at: %x", routingKey)
+	log.Debugf("Storing public key at: %q", routingKey) // routingKey may contain binary data per IPNS spec
 	return r.PutValue(ctx, routingKey, bytes)
 }
 
@@ -298,6 +298,6 @@ func PutIPNSRecord(ctx context.Context, r routing.ValueStore, name ipns.Name, re
 		return err
 	}
 
-	log.Debugf("Storing ipns record at: %x", routingKey)
+	log.Debugf("Storing ipns record at: %q", routingKey) // routingKey may contain binary data per IPNS spec
 	return r.PutValue(ctx, routingKey, bytes)
 }

--- a/routing/mock/centralized_client.go
+++ b/routing/mock/centralized_client.go
@@ -22,18 +22,18 @@ type client struct {
 
 // PutValue FIXME(brian): is this method meant to simulate putting a value into the network?
 func (c *client) PutValue(ctx context.Context, key string, val []byte, opts ...routing.Option) error {
-	log.Debugf("PutValue: %s", key)
+	log.Debugf("PutValue: %q", key) // key may contain binary data per IPNS spec
 	return c.vs.PutValue(ctx, key, val, opts...)
 }
 
 // GetValue FIXME(brian): is this method meant to simulate getting a value from the network?
 func (c *client) GetValue(ctx context.Context, key string, opts ...routing.Option) ([]byte, error) {
-	log.Debugf("GetValue: %s", key)
+	log.Debugf("GetValue: %q", key) // key may contain binary data per IPNS spec
 	return c.vs.GetValue(ctx, key, opts...)
 }
 
 func (c *client) SearchValue(ctx context.Context, key string, opts ...routing.Option) (<-chan []byte, error) {
-	log.Debugf("SearchValue: %s", key)
+	log.Debugf("SearchValue: %q", key) // key may contain binary data per IPNS spec
 	return c.vs.SearchValue(ctx, key, opts...)
 }
 


### PR DESCRIPTION
> - Discovered while testing https://github.com/ipfs/ipfs-webui/pull/2392

routing keys contain raw binary multihash bytes per IPNS spec (https://specs.ipfs.tech/ipns/ipns-record/#routing-record) which can result in garbled log output when using %s format, for example:

```
composer: calling putValue: /ipns/$ ��)f����*��V�+�7��|w�9ۮT<g�397
composer: calling putValue error: /ipns/$ ��)f����*��V�+�7��|w�9ۮT<g�397 routing: operation or key not supported
```

changes:
- use `%q` instead of `%`s for routing keys in mock client
- use `%q` instead of `%x` for routing keys in ipns publisher
- fix peer ID logging to use proper `String()` method

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
