### PR TITLE
fix(gateway): reject internal HAMT shard blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The following emojis are used to highlight certain changes:
 
 - `bitswap/server`: incoming identity CIDs in wantlist messages are now silently ignored instead of killing the connection to the remote peer. Some IPFS implementations naively send identity CIDs, and disconnecting them for it caused unnecessary churn. [#1117](https://github.com/ipfs/boxo/pull/1117)
 - `bitswap/network`: `ExtractHTTPAddress` now infers default ports for portless HTTP multiaddrs (e.g. `/dns/host/https` without `/tcp/443`). [#1123](https://github.com/ipfs/boxo/pull/1123)
+- `gateway`: internal HAMT shard blocks requested by CID now return HTTP 501 instead of rendering a directory listing with broken links. [#1127](https://github.com/ipfs/boxo/pull/1127)
 
 ### Security
 

--- a/gateway/backend_blocks.go
+++ b/gateway/backend_blocks.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ipfs/boxo/files"
 	"github.com/ipfs/boxo/ipld/merkledag"
 	ufile "github.com/ipfs/boxo/ipld/unixfs/file"
+	"github.com/ipfs/boxo/ipld/unixfs/hamt"
 	uio "github.com/ipfs/boxo/ipld/unixfs/io"
 	"github.com/ipfs/boxo/path"
 	"github.com/ipfs/boxo/path/resolver"
@@ -197,6 +198,9 @@ func (bb *BlocksBackend) Get(ctx context.Context, path path.ImmutablePath, range
 	}
 
 	if d, ok := f.(files.Directory); ok {
+		if pn, ok := nd.(*merkledag.ProtoNode); ok && hamt.IsInternalHAMTShard(ctx, pn, bb.dagService) {
+			return ContentPathMetadata{}, nil, errInternalHAMTShardBlock
+		}
 		dir, err := uio.NewDirectoryFromNode(bb.dagService, nd)
 		if err != nil {
 			return md, nil, err

--- a/gateway/backend_car.go
+++ b/gateway/backend_car.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ipfs/boxo/files"
 	"github.com/ipfs/boxo/ipld/merkledag"
 	"github.com/ipfs/boxo/ipld/unixfs"
+	"github.com/ipfs/boxo/ipld/unixfs/hamt"
 	"github.com/ipfs/boxo/path"
 	"github.com/ipfs/boxo/path/resolver"
 	"github.com/ipfs/boxo/retrieval"
@@ -537,6 +538,9 @@ func loadTerminalEntity(ctx context.Context, c cid.Cid, blk blocks.Block, lsys *
 			}
 			return NewGetResponseFromDirectoryListing(dirDagSize, ch, nil), nil
 		case ufsData.Data_HAMTShard:
+			if hamt.IsInternalHAMTShard(ctx, pn, nil) {
+				return nil, errInternalHAMTShardBlock
+			}
 			dirNd, err := unixfsnode.Reify(lctx, pbn, lsys)
 			if err != nil {
 				return nil, fmt.Errorf("could not reify sharded directory: %w", err)

--- a/gateway/errors.go
+++ b/gateway/errors.go
@@ -35,6 +35,7 @@ var (
 	errUnsupportedCarOrder      = errors.New("unsupported application/vnd.ipld.car order parameter")
 	errUnsupportedCarDups       = errors.New("unsupported application/vnd.ipld.car dups parameter")
 	errIndexNotReadable         = errors.New("index.html could not be read: not a file")
+	errInternalHAMTShardBlock   = errors.New("CID points to an internal HAMT shard block, not a browsable directory")
 )
 
 // ErrorRetryAfter wraps any error with "retry after" hint. When an error of this type

--- a/gateway/handler_defaults.go
+++ b/gateway/handler_defaults.go
@@ -67,6 +67,10 @@ func (i *handler) serveDefaults(ctx context.Context, w http.ResponseWriter, r *h
 		// related DAGs.
 		pathMetadata, getResp, err = i.backend.Get(ctx, rq.mostlyResolvedPath(), ranges...)
 		if err != nil {
+			if errors.Is(err, errInternalHAMTShardBlock) {
+				i.webError(w, r, err, http.StatusNotImplemented)
+				return false
+			}
 			if isWebRequest(rq.responseFormat) {
 				forwardedPath, continueProcessing := i.handleWebRequestErrors(w, r, rq.mostlyResolvedPath(), rq.immutablePath, rq.contentPath, err, rq.logger)
 				if !continueProcessing {

--- a/ipld/unixfs/hamt/hamt.go
+++ b/ipld/unixfs/hamt/hamt.go
@@ -53,6 +53,84 @@ func init() {
 	internal.HAMTHashFunction = murmur3Hash
 }
 
+// IsInternalHAMTShard reports whether nd is an internal HAMT shard node
+// (not the root of a HAMT directory). It verifies hash-based bucket
+// alignment for a sample entry: if the entry's hash prefix (at bit
+// offset 0) disagrees with its actual position, this shard is at a
+// deeper trie level.
+//
+// Internal shards are only reachable by directly requesting their CID.
+// Legitimate HAMT path traversal always resolves to value link targets
+// (files/directories), never to internal shard nodes.
+//
+// Phase 1 (zero I/O): checks a value link in the current node.
+// Phase 2 (one block load): if all children are sub-shards, loads one
+// child to find a testable value link.
+func IsInternalHAMTShard(ctx context.Context, nd *dag.ProtoNode, ds ipld.DAGService) bool {
+	fsn, err := format.FSNodeFromBytes(nd.Data())
+	if err != nil || fsn.Type() != format.THAMTShard {
+		return false
+	}
+	fanout := fsn.Fanout()
+	if fanout == 0 {
+		return false
+	}
+	lg2, err := Logtwo(int(fanout))
+	if err != nil {
+		return false
+	}
+	padLen := len(fmt.Sprintf("%X", fanout-1))
+	padFmt := fmt.Sprintf("%%0%dX", padLen)
+
+	// Phase 1: check first value link in this node (zero I/O).
+	for _, lnk := range nd.Links() {
+		if len(lnk.Name) <= padLen {
+			continue
+		}
+		hv := newHashBits(lnk.Name[padLen:])
+		idx, err := hv.Next(lg2)
+		if err != nil {
+			return false
+		}
+		return lnk.Name[:padLen] != fmt.Sprintf(padFmt, idx)
+	}
+
+	// Phase 2: no value links in this node (all children are sub-shards).
+	// Load one child and find a value link there. All shards in a HAMT
+	// directory share the same fanout, so we reuse the parent's parameters.
+	if ds == nil {
+		return false
+	}
+	for _, lnk := range nd.Links() {
+		if len(lnk.Name) != padLen {
+			continue
+		}
+		childNd, err := ds.Get(ctx, lnk.Cid)
+		if err != nil {
+			continue
+		}
+		childPn, ok := childNd.(*dag.ProtoNode)
+		if !ok {
+			continue
+		}
+		for _, cl := range childPn.Links() {
+			if len(cl.Name) <= padLen {
+				continue
+			}
+			// Hash this entry's filename and check if the first
+			// hash bits match the PARENT's bucket index for this child.
+			// They will match iff the parent is the root (depth 0).
+			hv := newHashBits(cl.Name[padLen:])
+			idx, err := hv.Next(lg2)
+			if err != nil {
+				return false
+			}
+			return lnk.Name != fmt.Sprintf(padFmt, idx)
+		}
+	}
+	return false
+}
+
 func (ds *Shard) isValueNode() bool {
 	return ds.key != "" && ds.val != nil
 }

--- a/ipld/unixfs/hamt/hamt_test.go
+++ b/ipld/unixfs/hamt/hamt_test.go
@@ -776,3 +776,70 @@ func TestHamtNilLinkAndShard(t *testing.T) {
 		t.Fatal("nextShard should be nil")
 	}
 }
+
+// TestIsInternalHAMTShard verifies detection of internal HAMT shard nodes.
+//
+// A HAMT directory is a trie: the root shard fans out into child shards,
+// which may fan out further. When a user requests the root shard CID,
+// the gateway can render a working directory listing. But when a user
+// requests an internal (non-root) shard CID directly, the listing looks
+// fine yet every link 404s because the HAMT lookup starts at the wrong
+// hash bit offset.
+//
+// IsInternalHAMTShard lets the gateway detect this situation and refuse
+// to render a broken listing.
+func TestIsInternalHAMTShard(t *testing.T) {
+	ds := mdtest.Mock()
+	ctx := context.Background()
+
+	// Build a HAMT directory large enough to produce internal shard nodes.
+	_, s, err := makeDirWidth(ds, 1000, 256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootNd, err := s.Node()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootPn := rootNd.(*dag.ProtoNode)
+
+	t.Run("root HAMT shard is not internal", func(t *testing.T) {
+		// The root shard is the directory itself; requesting its CID
+		// produces a working listing, so it must NOT be flagged.
+		if IsInternalHAMTShard(ctx, rootPn, ds) {
+			t.Fatal("root shard incorrectly detected as internal")
+		}
+	})
+
+	t.Run("child shard is internal", func(t *testing.T) {
+		// A child shard is an internal trie node. Requesting its CID
+		// directly produces a listing with broken links, so it MUST
+		// be flagged.
+		fsn, _ := ft.FSNodeFromBytes(rootPn.Data())
+		padLen := len(fmt.Sprintf("%X", fsn.Fanout()-1))
+		var tested bool
+		for _, lnk := range rootPn.Links() {
+			if len(lnk.Name) == padLen { // sub-shard link (name is just the hex prefix)
+				childNd, err := ds.Get(ctx, lnk.Cid)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !IsInternalHAMTShard(ctx, childNd.(*dag.ProtoNode), ds) {
+					t.Fatal("internal shard not detected")
+				}
+				tested = true
+				break
+			}
+		}
+		if !tested {
+			t.Fatal("no internal shard found; increase entry count")
+		}
+	})
+
+	t.Run("plain directory is not internal", func(t *testing.T) {
+		// A regular (non-HAMT) directory should never be flagged.
+		if IsInternalHAMTShard(ctx, ft.EmptyDirNode(), ds) {
+			t.Fatal("plain directory incorrectly detected as internal HAMT shard")
+		}
+	})
+}


### PR DESCRIPTION
Return HTTP 501 instead of rendering a directory listing with broken links when the requested CID is an internal HAMT shard node. This is better than returning partial broken state, and less involved if we had to write custom UI for this.

- Fixes https://github.com/ipfs/boxo/issues/1126

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->

### Complexity

Not a fan, but there seem to be no easy way to detect we are in internal HAMT node.

Detection uses zero-I/O hash prefix alignment check on value links, with a one-block fallback for all-sub-shard nodes (large directories like Wikipedia). The fetched block is cached and reused by the subsequent EnumLinksAsync call, but still,.. not a fan.

Maybe we just.. leave this alone?