### PR TITLE
rename `retrieval.RetrievalState` to `retrieval.State`

### DIFF
--- a/bitswap/client/client.go
+++ b/bitswap/client/client.go
@@ -446,7 +446,7 @@ func (bs *Client) GetBlocks(ctx context.Context, keys []cid.Cid) (<-chan blocks.
 	// Temporary session closed indepentendly of cancellation ctx.
 	sessCtx, cancelSession := context.WithCancel(context.Background())
 
-	// Preserve RetrievalState from the original request context if present
+	// Preserve retrieval.State from the original request context if present
 	if retrievalState := retrieval.StateFromContext(ctx); retrievalState != nil {
 		sessCtx = context.WithValue(sessCtx, retrieval.ContextKey, retrievalState)
 	}

--- a/gateway/middleware_retrieval_timeout.go
+++ b/gateway/middleware_retrieval_timeout.go
@@ -32,7 +32,7 @@ func withRetrievalTimeout(handler http.Handler, timeout time.Duration, c *Config
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Add RetrievalState to request context for tracking provider diagnostics
+		// Add retrieval.State to request context for tracking provider diagnostics
 		ctx, retrievalState := retrieval.ContextWithState(r.Context())
 		r = r.WithContext(ctx)
 

--- a/routing/providerquerymanager/providerquerymanager.go
+++ b/routing/providerquerymanager/providerquerymanager.go
@@ -508,7 +508,7 @@ func (npqm *newProvideQueryMessage) handle(pqm *ProviderQueryManager) {
 		span.AddEvent("NewQuery", trace.WithAttributes(attribute.Stringer("cid", npqm.k)))
 		ctx = trace.ContextWithSpan(ctx, span)
 
-		// Preserve RetrievalState from the original request context if present
+		// Preserve retrieval.State from the original request context if present
 		if retrievalState := retrieval.StateFromContext(npqm.ctx); retrievalState != nil {
 			ctx = context.WithValue(ctx, retrieval.ContextKey, retrievalState)
 		}


### PR DESCRIPTION
Avoid name stutter.