### PR TITLE
fix(routing/http): don't cancel batch prematurely

### DIFF
--- a/routing/http/internal/goroutines_test.go
+++ b/routing/http/internal/goroutines_test.go
@@ -72,7 +72,7 @@ func TestDoBatch(t *testing.T) {
 			var onceMut sync.Mutex
 			var errored bool
 
-			DoBatch(ctx, c.maxBatchSize, c.maxConcurrency, c.items, func(ctx context.Context, batch []int) error {
+			err := DoBatch(ctx, c.maxBatchSize, c.maxConcurrency, c.items, func(ctx context.Context, batch []int) error {
 				if c.shouldErrOnce {
 					onceMut.Lock()
 					if !errored {
@@ -89,6 +89,7 @@ func TestDoBatch(t *testing.T) {
 				return nil
 			})
 
+			require.NoError(t, err)
 			require.Equal(t, len(c.expBatches), len(batches), "expected equal len %v %v", c.expBatches, batches)
 			for _, expBatch := range c.expBatches {
 				requireContainsBatch(t, batches, expBatch)


### PR DESCRIPTION
`workerCtx` was cancelled (to exit the infinite loop?), resulting in a failure of the `f()`.

`cancel()` should only be called once all batches have completed.
