### PR TITLE
fix(mfs): prevent flushUp from re-adding unlinked entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ The following emojis are used to highlight certain changes:
 - `bitswap/network`: `ExtractHTTPAddress` now infers default ports for portless HTTP multiaddrs (e.g. `/dns/host/https` without `/tcp/443`). [#1123](https://github.com/ipfs/boxo/pull/1123)
 - `mfs`: `FileDescriptor` operations are serialized with a mutex, preventing data races on the underlying `DagModifier` when FUSE mounts or Kubo RPC commands dispatch concurrent Read, Write, Seek, Truncate, Flush, or Close calls. `Flush` after `Close` returns `ErrClosed`. [#1131](https://github.com/ipfs/boxo/pull/1131) [#1133](https://github.com/ipfs/boxo/pull/1133)
 - `mfs`: preserve `CidBuilder` and `SizeEstimationMode` across `setNodeData()`, `Mkdir()` and `NewRoot()`. [#1125](https://github.com/ipfs/boxo/pull/1125)
+- `mfs`: closing a file descriptor after its directory entry was removed (e.g. FUSE RELEASE racing with RENAME) no longer re-adds the stale entry to the parent directory. [#1134](https://github.com/ipfs/boxo/pull/1134)
+- `mfs`: `SetMode` and `SetModTime` no longer drop file content links when updating UnixFS metadata. [#1134](https://github.com/ipfs/boxo/pull/1134)
 
 ### Security
 

--- a/mfs/dir.go
+++ b/mfs/dir.go
@@ -423,6 +423,14 @@ func (d *Directory) Unlink(name string) error {
 	d.lock.Lock()
 	defer d.lock.Unlock()
 
+	if child, ok := d.entriesCache[name]; ok {
+		switch c := child.(type) {
+		case *File:
+			c.unlinked.Store(true)
+		case *Directory:
+			c.unlinked.Store(true)
+		}
+	}
 	delete(d.entriesCache, name)
 
 	return d.unixfsDir.RemoveChild(d.ctx, name)

--- a/mfs/fd.go
+++ b/mfs/fd.go
@@ -186,8 +186,9 @@ func (fi *fileDescriptor) flushUp(fullSync bool) error {
 		name := fi.inode.name
 		fi.inode.nodeLock.Unlock()
 
-		// Bubble up the update's to the parent, only if fullSync is set to true.
-		if fullSync {
+		// Bubble up the update to the parent, unless the file was
+		// unlinked (see inode.unlinked for details).
+		if fullSync && !fi.inode.unlinked.Load() {
 			if err := parent.updateChildEntry(child{name, nd}); err != nil {
 				return err
 			}

--- a/mfs/file.go
+++ b/mfs/file.go
@@ -273,8 +273,11 @@ func (fi *File) SetModTime(ts time.Time) error {
 func (fi *File) setNodeData(data []byte) error {
 	nd := dag.NodeWithData(data)
 
-	// Preserve previous node's CidBuilder
+	// Preserve the previous node's links (file content blocks) and
+	// CidBuilder. Without this, the new node would have the updated
+	// metadata (mode, mtime) but no content.
 	if oldNode, ok := fi.node.(*dag.ProtoNode); ok {
+		nd.SetLinks(oldNode.Links())
 		if builder := oldNode.CidBuilder(); builder != nil {
 			nd.SetCidBuilder(builder)
 		}

--- a/mfs/inode.go
+++ b/mfs/inode.go
@@ -1,6 +1,8 @@
 package mfs
 
 import (
+	"sync/atomic"
+
 	"github.com/ipfs/boxo/provider"
 	ipld "github.com/ipfs/go-ipld-format"
 )
@@ -22,4 +24,19 @@ type inode struct {
 
 	// provider used to announce CIDs
 	prov provider.MultihashProvider
+
+	// unlinked prevents flushUp from re-adding this entry to the
+	// parent directory after Unlink removed it.
+	//
+	// This is not a problem for `ipfs files mv` (Mv in ops.go)
+	// because it adds the new name before removing the old one,
+	// and both happen synchronously in the same goroutine.
+	//
+	// With FUSE, the kernel sends RELEASE (triggers Close/flushUp)
+	// and RENAME (triggers Unlink) as separate concurrent requests.
+	// We cannot control the order, and serializing them at the FUSE
+	// layer would block all operations on the directory. This flag
+	// is checked once per file close in flushUp to skip propagation
+	// when the entry no longer exists in the parent.
+	unlinked atomic.Bool
 }

--- a/mfs/mfs_test.go
+++ b/mfs/mfs_test.go
@@ -2779,3 +2779,45 @@ func TestFlushUpAfterUnlink(t *testing.T) {
 		}
 	}
 }
+
+// TestSetModePreservesContent verifies that SetMode does not drop the
+// file's content links. This was a bug where setNodeData created a
+// bare ProtoNode from metadata bytes without copying the child links
+// from the old node.
+func TestSetModePreservesContent(t *testing.T) {
+	ctx := context.Background()
+	dagserv := getDagserv(t)
+
+	root, err := NewEmptyRoot(ctx, dagserv, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := root.GetDirectory()
+
+	fileNode := dag.NodeWithData(ft.FilePBData(nil, 0))
+	dir.AddChild("test", fileNode)
+	dir.Flush()
+
+	child, _ := dir.Child("test")
+	fi := child.(*File)
+
+	// Write content and flush.
+	fd, _ := fi.Open(Flags{Write: true, Sync: true})
+	fd.Write([]byte("hello world"))
+	fd.Flush()
+	fd.Close()
+
+	// Set mode (this calls setNodeData internally).
+	fi.SetMode(0o755)
+
+	// Reopen and read: content must still be present.
+	fd2, _ := fi.Open(Flags{Read: true})
+	sz, _ := fd2.Size()
+	buf := make([]byte, 100)
+	n, _ := fd2.Read(buf)
+	fd2.Close()
+
+	if sz != 11 || n != 11 || string(buf[:n]) != "hello world" {
+		t.Fatalf("content lost after SetMode: size=%d read=%d data=%q", sz, n, buf[:n])
+	}
+}

--- a/mfs/mfs_test.go
+++ b/mfs/mfs_test.go
@@ -2706,3 +2706,76 @@ func TestOpsMkdirFallbackToRootDefaults(t *testing.T) {
 		}
 	}
 }
+
+// TestFlushUpAfterUnlink verifies that a file's flushUp (triggered by
+// Close) does not re-add a directory entry that was removed by Unlink.
+// This race occurs in FUSE mounts where Close (RELEASE) and Rename
+// are dispatched in separate goroutines.
+func TestFlushUpAfterUnlink(t *testing.T) {
+	ctx := context.Background()
+	dagserv := getDagserv(t)
+
+	root, err := NewEmptyRoot(ctx, dagserv, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := root.GetDirectory()
+
+	// Create a file and flush so it's committed to the DAG.
+	fileNode := dag.NodeWithData(ft.FilePBData(nil, 0))
+	if err := dir.AddChild("victim", fileNode); err != nil {
+		t.Fatal(err)
+	}
+	if err := dir.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Open the file for writing (like FUSE Open does).
+	child, err := dir.Child("victim")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fi := child.(*File)
+	fd, err := fi.Open(Flags{Write: true, Sync: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Write some data so the file is dirty.
+	if _, err := fd.Write([]byte("data")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Unlink the file (like FUSE Rename does: unlink source).
+	if err := dir.Unlink("victim"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now close the file descriptor. This triggers flushUp which
+	// propagates the dirty node to the parent directory via
+	// localUpdate. Without the fix, localUpdate would re-add
+	// "victim" to the directory.
+	if err := fd.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// The directory should NOT contain "victim".
+	names, err := dir.ListNames(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slices.Contains(names, "victim") {
+		t.Fatalf("unlinked file re-appeared in directory listing: %v", names)
+	}
+
+	// List should agree with ListNames.
+	listing, err := dir.List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range listing {
+		if entry.Name == "victim" {
+			t.Fatalf("unlinked file re-appeared in List: %v", listing)
+		}
+	}
+}


### PR DESCRIPTION


### Fix in https://github.com/ipfs/boxo/pull/1134/commits/8ae46d51c5d399d557b644b123cd704315393ff3: prevent flushUp from re-adding unlinked entries

When a file descriptor outlives its directory entry (e.g. FUSE RELEASE racing with RENAME), flushUp would propagate the stale name back into the parent directory via localUpdate/AddChild.

Mark inodes as unlinked in Directory.Unlink so that flushUp skips the parent propagation. This is not a problem for `ipfs files mv` because it adds the new name before removing the old one, and both happen synchronously. With FUSE the kernel sends RELEASE and RENAME as concurrent requests and we cannot control the order.

> [!NOTE]
> This PR is a surgical fix that only impacts FUSE in https://github.com/ipfs/kubo/pull/11272. Alternative is to rewrite entire `boxo/mfs` :upside_down_face:
> All legacy "rename" operations are not impacted because they already work around this in serial manner.

### Fix in https://github.com/ipfs/boxo/pull/1134/commits/552d8e74d86b6963546c54c2ce528df5d1aba706: preserve content links in setNodeData

SetMode and SetModTime call setNodeData which creates a new
ProtoNode from the serialized UnixFS metadata bytes. The old code did not copy the child links from the previous node, so the file appeared empty after chmod or touch. The Blocksizes array in the UnixFS protobuf is preserved by GetBytes and stays in sync with the copied links.

