### PR TITLE
Use `time.Duration` for rebroadcast delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The following emojis are used to highlight certain changes:
 
 ### Changed
 
-- `bitswap/client`: The `RebroadcastDelay` option now takes a `time.Duration` value. This is a potentially BREAKING CHANGE. The time varying functionality was never of `delay.Delay` was never used, so was replaced with a fixed duration value.
+- 🛠 `bitswap/client`: The `RebroadcastDelay` option now takes a `time.Duration` value. This is a potentially BREAKING CHANGE. The time-varying functionality of `delay.Delay` was never used, so it was replaced with a fixed duration value. This also removes the `github.com/ipfs/go-ipfs-delay` dependency.
 
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ The following emojis are used to highlight certain changes:
 
 ### Changed
 
+- `bitswap/client`: The `RebroadcastDelay` option now takes a `time.Duration` value. This is a potentially BREAKING CHANGE. The time varying functionality was never of `delay.Delay` was never used, so was replaced with a fixed duration value.
+
+
 ### Removed
 
 ### Fixed

--- a/bitswap/client/bitswap_with_sessions_test.go
+++ b/bitswap/client/bitswap_with_sessions_test.go
@@ -334,7 +334,7 @@ func TestFetchAfterDisconnect(t *testing.T) {
 	router := mockrouting.NewServer()
 	ig := testinstance.NewTestInstanceGenerator(vnet, router, nil, []bitswap.Option{
 		bitswap.ProviderSearchDelay(10 * time.Millisecond),
-		bitswap.RebroadcastDelay(delay.Fixed(15 * time.Millisecond)),
+		bitswap.RebroadcastDelay(15 * time.Millisecond),
 		bitswap.WithClientOption(client.WithTraceBlock(true)),
 	})
 	defer ig.Close()

--- a/bitswap/client/client.go
+++ b/bitswap/client/client.go
@@ -28,7 +28,6 @@ import (
 	rpqm "github.com/ipfs/boxo/routing/providerquerymanager"
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
-	delay "github.com/ipfs/go-ipfs-delay"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/ipfs/go-metrics-interface"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -64,7 +63,7 @@ func ProviderSearchDelay(newProvSearchDelay time.Duration) Option {
 // When the value ellapses, a random CID from the wantlist is chosen and the
 // client attempts to find more peers for it and sends them the single want.
 // [defaults.RebroadcastDelay] for the default.
-func RebroadcastDelay(newRebroadcastDelay delay.D) Option {
+func RebroadcastDelay(newRebroadcastDelay time.Duration) Option {
 	return func(bs *Client) {
 		bs.rebroadcastDelay = newRebroadcastDelay
 	}
@@ -241,7 +240,7 @@ func New(parent context.Context, network bsnet.BitSwapNetwork, providerFinder ro
 		havesReceivedGauge:          bmetrics.HavesReceivedGauge(ctx),
 		blocksReceivedGauge:         bmetrics.BlocksReceivedGauge(ctx),
 		provSearchDelay:             defaults.ProvSearchDelay,
-		rebroadcastDelay:            delay.Fixed(defaults.RebroadcastDelay),
+		rebroadcastDelay:            defaults.RebroadcastDelay,
 		simulateDontHavesOnTimeout:  true,
 		defaultProviderQueryManager: true,
 
@@ -308,7 +307,7 @@ func New(parent context.Context, network bsnet.BitSwapNetwork, providerFinder ro
 		bpm *bsbpm.BlockPresenceManager,
 		notif notifications.PubSub,
 		provSearchDelay time.Duration,
-		rebroadcastDelay delay.D,
+		rebroadcastDelay time.Duration,
 		self peer.ID,
 		retrievalState *retrieval.State,
 	) bssm.Session {
@@ -392,7 +391,7 @@ type Client struct {
 	provSearchDelay time.Duration
 
 	// how often to rebroadcast providing requests to find more optimized providers
-	rebroadcastDelay delay.D
+	rebroadcastDelay time.Duration
 
 	blockReceivedNotifier BlockReceivedNotifier
 

--- a/bitswap/client/internal/session/session_test.go
+++ b/bitswap/client/internal/session/session_test.go
@@ -14,7 +14,6 @@ import (
 	bsspm "github.com/ipfs/boxo/bitswap/client/internal/sessionpeermanager"
 	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
-	delay "github.com/ipfs/go-ipfs-delay"
 	"github.com/ipfs/go-test/random"
 	peer "github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
@@ -165,7 +164,7 @@ func TestSessionGetBlocks(t *testing.T) {
 	defer notif.Shutdown()
 	id := random.SequenceNext()
 	sm := newMockSessionMgr(sim)
-	session := New(sm, id, fspm, fpf, sim, fpm, bpm, notif, time.Second, delay.Fixed(time.Minute), "", nil, nil)
+	session := New(sm, id, fspm, fpf, sim, fpm, bpm, notif, time.Second, time.Minute, "", nil, nil)
 	defer session.Close()
 	blks := random.BlocksOfSize(broadcastLiveWantsLimit*2, blockSize)
 	var cids []cid.Cid
@@ -244,7 +243,7 @@ func TestSessionFindMorePeers(t *testing.T) {
 	defer notif.Shutdown()
 	id := random.SequenceNext()
 	sm := newMockSessionMgr(sim)
-	session := New(sm, id, fspm, fpf, sim, fpm, bpm, notif, time.Second, delay.Fixed(time.Minute), "", nil, nil)
+	session := New(sm, id, fspm, fpf, sim, fpm, bpm, notif, time.Second, time.Minute, "", nil, nil)
 	defer session.Close()
 	session.SetBaseTickDelay(200 * time.Microsecond)
 	blks := random.BlocksOfSize(broadcastLiveWantsLimit*2, blockSize)
@@ -317,7 +316,7 @@ func TestSessionOnPeersExhausted(t *testing.T) {
 	defer notif.Shutdown()
 	id := random.SequenceNext()
 	sm := newMockSessionMgr(sim)
-	session := New(sm, id, fspm, fpf, sim, fpm, bpm, notif, time.Second, delay.Fixed(time.Minute), "", nil, nil)
+	session := New(sm, id, fspm, fpf, sim, fpm, bpm, notif, time.Second, time.Minute, "", nil, nil)
 	defer session.Close()
 	blks := random.BlocksOfSize(broadcastLiveWantsLimit+5, blockSize)
 	var cids []cid.Cid
@@ -357,7 +356,7 @@ func TestSessionFailingToGetFirstBlock(t *testing.T) {
 	defer notif.Shutdown()
 	id := random.SequenceNext()
 	sm := newMockSessionMgr(sim)
-	session := New(sm, id, fspm, fpf, sim, fpm, bpm, notif, 10*time.Millisecond, delay.Fixed(100*time.Millisecond), "", nil, nil)
+	session := New(sm, id, fspm, fpf, sim, fpm, bpm, notif, 10*time.Millisecond, 100*time.Millisecond, "", nil, nil)
 	defer session.Close()
 	blks := random.BlocksOfSize(4, blockSize)
 	var cids []cid.Cid
@@ -462,7 +461,7 @@ func TestSessionCtxCancelClosesGetBlocksChannel(t *testing.T) {
 	sm := newMockSessionMgr(sim)
 
 	// Create a new session with its own context
-	session := New(sm, id, fspm, fpf, sim, fpm, bpm, notif, time.Second, delay.Fixed(time.Minute), "", nil, nil)
+	session := New(sm, id, fspm, fpf, sim, fpm, bpm, notif, time.Second, time.Minute, "", nil, nil)
 	defer session.Close()
 
 	timerCtx, timerCancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
@@ -505,7 +504,7 @@ func TestSessionOnShutdownCalled(t *testing.T) {
 	sm := newMockSessionMgr(sim)
 
 	// Create a new session
-	session := New(sm, id, fspm, fpf, sim, fpm, bpm, notif, time.Second, delay.Fixed(time.Minute), "", nil, nil)
+	session := New(sm, id, fspm, fpf, sim, fpm, bpm, notif, time.Second, time.Minute, "", nil, nil)
 
 	// Shutdown the session
 	session.Close()
@@ -527,7 +526,7 @@ func TestSessionReceiveMessageAfterClose(t *testing.T) {
 	defer notif.Shutdown()
 	id := random.SequenceNext()
 	sm := newMockSessionMgr(sim)
-	session := New(sm, id, fspm, fpf, sim, fpm, bpm, notif, time.Second, delay.Fixed(time.Minute), "", nil, nil)
+	session := New(sm, id, fspm, fpf, sim, fpm, bpm, notif, time.Second, time.Minute, "", nil, nil)
 	defer session.Close()
 
 	blks := random.BlocksOfSize(2, blockSize)

--- a/bitswap/client/internal/sessionmanager/sessionmanager.go
+++ b/bitswap/client/internal/sessionmanager/sessionmanager.go
@@ -14,7 +14,6 @@ import (
 	exchange "github.com/ipfs/boxo/exchange"
 	"github.com/ipfs/boxo/retrieval"
 	cid "github.com/ipfs/go-cid"
-	delay "github.com/ipfs/go-ipfs-delay"
 	peer "github.com/libp2p/go-libp2p/core/peer"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -40,7 +39,7 @@ type SessionFactory func(
 	bpm *bsbpm.BlockPresenceManager,
 	notif notifications.PubSub,
 	provSearchDelay time.Duration,
-	rebroadcastDelay delay.D,
+	rebroadcastDelay time.Duration,
 	self peer.ID,
 	retrievalState *retrieval.State) Session
 
@@ -95,7 +94,7 @@ func New(sessionFactory SessionFactory, sessionInterestManager *bssim.SessionInt
 // The returned Session must be closed via its Close() method when no longer needed.
 // Note: When sessions are created via Client.NewSession(ctx), automatic cleanup
 // via context.AfterFunc is provided.
-func (sm *SessionManager) NewSession(provSearchDelay time.Duration, rebroadcastDelay delay.D, retrievalState *retrieval.State) Session {
+func (sm *SessionManager) NewSession(provSearchDelay, rebroadcastDelay time.Duration, retrievalState *retrieval.State) Session {
 	id := sm.GetNextSessionID()
 
 	_, span := internal.StartSpan(context.Background(), "SessionManager.NewSession", trace.WithAttributes(attribute.String("ID", strconv.FormatUint(id, 10))))

--- a/bitswap/client/internal/sessionmanager/sessionmanager_test.go
+++ b/bitswap/client/internal/sessionmanager/sessionmanager_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ipfs/boxo/retrieval"
 	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
-	delay "github.com/ipfs/go-ipfs-delay"
 	peer "github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
 )
@@ -93,7 +92,7 @@ func sessionFactory(
 	bpm *bsbpm.BlockPresenceManager,
 	notif notifications.PubSub,
 	provSearchDelay time.Duration,
-	rebroadcastDelay delay.D,
+	rebroadcastDelay time.Duration,
 	self peer.ID,
 	retrievalState *retrieval.State,
 ) Session {
@@ -123,11 +122,11 @@ func TestReceiveFrom(t *testing.T) {
 	p := peer.ID(strconv.Itoa(123))
 	block := blocks.NewBlock([]byte("block"))
 
-	firstSession := sm.NewSession(time.Second, delay.Fixed(time.Minute), nil).(*fakeSession)
+	firstSession := sm.NewSession(time.Second, time.Minute, nil).(*fakeSession)
 	defer firstSession.Close()
-	secondSession := sm.NewSession(time.Second, delay.Fixed(time.Minute), nil).(*fakeSession)
+	secondSession := sm.NewSession(time.Second, time.Minute, nil).(*fakeSession)
 	defer secondSession.Close()
-	thirdSession := sm.NewSession(time.Second, delay.Fixed(time.Minute), nil).(*fakeSession)
+	thirdSession := sm.NewSession(time.Second, time.Minute, nil).(*fakeSession)
 	defer thirdSession.Close()
 
 	sim.RecordSessionInterest(firstSession.ID(), []cid.Cid{block.Cid()})
@@ -170,11 +169,11 @@ func TestReceiveBlocksWhenManagerShutdown(t *testing.T) {
 	p := peer.ID(strconv.Itoa(123))
 	block := blocks.NewBlock([]byte("block"))
 
-	firstSession := sm.NewSession(time.Second, delay.Fixed(time.Minute), nil).(*fakeSession)
+	firstSession := sm.NewSession(time.Second, time.Minute, nil).(*fakeSession)
 	defer firstSession.Close()
-	secondSession := sm.NewSession(time.Second, delay.Fixed(time.Minute), nil).(*fakeSession)
+	secondSession := sm.NewSession(time.Second, time.Minute, nil).(*fakeSession)
 	defer secondSession.Close()
-	thirdSession := sm.NewSession(time.Second, delay.Fixed(time.Minute), nil).(*fakeSession)
+	thirdSession := sm.NewSession(time.Second, time.Minute, nil).(*fakeSession)
 	defer thirdSession.Close()
 
 	sim.RecordSessionInterest(firstSession.ID(), []cid.Cid{block.Cid()})
@@ -207,11 +206,11 @@ func TestReceiveBlocksWhenSessionContextCancelled(t *testing.T) {
 	p := peer.ID(strconv.Itoa(123))
 	block := blocks.NewBlock([]byte("block"))
 
-	firstSession := sm.NewSession(time.Second, delay.Fixed(time.Minute), nil).(*fakeSession)
+	firstSession := sm.NewSession(time.Second, time.Minute, nil).(*fakeSession)
 	defer firstSession.Close()
-	secondSession := sm.NewSession(time.Second, delay.Fixed(time.Minute), nil).(*fakeSession)
+	secondSession := sm.NewSession(time.Second, time.Minute, nil).(*fakeSession)
 	defer secondSession.Close()
-	thirdSession := sm.NewSession(time.Second, delay.Fixed(time.Minute), nil).(*fakeSession)
+	thirdSession := sm.NewSession(time.Second, time.Minute, nil).(*fakeSession)
 	defer thirdSession.Close()
 
 	sim.RecordSessionInterest(firstSession.ID(), []cid.Cid{block.Cid()})
@@ -244,7 +243,7 @@ func TestShutdown(t *testing.T) {
 	p := peer.ID(strconv.Itoa(123))
 	block := blocks.NewBlock([]byte("block"))
 	cids := []cid.Cid{block.Cid()}
-	firstSession := sm.NewSession(time.Second, delay.Fixed(time.Minute), nil).(*fakeSession)
+	firstSession := sm.NewSession(time.Second, time.Minute, nil).(*fakeSession)
 	defer firstSession.Close()
 	sim.RecordSessionInterest(firstSession.ID(), cids)
 	sm.ReceiveFrom(ctx, p, []cid.Cid{}, []cid.Cid{}, cids)

--- a/bitswap/options.go
+++ b/bitswap/options.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ipfs/boxo/bitswap/client"
 	"github.com/ipfs/boxo/bitswap/server"
 	"github.com/ipfs/boxo/bitswap/tracer"
-	delay "github.com/ipfs/go-ipfs-delay"
 )
 
 type option func(*Bitswap)
@@ -74,7 +73,7 @@ func ProviderSearchDelay(newProvSearchDelay time.Duration) Option {
 	return Option{client.ProviderSearchDelay(newProvSearchDelay)}
 }
 
-func RebroadcastDelay(newRebroadcastDelay delay.D) Option {
+func RebroadcastDelay(newRebroadcastDelay time.Duration) Option {
 	return Option{client.RebroadcastDelay(newRebroadcastDelay)}
 }
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -51,7 +51,6 @@ require (
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/ipfs/bbloom v0.0.4 // indirect
 	github.com/ipfs/go-bitfield v1.1.0 // indirect
-	github.com/ipfs/go-ipfs-delay v0.0.1 // indirect
 	github.com/ipfs/go-ipfs-pq v0.0.3 // indirect
 	github.com/ipfs/go-ipfs-redirects-file v0.1.2 // indirect
 	github.com/ipfs/go-ipld-cbor v0.2.0 // indirect


### PR DESCRIPTION
The rebroadcast delay was a `delay.Delay` that was only being used as a fixed time, so it had no more utility than a plain `time.Duration` value. Since no time varying functionality was used anywhere, the `delay.Delay` was replaced with a `time.Duration`.

**BREAKING CHANGE** This changes the argument type to one of the bitswap client options: `RebroadcastDelay`