### PR TITLE
test(gateway): cover bare CID etag match for dir listings

### DIFF
--- a/gateway/handler_test.go
+++ b/gateway/handler_test.go
@@ -16,13 +16,22 @@ func TestEtagMatch(t *testing.T) {
 		{"", `"etag"`, "", false},                        // no If-None-Match
 		{"", "", `"etag"`, false},                        // no If-None-Match
 		{`"etag"`, `"etag"`, "", true},                   // file etag match
-		{`W/"etag"`, `"etag"`, "", true},                 // file etag match
+		{`W/"etag"`, `"etag"`, "", true},                 // file etag match (weak)
 		{`"foo", W/"bar", W/"etag"`, `"etag"`, "", true}, // file etag match (array)
 		{`"foo",W/"bar",W/"etag"`, `"etag"`, "", true},   // file etag match (compact array)
 		{`"etag"`, "", `W/"etag"`, true},                 // dir etag match
 		{`"etag"`, "", `W/"etag"`, true},                 // dir etag match
 		{`W/"etag"`, "", `W/"etag"`, true},               // dir etag match
 		{`*`, `"etag"`, "", true},                        // wildcard etag match
+
+		// Bare CID as weak ETag should match against cidEtag even when
+		// the response carries a DirIndex ETag. This works because
+		// handleIfNoneMatch checks If-None-Match against both cidEtag
+		// and dirEtag, and W/"<CID>" weak-matches the bare CID ETag.
+		// This is a boxo-specific optimization: the CID match is
+		// inexpensive and happens before any I/O.
+		{`W/"CID"`, `"CID"`, `"DirIndex-xxhash_CID-CID"`, true}, // bare CID etag matches cidEtag for dir listing
+		{`"CID"`, `"CID"`, `"DirIndex-xxhash_CID-CID"`, true},   // strong bare CID also matches
 	} {
 		result := etagMatch(test.header, test.cidEtag, test.dirEtag)
 		assert.Equalf(t, test.expected, result, "etagMatch(%q, %q, %q)", test.header, test.cidEtag, test.dirEtag)


### PR DESCRIPTION
This test was originally in `go-ipfs` (now kubo) sharness `t0116`, then ported to `ipfs/gateway-conformance`. Moving it here because matching `W/"<CID>"` against a directory listing is a boxo-specific optimization, not a spec requirement for all gateways.

`handleIfNoneMatch` checks `If-None-Match` HTTP header against both the bare CID ETag and the DirIndex ETag before doing any I/O, so a client sending `W/"<CID>"` gets a 304 even though the actual response ETag is `"DirIndex-<hash>_CID-<CID>"`.

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
