### PR TITLE
feat(gateway): add MaxRangeRequestFileSize protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The following emojis are used to highlight certain changes:
   - Added retrieval state tracking for timeout diagnostics. When retrieval timeouts occur, the error messages now include detailed information about which phase failed (path resolution, provider discovery, connecting, or data retrieval) and provider statistics including failed peer IDs [#1015](https://github.com/ipfs/boxo/pull/1015) [#1023](https://github.com/ipfs/boxo/pull/1023)
   - Added `Config.DiagnosticServiceURL` to configure a CID retrievability diagnostic service. When set, 504 Gateway Timeout errors show a "Check CID retrievability" button linking to the service with `?cid=<failed-cid>` [#1023](https://github.com/ipfs/boxo/pull/1023)
   - Improved 504 error pages with "Retry" button, diagnostic service integration, and clear indication when timeout occurs on sub-resource vs root CID [#1023](https://github.com/ipfs/boxo/pull/1023)
+- `gateway`: Added `Config.MaxRangeRequestFileSize` to protect against CDN issues with large file range requests. When set to a non-zero value, range requests for files larger than this limit return HTTP 501 Not Implemented with a suggestion to use verifiable block requests (`application/vnd.ipld.raw`) instead. This provides protection against Cloudflare's issue where range requests for files over 5GiB are silently ignored, causing excess bandwidth consumption and billing
 
 ### Changed
 

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -126,6 +126,13 @@ type Config struct {
 	// button is not shown.
 	DiagnosticServiceURL string
 
+	// MaxRangeRequestFileSize is the maximum file size in bytes for which range
+	// requests are supported. When set to a value greater than 0, range requests
+	// for files larger than this limit will return 501 Not Implemented error.
+	// This provides protection against CDN/proxy issues with large files
+	// (e.g., Cloudflare's 5GB limit). A value of 0 disables this limit.
+	MaxRangeRequestFileSize int64
+
 	// MetricsRegistry is the Prometheus registry to use for metrics.
 	// If nil, prometheus.DefaultRegisterer will be used.
 	MetricsRegistry prometheus.Registerer


### PR DESCRIPTION
Adds Config.MaxRangeRequestFileSize to protect against CDN issues with large file range requests. when set, range requests for files larger than this limit return HTTP 501 with suggestion to use verifiable block requests (application/vnd.ipld.raw).

Intention here is to protect against Cloudflare's issue where range requests for files over 5GiB are silently ignored, causing entire file to be returned instead of requested range, leading to excess bandwidth and billing.

The fix here shouldengage when cloudflare sends very first range request to boxo/gateway backend. The backend is able to detect range request for a file beyond safe size, and refuse responding. 

- Provides alternative way of handling issues like #856

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
