### PR TITLE
fix(mfs): prevent panic on concurrent flush and close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The following emojis are used to highlight certain changes:
 
 - `bitswap/server`: incoming identity CIDs in wantlist messages are now silently ignored instead of killing the connection to the remote peer. Some IPFS implementations naively send identity CIDs, and disconnecting them for it caused unnecessary churn. [#1117](https://github.com/ipfs/boxo/pull/1117)
 - `bitswap/network`: `ExtractHTTPAddress` now infers default ports for portless HTTP multiaddrs (e.g. `/dns/host/https` without `/tcp/443`). [#1123](https://github.com/ipfs/boxo/pull/1123)
+- `mfs`: fixed a race between concurrent `FileDescriptor.Flush` and `Close` calls that could panic with a nil pointer dereference. `Flush` after `Close` now returns `ErrClosed`.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The following emojis are used to highlight certain changes:
 
 - `routing/http/client`: `WithProviderInfoFunc` option resolves provider addresses at provide-time instead of client construction time. This only impacts legacy HTTP-only custom routing setups that depend on [IPIP-526](https://github.com/ipfs/specs/pull/526) and were sending unresolved `0.0.0.0` addresses in provider records instead of actual interface addresses. [#1115](https://github.com/ipfs/boxo/pull/1115)
 - `chunker`: added `Register` function to allow custom chunkers to be registered for use with `FromString`.
+- `mfs`: added `Directory.Mode()` and `Directory.ModTime()` getters to match the existing `File.Mode()` and `File.ModTime()` API.
 
 ### Changed
 

--- a/mfs/dir.go
+++ b/mfs/dir.go
@@ -526,6 +526,20 @@ func (d *Directory) getNode(cacheClean bool) (ipld.Node, error) {
 	return nd.Copy(), err
 }
 
+// Mode returns the directory's POSIX permission bits from UnixFS metadata.
+// Returns 0 when no mode is stored.
+func (d *Directory) Mode() (os.FileMode, error) {
+	nd, err := d.GetNode()
+	if err != nil {
+		return 0, err
+	}
+	fsn, err := ft.ExtractFSNode(nd)
+	if err != nil {
+		return 0, err
+	}
+	return fsn.Mode() & 0xFFF, nil
+}
+
 func (d *Directory) SetMode(mode os.FileMode) error {
 	nd, err := d.GetNode()
 	if err != nil {
@@ -550,6 +564,20 @@ func (d *Directory) SetMode(mode os.FileMode) error {
 
 	d.unixfsDir.SetStat(mode, time.Time{})
 	return nil
+}
+
+// ModTime returns the directory's last modification time from UnixFS metadata.
+// Returns zero time when no mtime is stored.
+func (d *Directory) ModTime() (time.Time, error) {
+	nd, err := d.GetNode()
+	if err != nil {
+		return time.Time{}, err
+	}
+	fsn, err := ft.ExtractFSNode(nd)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return fsn.ModTime(), nil
 }
 
 func (d *Directory) SetModTime(ts time.Time) error {

--- a/mfs/fd.go
+++ b/mfs/fd.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 
 	mod "github.com/ipfs/boxo/ipld/unixfs/mod"
 	ipld "github.com/ipfs/go-ipld-format"
@@ -45,6 +46,12 @@ type fileDescriptor struct {
 	mod   *mod.DagModifier
 	flags Flags
 
+	// mu serializes Flush and Close to prevent concurrent access to
+	// the underlying DagModifier, which is not safe for concurrent use.
+	// Without this, a caller that invokes Flush and Close from separate
+	// goroutines (e.g. FUSE dispatching FLUSH and RELEASE concurrently)
+	// can trigger a data race inside DagModifier.Sync.
+	mu    sync.Mutex
 	state state
 }
 
@@ -110,6 +117,8 @@ func (fi *fileDescriptor) CtxReadFull(ctx context.Context, b []byte) (int, error
 // Close flushes, then propagates the modified dag node up the directory structure
 // and signals a republish to occur
 func (fi *fileDescriptor) Close() error {
+	fi.mu.Lock()
+	defer fi.mu.Unlock()
 	if fi.state == stateClosed {
 		return ErrClosed
 	}
@@ -128,6 +137,11 @@ func (fi *fileDescriptor) Close() error {
 // the entry in the parent directory (setting `fullSync` to
 // propagate the update all the way to the root).
 func (fi *fileDescriptor) Flush() error {
+	fi.mu.Lock()
+	defer fi.mu.Unlock()
+	if fi.state == stateClosed {
+		return ErrClosed
+	}
 	return fi.flushUp(true)
 }
 

--- a/mfs/mfs_test.go
+++ b/mfs/mfs_test.go
@@ -1447,6 +1447,65 @@ func TestConcurrentWrites(t *testing.T) {
 	}
 }
 
+// TestConcurrentFlushAndClose verifies that calling Flush and Close on the
+// same fileDescriptor from different goroutines does not panic or corrupt
+// data. This guards against the race where a FUSE daemon dispatches FLUSH
+// and RELEASE concurrently for the same file handle (e.g. when FLUSH is
+// interrupted by SIGURG and the kernel sends RELEASE while the flush
+// goroutine is still running).
+func TestConcurrentFlushAndClose(t *testing.T) {
+	ctx := t.Context()
+	ds, rt := setupRoot(ctx, t)
+	dir := rt.GetDirectory()
+
+	nd := dag.NodeWithData(ft.FilePBData(nil, 0))
+	prov := new(fakeProvider)
+
+	// Run many iterations to increase the chance of hitting the race.
+	for range 200 {
+		fi, err := NewFile("test", nd, dir, ds, prov)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		fd, err := fi.Open(Flags{Read: true, Write: true, Sync: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := fd.Write([]byte("hello")); err != nil {
+			t.Fatal(err)
+		}
+
+		// Launch Flush and Close concurrently. One of them will
+		// acquire the internal mutex first; the other must wait
+		// and then observe a consistent state (either flushed or
+		// closed). Neither should panic.
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			// Flush may succeed or return ErrClosed if Close wins.
+			err := fd.Flush()
+			if err != nil && !errors.Is(err, ErrClosed) {
+				t.Errorf("Flush: unexpected error: %v", err)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			if err := fd.Close(); err != nil {
+				t.Errorf("Close: %v", err)
+			}
+		}()
+		wg.Wait()
+
+		// A second Close must return ErrClosed.
+		if err := fd.Close(); !errors.Is(err, ErrClosed) {
+			t.Fatalf("expected ErrClosed on double close, got: %v", err)
+		}
+	}
+}
+
 func TestFileDescriptors(t *testing.T) {
 	ctx := t.Context()
 


### PR DESCRIPTION
This PR fixes a FUSE panic found in Kubo when running FUSE tests on CI ([log](https://github.com/ipfs/kubo/actions/runs/23948395034/job/69849704003?pr=11272#step:6:34)).

When the FUSE kernel dispatches `FLUSH` and `RELEASE` concurrently for the same file handle, both `Flush` and `Close` call into `flushUp`, which accesses the underlying `DagModifier` without synchronization.  Two concurrent `Sync` calls race on the write buffer, causing a nil pointer dereference.

This PR adds a mutex to `fileDescriptor` that serializes `Flush` and `Close`, and returns `ErrClosed` when `Flush` is called after `Close`.

Also adds `Directory.Mode()` and `Directory.ModTime()` read-only getters to match the existing `File` API, needed by the Kubo FUSE layer.

## Changes

- `mfs/fd.go`: add `sync.Mutex` to `fileDescriptor`, acquired in `Flush` and `Close`
- `mfs/fd.go`: `Flush` on a closed descriptor now returns `ErrClosed`
- `mfs/dir.go`: add `Directory.Mode()` and `Directory.ModTime()` getters
- `mfs/mfs_test.go`: add `TestConcurrentFlushAndClose` (catches regressions with `-race`)

## Test plan

- [x] `TestConcurrentFlushAndClose` passes with `-race`
- [ ] Kubo FUSE tests pass with this boxo version